### PR TITLE
ユーザーアクセス制御とユーザー情報取得の機能強化

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -110,9 +110,10 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/TReservationInfo/edit/*', ['controller' => 'TReservationInfo', 'action' => 'edit']);
         $builder->connect('/TReservationInfo/delete/*', ['controller' => 'TReservationInfo', 'action' => 'delete']);
         $builder->connect('/MUserInfo', ['controller' => 'MUserInfo', 'action' => 'index']);
+        $builder->connect('/MUserInfo/admin_change_password', ['controller' => 'MUserInfo', 'action' => 'adminChangePassword']);
         $builder->connect('/MUserInfo/changePassword', ['controller' => 'MUserInfo', 'action' => 'changePassword']);
         $builder->connect('/MUserInfo/update-admin-status', ['controller' => 'MUserInfo', 'action' => 'updateAdminStatus'])->setMethods(['POST']);
-        $builder->connect('MUserInfo/login', ['controller' => 'MUserInfo', 'action' => 'login']);
+        $builder->connect('/MUserInfo/login', ['controller' => 'MUserInfo', 'action' => 'login']);
         $builder->connect('/MUserInfo/add', ['controller' => 'MUserInfo', 'action' => 'add']);
         $builder->connect('/MUserInfo/edit/*', ['controller' => 'MUserInfo', 'action' => 'edit']);
         $builder->connect('/MUserInfo/delete/*', ['controller' => 'MUserInfo', 'action' => 'delete']);

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -625,6 +625,7 @@ class TReservationInfoController extends AppController
         if (!$user) {
             return $this->jsonErrorResponse(__('ログイン情報がありません。'));
         }
+        $userLevel = $user->i_user_level;
 
         $userId = $user->get('i_id_user');
         $rooms = $this->getAuthorizedRooms($userId);
@@ -662,7 +663,7 @@ class TReservationInfoController extends AppController
             }
         }
 
-        $this->set(compact('rooms', 'tReservationInfo', 'date', 'roomId'));
+        $this->set(compact('rooms', 'tReservationInfo', 'date', 'roomId', 'userLevel'));
     }
 
     /**

--- a/src_web/kamaho-shokusu/templates/MUserInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/view.php
@@ -14,7 +14,9 @@ $currentUserId = $user->get('i_id_user');
             <?php if ($mUserInfo->i_id_user === $currentUserId || $user->get('i_admin') == 1 ): ?>
             <?= $this->Html->link(__('ユーザ情報を編集する'), ['action' => 'edit', $mUserInfo->i_id_user], ['class' => 'list-group-item list-group-item-action']) ?>
             <?php endif; ?>
+            <?php if ($user->get('i_admin') == 1): ?>
             <?= $this->Html->link(__('ユーザ一覧を表示する'), ['action' => 'index'], ['class' => 'list-group-item list-group-item-action']) ?>
+            <?php endif; ?>
         </div>
     </aside>
     <div class="col-md-9">


### PR DESCRIPTION
# 🔒 ユーザーアクセス制御とデータ処理の強化に関するプルリクエスト

このプルリクエストでは、`MUserInfoController` および `TReservationInfoController` におけるユーザーアクセス制御とデータ処理の改善、さらにルーティングやビューのテンプレートの更新を行いました。主な目的は、**セキュリティの向上**と**ユーザーロールに基づいた表示制御**です。

---

## ✅ ユーザーアクセス制御の強化

### 🔸 ユーザーロールに基づくデータアクセス制限

- `MUserInfoController` の `index()` メソッドを更新  
  → 管理者はすべてのユーザー情報にアクセス可能、一般ユーザーは自分の情報のみ閲覧可能に  
  [[変更箇所 1]](diffhunk://#diff-155694f82acd4da15b627253a258c9e096c2d90b0c653b1bd14a3b7dbbba0bedR51-R67)  
  [[変更箇所 2]](diffhunk://#diff-155694f82acd4da15b627253a258c9e096c2d90b0c653b1bd14a3b7dbbba0bedL70-R82)

- `view()` メソッドにアクセス制御を追加  
  → 閲覧権限のないユーザーは、エラーメッセージ付きで一覧ページにリダイレクトされるように設定

### 🔸 ロールに応じたビューの調整

- `view.php` の表示ロジックを修正し、管理者のみが特定のリンクを閲覧・操作できるように変更

---

## 🔧 ルーティングの更新

### 🔹 管理者用パスワード変更ルートの追加

- `/MUserInfo/admin_change_password` というルートを新規追加し、管理者がパスワードを変更できる機能に対応

### 🔹 パスのミス修正

- ログインルートにて、パスの先頭にスラッシュ `/` が抜けていた箇所を修正

---

## 📊 データ処理の改善

### 🔸 部屋情報取得処理の強化

- `getUserRooms()` メソッドを修正  
  → 部屋情報の存在チェックを追加し、無効なデータが含まれないように改善  
  [[変更箇所 1]](diffhunk://#diff-155694f82acd4da15b627253a258c9e096c2d90b0c653b1bd14a3b7dbbba0bedR92-R99)  
  [[変更箇所 2]](diffhunk://#diff-155694f82acd4da15b627253a258c9e096c2d90b0c653b1bd14a3b7dbbba0bedR109-R118)

### 🔸 ビューへの追加データ渡し

- `TReservationInfoController` の `add()` メソッドにて  
  → `userLevel`（ユーザーレベル）をビューに渡すようにし、ロールに応じた入力制御を可能に  
  [[変更箇所 1]](diffhunk://#diff-66cafedb948878aba9f76a05a1db2854b78c12f189f2bb28b1080b88b9d207b2R628)  
  [[変更箇所 2]](diffhunk://#diff-66cafedb948878aba9f76a05a1db2854b78c12f189f2bb28b1080b88b9d207b2L665-R666)

---

## 📝 結論

この変更により、以下の改善が実現されます：

- 各ユーザーに応じたデータアクセスと操作権限の制御
- 誤操作・不正アクセスの防止
- より堅牢で役割に応じた画面表示

今後もロールベースの制御強化を進めていく予定です。
