### PR TITLE
Resolve #125: view/:date の日付URL生成バグを根本修正

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -153,7 +153,7 @@ return function (RouteBuilder $routes): void {
 
         // 日付別ビュー
         $builder->connect(
-            '/TReservationInfo/view/:date',
+            '/TReservationInfo/view/{date}',
             ['controller' => 'TReservationInfo', 'action' => 'view']
         );
 

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -155,7 +155,7 @@ return function (RouteBuilder $routes): void {
         $builder->connect(
             '/TReservationInfo/view/:date',
             ['controller' => 'TReservationInfo', 'action' => 'view']
-        )->setPass(['date']);
+        );
 
         // === 予約トグル（POST）: roomId あり版 と なし版 の両方を受け付ける ===
         $builder->connect(

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -289,11 +289,11 @@ class TReservationInfoController extends AppController
      * @throws \Cake\Datasource\Exception\RecordNotFoundException 記録が見つからない場合
      * 管理者および所属部屋のみ詳細閲覧と修正可能
      */
-    public function view(?string $date = null): ?Response
+    public function view(): ?Response
     {
         $this->authorizeReservation('view');
 
-        $date = $date ?? $this->request->getQuery('date');
+        $date = $this->request->getParam('date') ?? $this->request->getQuery('date');
         $context = $this->viewService->buildViewContext(
             $this->request->getAttribute('identity'),
             $date,

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -441,7 +441,7 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
             <div class="tabs">
                 <?php foreach ($roomsForTabs as $rid => $rname): ?>
                     <a class="tab <?= ((int)$rid === (int)$activeRoomId) ? 'active' : '' ?>"
-                       href="<?= $this->Url->build(['controller' => 'TReservationInfo', 'action' => 'view', $date, '?' => ['room_id' => $rid]]) ?>">
+                       href="<?= $this->Url->build(['controller' => 'TReservationInfo', 'action' => 'view', 'date' => $date, '?' => ['room_id' => $rid]]) ?>">
                         <?= h($rname) ?>
                     </a>
                 <?php endforeach; ?>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -441,7 +441,7 @@ $totalNo = $roomMealSummary[$defaultMealType]['no'] ?? 0;
             <div class="tabs">
                 <?php foreach ($roomsForTabs as $rid => $rname): ?>
                     <a class="tab <?= ((int)$rid === (int)$activeRoomId) ? 'active' : '' ?>"
-                       href="<?= $this->Url->build(['controller' => 'TReservationInfo', 'action' => 'view', 'date' => $date, '?' => ['room_id' => $rid]]) ?>">
+                       href="<?= $this->Url->build('/TReservationInfo/view/' . h($date) . '?room_id=' . (int)$rid) ?>">
                         <?= h($rname) ?>
                     </a>
                 <?php endforeach; ?>


### PR DESCRIPTION
Closes #125
Closes #123

## 変更内容

### 問題の根本原因
CakePHP 5 では旧式の `:date` ルート記法を使った場合、`Url::build()` が URL 生成時にプレースホルダーをリテラル文字列 `:date` としてそのまま出力してしまう。
その結果、ルームタブのリンクが `/TReservationInfo/view/:date?room_id=5` になり、日付が今日の日付にフォールバックしていた。

### 修正内容

- **`config/routes.php`**
  - 旧式 `:date` → CakePHP 5 の新記法 `{date}` に変更
  - `->setPass(['date'])` を削除（不要）

- **`src/Controller/TReservationInfoController.php`**
  - アクションシグネチャを `view()` に統一
  - `$this->request->getParam('date')` で named param を取得（クエリパラメータ `?date=` へのフォールバックも維持）

- **`templates/TReservationInfo/view.php`**
  - ルームタブのリンク生成を `Url::build()` 配列形式 → 文字列連結方式に変更
  - `home.php` / `dashboard.php` の同様のURL生成と記法を統一

  ```php
  // 修正前（Url::build配列形式 → :date がリテラルになるバグ）
  $this->Url->build(['controller' => 'TReservationInfo', 'action' => 'view', $date, '?' => ['room_id' => $rid]])

  // 修正後（文字列連結 → 確実に日付が埋め込まれる）
  $this->Url->build('/TReservationInfo/view/' . h($date) . '?room_id=' . (int)$rid)
  ```

### 期待される動作
タブクリック時の URL が `/TReservationInfo/view/2025-04-07?room_id=1` のように日付・部屋ID両方が正しく含まれるようになる。