### PR TITLE
Resolve #129: MRoomInfo テンプレートのBootstrap 5対応

### DIFF
--- a/src_web/kamaho-shokusu/templates/MRoomInfo/add.php
+++ b/src_web/kamaho-shokusu/templates/MRoomInfo/add.php
@@ -9,7 +9,9 @@ $this->assign('title', __('部屋情報追加'));
     <aside class="col-md-3">
         <div class="p-3 bg-light rounded">
             <h4><?= __('アクション') ?></h4>
-            <?= $this->Html->link(__('部屋情報一覧'), ['action' => 'index'], ['class' => 'btn btn-secondary btn-block mt-2']) ?>
+            <div class="d-grid mt-2">
+                <?= $this->Html->link(__('部屋情報一覧'), ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+            </div>
         </div>
     </aside>
     <div class="col-md-9">

--- a/src_web/kamaho-shokusu/templates/MRoomInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomInfo/index.php
@@ -31,12 +31,12 @@ $isAdmin = $user->get('i_admin') === 1;
 </style>
 <div class="mRoomInfo index content">
     <?php if ($isAdmin): // 管理者のみが新しい部屋情報を追加できる ?>
-    <?= $this->Html->link(__('新しい部屋情報を追加'), ['action' => 'add'], ['class' => 'btn btn-success float-right mb-3']) ?>
+    <?= $this->Html->link(__('新しい部屋情報を追加'), ['action' => 'add'], ['class' => 'btn btn-success float-end mb-3']) ?>
     <?php endif; ?>
     <h3><?= __('部屋情報一覧') ?></h3>
     <div class="table-responsive">
         <table class="table table-striped table-bordered">
-            <thead class="thead-dark">
+            <thead class="table-dark">
             <tr>
                 <th><?= $this->Paginator->sort('i_id_room', '部屋ID') ?></th>
                 <th><?= $this->Paginator->sort('c_room_name', '部屋名') ?></th>

--- a/src_web/kamaho-shokusu/templates/MRoomInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/MRoomInfo/view.php
@@ -40,7 +40,7 @@ $this->Html->css(['bootstrap.min']);
                     <h4><?= __('所属メンバー') ?></h4>
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
-                            <thead class="thead-dark">
+                            <thead class="table-dark">
                             <tr>
                                 <th><?= __('ユーザー識別ID') ?></th>
                                 <th><?= __('ユーザー名') ?></th>


### PR DESCRIPTION
Closes #129

## 変更内容

- `MRoomInfo/index.php`: `float-right` → `float-end`
- `MRoomInfo/index.php`: `thead-dark` → `table-dark`
- `MRoomInfo/view.php`: `thead-dark` → `table-dark`
- `MRoomInfo/add.php`: `btn-block` を削除し `d-grid` ラッパーに変更

## 関連

- #127 / PR #128（MUserInfo の同様の修正）