### PR TITLE
fix: 承認フローのDB修正・ボタン修正・ファイル復元

### DIFF
--- a/sql/updates/20260411_003_enable_admin_users.sql
+++ b/sql/updates/20260411_003_enable_admin_users.sql
@@ -1,2 +1,2 @@
--- 管理者ユーザー（i_admin = 1）の有効フラグを有効化する
-UPDATE m_user_info SET i_enable = 1 WHERE i_admin = 1 AND i_enable = 0;
+-- 管理者ユーザー（i_admin = 1）の有効フラグを有効化する（i_enable: 0=有効, 1=無効）
+UPDATE m_user_info SET i_enable = 0 WHERE i_admin = 1 AND i_enable != 0;

--- a/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
+++ b/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- t_individual_reservation_info に承認ステータスカラムを追加
+--
+-- i_approval_status:
+--   0 = 未承認
+--   1 = ブロック長承認済
+--   2 = 管理者承認済（最終）
+--   3 = 差し戻し
+-- ============================================================
+ALTER TABLE t_individual_reservation_info
+    ADD COLUMN i_approval_status TINYINT NOT NULL DEFAULT 0
+        COMMENT '0:未承認 1:ブロック長承認済 2:管理者承認済(最終) 3:差し戻し'
+        AFTER i_change_flag;

--- a/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
+++ b/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
@@ -8,6 +8,6 @@
 --   3 = 差し戻し
 -- ============================================================
 ALTER TABLE t_individual_reservation_info
-    ADD COLUMN i_approval_status TINYINT NOT NULL DEFAULT 0
+    ADD COLUMN IF NOT EXISTS i_approval_status TINYINT NOT NULL DEFAULT 0
         COMMENT '0:未承認 1:ブロック長承認済 2:管理者承認済(最終) 3:差し戻し'
         AFTER i_change_flag;

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -312,7 +312,7 @@ foreach ($summary as $row) {
             <h1 class="page-title">承認管理</h1>
             <div class="page-subtitle">管理者向けに、ブロック長承認済の申請確認、最終承認、差し戻し、食数反映までを行います。</div>
         </div>
-        <a href="<?= h($basePath) ?>/MUserInfo/logout" class="btn btn-outline-secondary mui-btn">ログアウト</a>
+        <a href="<?= h($basePath) ?>/" class="btn btn-outline-secondary mui-btn">戻る</a>
     </div>
 
     <div class="summary-grid">

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -246,7 +246,7 @@ foreach ($records as $record) {
             <h1 class="page-title">承認一覧</h1>
             <div class="page-subtitle">ブロック長向けに、担当部屋の申請を確認して承認または差し戻しを行います。</div>
         </div>
-        <a href="<?= h($basePath) ?>/MUserInfo/logout" class="btn btn-outline-secondary mui-btn">ログアウト</a>
+        <a href="<?= h($basePath) ?>/" class="btn btn-outline-secondary mui-btn">戻る</a>
     </div>
 
     <div class="summary-grid">


### PR DESCRIPTION
## Summary

- 承認画面のログアウトボタンを戻るボタンに変更
- i_approval_status カラム追加マイグレーションを追加（IF NOT EXISTS対応）
- i_enable の値の誤りを修正（0=有効, 1=無効）
- 管理者ユーザー有効化マイグレーションを修正
- マージで消失した承認フロー・通知機能のファイルを全件復元

## 変更内容

### テンプレート
- `admin_index.php` / `block_leader_index.php`: ログアウト → 戻る（ダッシュボードへ）

### SQL マイグレーション（sql/updates/）
- `20260411_003`: 管理者ユーザー有効化（i_enable=0）
- `20260411_004`: t_individual_reservation_info に i_approval_status カラム追加

## Test plan

- [ ] 承認管理画面で「戻る」ボタンがダッシュボードに戻ることを確認
- [ ] 承認一覧画面で「戻る」ボタンがダッシュボードに戻ることを確認
- [ ] 管理者アカウントでログインできることを確認