### PR TITLE
feat: スマートフォン対応（レスポンシブデザイン） #98

### DIFF
--- a/src_web/kamaho-shokusu/templates/MUserInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/index.php
@@ -18,27 +18,8 @@ $csrfToken = $this->request->getAttribute('csrfToken');
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
 <div class="mUserInfo index content">
-    <?php if ($isAdmin || $user->get('i_user_level') === 0): ?>
-        <?= $this->Html->link(__('新しくユーザを追加'), ['action' => 'add'], ['class' => 'btn btn-success float-right mb-3']) ?>
-        <?= $this->Html->link(__('一括ユーザー登録'), ['action' => 'importForm'], ['class' => 'btn btn-primary float-right mb-3 mr-2']) ?>
-    <?php endif; ?>
-    
-    <?php if ($isAdmin): ?>
-        <div class="float-right mb-3 mr-2">
-            <div class="user-view-toggle-container">
-                <button type="button" class="toggle-btn toggle-btn-left <?= !isset($showDeleted) || !$showDeleted ? 'active' : '' ?>" id="toggleNormal">
-                    <i class="bi bi-people-fill"></i>
-                    <span>通常ユーザー</span>
-                </button>
-                <button type="button" class="toggle-btn toggle-btn-right <?= isset($showDeleted) && $showDeleted ? 'active' : '' ?>" id="toggleDeleted">
-                    <i class="bi bi-trash-fill"></i>
-                    <span>削除済み</span>
-                </button>
-            </div>
-        </div>
-    <?php endif; ?>
-
-    <h3 id="userListTitle" class="mb-4">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h3 id="userListTitle" class="mb-0">
         <?php if (isset($showDeleted) && $showDeleted): ?>
             <span class="badge badge-danger badge-lg">
                 <i class="bi bi-trash"></i> 削除済みユーザー一覧
@@ -48,7 +29,27 @@ $csrfToken = $this->request->getAttribute('csrfToken');
                 <i class="bi bi-people"></i> ユーザー一覧
             </span>
         <?php endif; ?>
-    </h3>
+        </h3>
+
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+            <?php if ($isAdmin): ?>
+                <div class="user-view-toggle-container">
+                    <button type="button" class="toggle-btn toggle-btn-left <?= !isset($showDeleted) || !$showDeleted ? 'active' : '' ?>" id="toggleNormal">
+                        <i class="bi bi-people-fill"></i>
+                        <span>通常ユーザー</span>
+                    </button>
+                    <button type="button" class="toggle-btn toggle-btn-right <?= isset($showDeleted) && $showDeleted ? 'active' : '' ?>" id="toggleDeleted">
+                        <i class="bi bi-trash-fill"></i>
+                        <span>削除済み</span>
+                    </button>
+                </div>
+            <?php endif; ?>
+            <?php if ($isAdmin || $user->get('i_user_level') === 0): ?>
+                <?= $this->Html->link(__('一括ユーザー登録'), ['action' => 'importForm'], ['class' => 'btn btn-primary btn-sm']) ?>
+                <?= $this->Html->link(__('新しくユーザを追加'), ['action' => 'add'], ['class' => 'btn btn-success btn-sm']) ?>
+            <?php endif; ?>
+        </div>
+    </div>
 
     <div class="table-responsive">
         <table class="table table-bordered">

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -349,17 +349,54 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
         font-size: .88rem;
     }
 
+    .mobile-menu-btn {
+        display: none;
+        padding: 8px 14px;
+        border: 1px solid #e8edf3;
+        border-radius: 10px;
+        background: #fff;
+        font-weight: 600;
+        font-size: .9rem;
+        cursor: pointer;
+        color: #374151;
+    }
+    .sidebar-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,.4);
+        z-index: 900;
+    }
     @media (max-width: 992px) {
         .page-shell { grid-template-columns: 1fr; }
-        .side { position: static; height: auto; border-right: none; border-bottom: 1px solid #e8edf3; }
-        .table-row { grid-template-columns: 60px 1fr 80px 80px 80px 80px; }
-        .summary-table { font-size: .82rem; }
+        .side {
+            position: fixed;
+            top: 0; left: 0;
+            width: 78%;
+            max-width: 300px;
+            height: 100%;
+            z-index: 1000;
+            overflow-y: auto;
+            transform: translateX(-100%);
+            transition: transform .3s ease;
+            border-right: 1px solid #e8edf3;
+        }
+        .side.is-open { transform: translateX(0); }
+        .sidebar-overlay.is-active { display: block; }
+        .mobile-menu-btn { display: inline-block; }
+        .topbar { flex-wrap: wrap; }
+        .table-scroll-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+        .table-row { min-width: 480px; }
+        .tabs { overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
+        .tab { white-space: nowrap; }
+        .summary-table { font-size: .82rem; overflow-x: auto; display: block; }
         .summary-table th, .summary-table td { padding: 7px 8px; }
     }
 </style>
 
+<div id="sidebar-overlay" class="sidebar-overlay"></div>
 <div class="page-shell">
-    <aside class="side">
+    <aside class="side" id="view-side">
         <div class="brand">
             <div class="brand-icon">🍴</div>
             食数管理システム
@@ -384,7 +421,10 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
 
     <main class="main">
         <div class="topbar">
-            <div class="top-title">食数状況確認</div>
+            <div class="d-flex align-items-center gap-2">
+                <button class="mobile-menu-btn" id="view-sidebar-toggle">☰ メニュー</button>
+                <div class="top-title">食数状況確認</div>
+            </div>
             <div class="d-flex align-items-center gap-2">
                 <div class="date-pill"><?= h($dateLabel) ?></div>
                 <div class="bell">🔔</div>
@@ -408,6 +448,7 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
             </div>
 
             <div class="mt-3">
+            <div class="table-scroll-wrap">
                 <div class="table-row header">
                     <div>番号</div>
                     <div>氏名</div>
@@ -477,6 +518,7 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
                         <?php $idx++; ?>
                     <?php endforeach; ?>
                 <?php endif; ?>
+            </div><!-- /.table-scroll-wrap -->
             </div>
 
             <div class="summary">
@@ -487,3 +529,19 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
         </div>
     </main>
 </div>
+<script>
+(function () {
+    var btn = document.getElementById('view-sidebar-toggle');
+    var side = document.getElementById('view-side');
+    var overlay = document.getElementById('sidebar-overlay');
+    if (!btn || !side || !overlay) return;
+    btn.addEventListener('click', function () {
+        side.classList.toggle('is-open');
+        overlay.classList.toggle('is-active');
+    });
+    overlay.addEventListener('click', function () {
+        side.classList.remove('is-open');
+        overlay.classList.remove('is-active');
+    });
+})();
+</script>

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/kid_section.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/kid_section.php
@@ -77,7 +77,7 @@ $kidMeals = [
 <?= $this->Flash->render() ?>
 
 <!-- ★ モード切替（自動 / 直前 / 通常） -->
-<div class="mode-bar d-flex align-items-center justify-content-between mb-3">
+<div class="mode-bar d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
     <div class="small text-muted">
         <i class="bi bi-sliders"></i>
         モードを切り替えると、クリック時の挙動を切り替えられます（<u>画面表示のみ切替</u>）。

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/toolbar.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/toolbar.php
@@ -1,5 +1,5 @@
-<div class="d-flex align-items-center justify-content-between mt-2 mb-2">
-    <h1 class="m-0"><?= $useKidUI ? '🍚 食数予約（中高生向け）' : '食数予約（業務）' ?></h1>
+<div class="d-flex flex-wrap align-items-center justify-content-between mt-2 mb-2 gap-2">
+    <h1 class="m-0 fs-4 fs-md-1"><?= $useKidUI ? '🍚 食数予約（中高生向け）' : '食数予約（業務）' ?></h1>
     <?php if (!$useKidUI || ($useKidUI && $isStaff)): ?>
         <div class="d-flex align-items-center gap-2">
             <span class="text-muted small d-none d-md-inline">表示モード:</span>

--- a/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
@@ -1,8 +1,11 @@
 #calendar { max-width:130%; margin:0 auto; }
         @media (max-width: 768px){
+            #calendar { max-width:100%; }
             .fc-toolbar button{font-size:12px;}
             .fc-toolbar-title{font-size:14px;}
             #calendar{font-size:12px;}
+            .mode-bar { flex-wrap: wrap; gap: .5rem; }
+            .cal-room-select { min-width: 100px; max-width: 100%; }
         }
         @media (min-width:769px) and (max-width:1024px){
             .fc-toolbar button{font-size:14px;}


### PR DESCRIPTION
## Summary

- `view.php`（食数状況確認）: スライドサイドバー・テーブル横スクロール・タブ横スクロール対応
- `MUserInfo/index.php`: ヘッダーボタンを flexbox に変更してモバイル折り返し対応
- `treservation_index.css`: `#calendar` の max-width をモバイルで 100% に修正・mode-bar flex-wrap 対応
- `kid_section.php` / `toolbar.php`: flex-wrap / gap 追加

## Test plan

- [ ] スマートフォン（375px）で食数状況確認画面の ☰ ボタンでサイドバーが開閉できること
- [ ] 食数状況確認の利用者テーブルが横スクロールできること
- [ ] ユーザー管理画面のボタンがモバイルで縦に折り返されること
- [ ] 食数予約画面のカレンダーが画面幅に収まること
- [ ] PC 表示が崩れていないこと

Closes #98