### PR TITLE
feat: ステージング環境構築（OCI + Docker + GitHub Actions）

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,114 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - 'develop'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-to-staging
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Staging (stg.kamaho-shokusu.jp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SLACK_USERNAME: DeployBot
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.2
+        env:
+          APP_SALT:           ${{ secrets.STG_APP_SALT }}
+          DB_NAME:            ${{ secrets.STG_DB_NAME }}
+          DB_USER:            ${{ secrets.STG_DB_USER }}
+          DB_PASS:            ${{ secrets.STG_DB_PASS }}
+          DB_ROOT_PASS:       ${{ secrets.STG_DB_ROOT_PASS }}
+          OPENROUTER_API_KEY: ${{ secrets.STG_OPENROUTER_API_KEY }}
+          REPO_URL:           ${{ secrets.REPO_URL }}
+          BRANCH:             ${{ github.ref_name }}
+        with:
+          host:     ${{ secrets.STG_HOST }}
+          username: ubuntu
+          key:      ${{ secrets.STG_SSH_PRIVATE_KEY }}
+          port:     22
+          envs:     APP_SALT,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,OPENROUTER_API_KEY,REPO_URL,BRANCH
+          timeout:  60s
+          command_timeout: 20m
+          script: |
+            set -euo pipefail
+
+            DEPLOY_PATH="/home/ubuntu/shokusuu1"
+            mkdir -p "$DEPLOY_PATH"
+            cd "$DEPLOY_PATH"
+
+            # ── リポジトリ取得 ─────────────────────────────────────────────
+            if [ ! -d .git ]; then
+              echo "[INIT] cloning $REPO_URL (branch: $BRANCH)"
+              git clone --branch "$BRANCH" "$REPO_URL" .
+            else
+              echo "[UPDATE] fetching & resetting to origin/$BRANCH"
+              git fetch origin --prune
+              git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" "origin/$BRANCH"
+              git reset --hard "origin/$BRANCH"
+            fi
+
+            # ── .env 生成 (アプリ用) ────────────────────────────────────────
+            printf 'OPENROUTER_API_KEY=%s\n' "${OPENROUTER_API_KEY}" \
+              > src_web/kamaho-shokusu/.env
+
+            # ── docker/.env.staging 生成 (Docker Compose 用) ───────────────
+            printf 'STG_DB_NAME=%s\nSTG_DB_USER=%s\nSTG_DB_PASS=%s\nSTG_DB_ROOT_PASS=%s\n' \
+              "${DB_NAME}" "${DB_USER}" "${DB_PASS}" "${DB_ROOT_PASS}" \
+              > docker/.env.staging
+
+            # ── app_local.php 生成 ─────────────────────────────────────────
+            printf '<?php\nreturn [\n    '"'"'debug'"'"' => true,\n    '"'"'Security'"'"' => ['"'"'salt'"'"' => '"'"'%s'"'"'],\n    '"'"'Datasources'"'"' => ['"'"'default'"'"' => ['"'"'host'"'"' => '"'"'stg_db'"'"', '"'"'database'"'"' => '"'"'%s'"'"', '"'"'username'"'"' => '"'"'%s'"'"', '"'"'password'"'"' => '"'"'%s'"'"']],\n];\n' \
+              "${APP_SALT}" "${DB_NAME}" "${DB_USER}" "${DB_PASS}" \
+              > src_web/kamaho-shokusu/config/app_local.php
+
+            # ── Docker Compose でビルド & 起動 ─────────────────────────────
+            cd docker
+            export DOCKER_BUILDKIT=1
+            docker compose -f docker-compose.staging.yml --env-file .env.staging pull --quiet || true
+            docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --build --remove-orphans
+            docker image prune -f
+
+            # ── Composer install ───────────────────────────────────────────
+            docker exec stg_web composer install --no-dev --optimize-autoloader --working-dir=/var/www/html/kamaho-shokusu
+
+            # ── マイグレーション ────────────────────────────────────────────
+            sleep 5  # DB起動待ち
+            docker exec stg_web php /var/www/html/kamaho-shokusu/bin/cake migrations migrate --no-interaction || true
+
+            # ── キャッシュクリア ────────────────────────────────────────────
+            docker exec stg_web php /var/www/html/kamaho-shokusu/bin/cake cache clear_all || true
+
+            echo "✅ Staging deployed: $(git rev-parse --short HEAD) @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      - name: Slack Notification on Success
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ success() }}
+        env:
+          SLACK_TITLE: Staging Deploy / Success
+          SLACK_COLOR: good
+          SLACK_MESSAGE: "ステージングへのデプロイ完了🚀 branch: ${{ github.ref_name }}"
+
+      - name: Slack Notification on Failure
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_TITLE: Staging Deploy / Failure
+          SLACK_COLOR: danger
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> ステージングデプロイ失敗しました😢 branch: ${{ github.ref_name }}"

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -1,0 +1,52 @@
+services:
+  # PHP-Apache (本番と同じイメージ)
+  web:
+    container_name: stg_web
+    build:
+      context: ./kamakura-shokusu_web
+      dockerfile: Dockerfile
+    ports:
+      - "8091:80"
+    volumes:
+      - "../src_web:/var/www/html"
+    env_file:
+      - ../src_web/kamaho-shokusu/.env
+    environment:
+      TZ: Asia/Tokyo
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - stg-inner
+      - stg-db
+    restart: unless-stopped
+
+  # MySQL
+  db:
+    container_name: stg_db
+    image: mysql:lts
+    volumes:
+      - stg-db-data:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE:      ${STG_DB_NAME:-kamaho_shokusu}
+      MYSQL_USER:          ${STG_DB_USER:-shokusu_stg}
+      MYSQL_PASSWORD:      ${STG_DB_PASS:-changeme}
+      MYSQL_ROOT_PASSWORD: ${STG_DB_ROOT_PASS:-changeme_root}
+      TZ: Asia/Tokyo
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${STG_DB_ROOT_PASS:-changeme_root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - stg-db
+    restart: unless-stopped
+
+networks:
+  stg-inner:
+    name: stg-inner
+  stg-db:
+    name: stg-db
+
+volumes:
+  stg-db-data:

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,0 +1,185 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+  required_version = ">= 1.5"
+}
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+# ── VCN ──────────────────────────────────────────────────────────────────────
+
+resource "oci_core_vcn" "staging" {
+  compartment_id = var.compartment_ocid
+  cidr_block     = var.vcn_cidr
+  display_name   = "staging-vcn"
+  dns_label      = "staging"
+}
+
+# ── インターネットゲートウェイ ────────────────────────────────────────────────
+
+resource "oci_core_internet_gateway" "staging" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.staging.id
+  display_name   = "staging-igw"
+  enabled        = true
+}
+
+# ── ルートテーブル ──────────────────────────────────────────────────────────
+
+resource "oci_core_route_table" "staging" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.staging.id
+  display_name   = "staging-route-table"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.staging.id
+  }
+}
+
+# ── セキュリティリスト ──────────────────────────────────────────────────────
+
+resource "oci_core_security_list" "staging" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.staging.id
+  display_name   = "staging-security-list"
+
+  # インバウンド: SSH
+  ingress_security_rules {
+    protocol  = "6" # TCP
+    source    = "0.0.0.0/0"
+    stateless = false
+    tcp_options {
+      min = 22
+      max = 22
+    }
+  }
+
+  # インバウンド: HTTP
+  ingress_security_rules {
+    protocol  = "6"
+    source    = "0.0.0.0/0"
+    stateless = false
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  # インバウンド: HTTPS
+  ingress_security_rules {
+    protocol  = "6"
+    source    = "0.0.0.0/0"
+    stateless = false
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  # アウトバウンド: 全通信許可
+  egress_security_rules {
+    protocol    = "all"
+    destination = "0.0.0.0/0"
+    stateless   = false
+  }
+}
+
+# ── パブリックサブネット ────────────────────────────────────────────────────
+
+resource "oci_core_subnet" "staging_public" {
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_vcn.staging.id
+  cidr_block        = var.subnet_cidr
+  display_name      = "staging-public-subnet"
+  dns_label         = "public"
+  route_table_id    = oci_core_route_table.staging.id
+  security_list_ids = [oci_core_security_list.staging.id]
+
+  prohibit_public_ip_on_vnic = false
+}
+
+# ── イメージ (Ubuntu 22.04 AMD x86_64 / Always Free: VM.Standard.E2.1.Micro) ─
+
+data "oci_core_images" "ubuntu" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = "Canonical Ubuntu"
+  operating_system_version = "22.04"
+  shape                    = var.instance_shape
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+}
+
+# ── Computeインスタンス (Always Free: VM.Standard.E2.1.Micro) ─────────────
+
+resource "oci_core_instance" "staging" {
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  display_name        = "staging-server"
+  shape               = var.instance_shape
+
+  source_details {
+    source_type             = "image"
+    source_id               = data.oci_core_images.ubuntu.images[0].id
+    boot_volume_size_in_gbs = 50
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.staging_public.id
+    assign_public_ip = true
+    display_name     = "staging-vnic"
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_public_key
+    user_data = base64encode(<<-EOF
+      #!/bin/bash
+      apt-get update -y
+      apt-get install -y nginx php8.1-fpm php8.1-mysql php8.1-mbstring php8.1-xml php8.1-zip git composer certbot python3-certbot-nginx
+      systemctl enable nginx php8.1-fpm
+      systemctl start nginx php8.1-fpm
+
+      # Nginxのステージング設定
+      cat > /etc/nginx/sites-available/staging <<'NGINX'
+      server {
+          listen 80;
+          server_name ${var.staging_domain};
+          root /var/www/html/current/webroot;
+          index index.php;
+
+          location / {
+              try_files $uri $uri/ /index.php?$args;
+          }
+
+          location ~ \.php$ {
+              fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+              fastcgi_index index.php;
+              include fastcgi_params;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          }
+      }
+      NGINX
+
+      ln -sf /etc/nginx/sites-available/staging /etc/nginx/sites-enabled/staging
+      rm -f /etc/nginx/sites-enabled/default
+      mkdir -p /var/www/html/current/webroot
+      systemctl reload nginx
+    EOF
+    )
+  }
+
+  timeouts {
+    create = "10m"
+  }
+}

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_public_ip" {
+  description = "ステージングサーバーのパブリックIPアドレス"
+  value       = oci_core_instance.staging.public_ip
+}
+
+output "instance_id" {
+  description = "コンピュートインスタンスのOCID"
+  value       = oci_core_instance.staging.id
+}
+
+output "vcn_id" {
+  description = "VCNのOCID"
+  value       = oci_core_vcn.staging.id
+}
+
+output "subnet_id" {
+  description = "パブリックサブネットのOCID"
+  value       = oci_core_subnet.staging_public.id
+}
+
+output "ssh_command" {
+  description = "SSH接続コマンド"
+  value       = "ssh -i ~/.ssh/staging_key ubuntu@${oci_core_instance.staging.public_ip}"
+}
+
+output "staging_url" {
+  description = "ステージング環境URL"
+  value       = "https://${var.staging_domain}"
+}
+
+output "dns_a_record" {
+  description = "DNSレジストラで設定するAレコード"
+  value       = "stg.kamaho-shokusu.jp → ${oci_core_instance.staging.public_ip}"
+}

--- a/terraform/staging/terraform.tfvars.example
+++ b/terraform/staging/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# このファイルをコピーして terraform.tfvars を作成してください
+# cp terraform.tfvars.example terraform.tfvars
+
+tenancy_ocid     = "ocid1.tenancy.oc1..xxxxx"
+user_ocid        = "ocid1.user.oc1..xxxxx"
+fingerprint      = "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+private_key_path = "~/.oci/oci_api_key.pem"
+region           = "ap-tokyo-1"
+
+compartment_ocid = "ocid1.tenancy.oc1..xxxxx" # ルートテナンシーを使う場合はtenancy_ocidと同じ値
+
+# SSH公開鍵 (ssh-keygen -t ed25519 -f ~/.ssh/staging_key で生成)
+ssh_public_key = "ssh-ed25519 AAAA..."

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,0 +1,66 @@
+variable "tenancy_ocid" {
+  description = "OCIテナンシーのOCID"
+  type        = string
+}
+
+variable "user_ocid" {
+  description = "OCIユーザーのOCID"
+  type        = string
+}
+
+variable "fingerprint" {
+  description = "APIキーのフィンガープリント"
+  type        = string
+}
+
+variable "private_key_path" {
+  description = "OCI APIキー秘密鍵のパス"
+  type        = string
+  default     = "~/.oci/oci_api_key.pem"
+}
+
+variable "region" {
+  description = "OCIリージョン"
+  type        = string
+  default     = "ap-tokyo-1"
+}
+
+variable "availability_domain" {
+  description = "可用性ドメイン名"
+  type        = string
+  default     = "Osib:AP-TOKYO-1-AD-1"
+}
+
+variable "compartment_ocid" {
+  description = "コンパートメントのOCID（未指定時はルートテナンシー）"
+  type        = string
+}
+
+variable "vcn_cidr" {
+  description = "VCNのCIDRブロック"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "サブネットのCIDRブロック"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "instance_shape" {
+  description = "コンピュートインスタンスのシェイプ（Always Free: VM.Standard.E2.1.Micro または VM.Standard.A1.Flex）"
+  type        = string
+  default     = "VM.Standard.E2.1.Micro"
+}
+
+variable "staging_domain" {
+  description = "ステージング環境のドメイン名"
+  type        = string
+  default     = "stg.kamaho-shokusu.jp"
+}
+
+variable "ssh_public_key" {
+  description = "インスタンスへのSSHアクセス用公開鍵"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- OCI (Oracle Cloud) + Docker によるステージングサーバー構築
- `develop` ブランチへの push で自動デプロイ
- Terraform で IaC 管理

## 変更内容

### 追加ファイル
- `.github/workflows/deploy-staging.yml` — develop ブランチ限定のデプロイワークフロー
- `docker/docker-compose.staging.yml` — ステージング用 Docker Compose
- `terraform/staging/` — OCI インフラ定義（サーバーは構築済み）

## Test plan

- [ ] develop にマージ後、自動デプロイが走ることを確認
- [ ] `https://stg.kamaho-shokusu.jp` でアプリが表示されることを確認