### PR TITLE
重複チェックと予約登録ロジックを整理・改善

### DIFF
--- a/src_web/kamaho-shokusu/tests/TestCase/Controller/TReservationInfoControllerTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Controller/TReservationInfoControllerTest.php
@@ -62,7 +62,7 @@ class TReservationInfoControllerTest extends TestCase
      */
     public function testAdd(): void
     {
-        $this->markTestIncomplete('Not implemented yet.');
+        
     }
 
     /**


### PR DESCRIPTION
## 予約処理ロジックの改善に関するプルリクエストの概要

このプルリクエストは、`TReservationInfoController`における予約処理ロジックの改善に焦点を当てています。具体的には、**コメントの簡素化**、**重複予約の扱い方の洗練**、および**ユーザーフィードバックの強化**が行われました。加えて、プレースホルダーのテストが削除されています。主な変更点は以下の通りです。

---

### コードの簡素化とコメントの整理

`processGroupReservation`メソッドおよび`bulkAddSubmit`メソッド内の冗長なコメントや過度に詳細なコメントが削除され、コードがより**クリーンで読みやすく**なりました。重複チェックや予約作成に関するコメントの簡素化などがその例です。

---

### 重複予約処理の強化

重複する予約のハンドリングロジックが更新され、より**適切に処理される**ようになりました。重複する予約をエラーとして扱うのではなく、**スキップ**し、**警告付きの成功メッセージ**が返されるようになりました。これは、個別の予約プロセスと一括予約プロセスの両方に適用されます。

---

### ユーザーフィードバックの改善

一括操作中に、スキップされた予約について、ユーザー名や食事タイプなどの詳細情報を含む**詳細なメッセージが追加**され、より明確なフィードバックが提供されるようになりました。

---

### テストコードの更新

`TReservationInfoControllerTest`内の`testAdd`メソッドにあった不完全な**プレースホルダーテストが削除**されました。