### PR TITLE
ci: GitHub Actionsで本番TLS証明書更新を自動化

### DIFF
--- a/.github/workflows/cert-renew.yml
+++ b/.github/workflows/cert-renew.yml
@@ -1,0 +1,26 @@
+name: Renew TLS Certificate
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renew:
+    name: Renew cert on production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run certbot renew on production host
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            sudo certbot renew --quiet \
+              --deploy-hook "docker exec network-reverse nginx -s reload"


### PR DESCRIPTION
## 概要
- `.github/workflows/cert-renew.yml` を追加
- GitHub Actions から本番サーバへSSH接続して `certbot renew` を実行
- 証明書が更新された場合のみ `--deploy-hook` で nginx を reload
- 週次の定期実行 (`schedule`) と手動実行 (`workflow_dispatch`) を有効化

## 関連Issue
- Closes #93

## 前提（Secrets）
以下のRepository Secretsを設定してください。
- `PROD_HOST`
- `PROD_USER`
- `PROD_SSH_KEY`

## 確認内容
- ワークフローファイルの構文確認
- ブランチpush済み
- Actionsから実行可能な状態