### PR TITLE
Fix: 本番環境のchangeEdit POST送信時の部屋ID・日付取得エラーを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MMenuInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MMenuInfoController.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Event\EventInterface;
+use Cake\Http\Client;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ServiceUnavailableException;
+
+class MMenuInfoController extends AppController
+{
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->loadComponent('Authentication.Authentication');
+        $this->viewBuilder()->setLayout('default');
+    }
+
+    public function index()
+    {
+
+    }
+
+    public function generateMenuChat()
+    {
+        $this->autoRender = false;
+
+    }
+}

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -2055,9 +2055,9 @@ class TReservationInfoController extends AppController
     public function changeEdit($roomId = null, $date = null, $mealType = null)
     {
         try {
-            // ---- パラメータ補完（route/query 両対応）----
-            $roomId   = $roomId   ?? $this->request->getParam('roomId')   ?? $this->request->getQuery('roomId');
-            $date     = $date     ?? $this->request->getParam('date')     ?? $this->request->getQuery('date');
+            // ---- パラメータ補完（route/query/POST 両対応）----
+            $roomId   = $roomId   ?? $this->request->getParam('roomId')   ?? $this->request->getQuery('roomId')   ?? $this->request->getData('i_id_room');
+            $date     = $date     ?? $this->request->getParam('date')     ?? $this->request->getQuery('date')     ?? $this->request->getData('d_reservation_date');
             // ALL モード固定（モーダルで 4 食種まとめ）
 
             // 応答種別

--- a/src_web/kamaho-shokusu/tests/TestCase/Controller/MMenuInfoControllerTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Controller/MMenuInfoControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Controller;
+
+use App\Controller\MMenuInfoController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Controller\MMenuInfoController Test Case
+ *
+ * @uses \App\Controller\MMenuInfoController
+ */
+class MMenuInfoControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var list<string>
+     */
+    protected array $fixtures = [
+        'app.MMenuInfo',
+    ];
+
+    /**
+     * Test index method
+     *
+     * @return void
+     * @uses \App\Controller\MMenuInfoController::index()
+     */
+    public function testIndex(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test view method
+     *
+     * @return void
+     * @uses \App\Controller\MMenuInfoController::view()
+     */
+    public function testView(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test add method
+     *
+     * @return void
+     * @uses \App\Controller\MMenuInfoController::add()
+     */
+    public function testAdd(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test edit method
+     *
+     * @return void
+     * @uses \App\Controller\MMenuInfoController::edit()
+     */
+    public function testEdit(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test delete method
+     *
+     * @return void
+     * @uses \App\Controller\MMenuInfoController::delete()
+     */
+    public function testDelete(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}


### PR DESCRIPTION
- changeEditアクションでPOSTデータからもパラメータを取得するように修正
- i_id_room と d_reservation_date をgetData()で取得
- 「部屋IDまたは日付が指定されていません」エラーを解消