### PR TITLE
Resolve #127: ユーザー一覧バッジのBootstrap 5対応

### DIFF
--- a/src_web/kamaho-shokusu/templates/MUserInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/index.php
@@ -21,11 +21,11 @@ $csrfToken = $this->request->getAttribute('csrfToken');
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h3 id="userListTitle" class="mb-0">
         <?php if (isset($showDeleted) && $showDeleted): ?>
-            <span class="badge badge-danger badge-lg">
+            <span class="badge text-bg-danger badge-lg">
                 <i class="bi bi-trash"></i> 削除済みユーザー一覧
             </span>
         <?php else: ?>
-            <span class="badge badge-primary badge-lg">
+            <span class="badge text-bg-primary badge-lg">
                 <i class="bi bi-people"></i> ユーザー一覧
             </span>
         <?php endif; ?>


### PR DESCRIPTION
Closes #127

## 変更内容

- `templates/MUserInfo/index.php` のタイトルバッジクラスをBootstrap 4からBootstrap 5の記法に修正
  - 削除済みユーザー一覧バッジ: `badge-danger` → `text-bg-danger`
  - 通常ユーザー一覧バッジ: `badge-primary` → `text-bg-primary`

## 原因と対応

Bootstrap 5では `badge-{color}` クラスが廃止され、`text-bg-{color}` に変更された。このプロジェクトはBootstrap 5を使用しているにもかかわらず、旧記法が残っていたためデザインが崩れていた。