### PR TITLE
fix: マイグレーションチェックサムエラーの修正

### DIFF
--- a/sql/updates/20260411_003_enable_admin_users.sql
+++ b/sql/updates/20260411_003_enable_admin_users.sql
@@ -1,2 +1,2 @@
--- 管理者ユーザー（i_admin = 1）の有効フラグを有効化する（i_enable: 0=有効, 1=無効）
-UPDATE m_user_info SET i_enable = 0 WHERE i_admin = 1 AND i_enable != 0;
+-- 管理者ユーザー（i_admin = 1）の有効フラグを有効化する
+UPDATE m_user_info SET i_enable = 1 WHERE i_admin = 1 AND i_enable = 0;

--- a/sql/updates/20260411_005_fix_admin_users_enable.sql
+++ b/sql/updates/20260411_005_fix_admin_users_enable.sql
@@ -1,0 +1,3 @@
+-- 管理者ユーザーの有効フラグを修正する（i_enable: 0=有効, 1=無効）
+-- 003で誤って i_enable=1（無効）に設定したため、0（有効）に戻す
+UPDATE m_user_info SET i_enable = 0 WHERE i_admin = 1 AND i_enable = 1;


### PR DESCRIPTION
## Summary

- 適用済みSQLファイルの内容変更によるチェックサムエラーを修正
- 003を元の内容に戻し、管理者ユーザー有効化の修正を005として新規追加

## 変更内容

### SQL マイグレーション
- `20260411_003`: 元の内容に復元（チェックサム一致）
- `20260411_005`: 管理者ユーザーの i_enable を正しく修正（0=有効）

## Test plan

- [ ] デプロイ時にチェックサムエラーが発生しないことを確認
- [ ] 管理者アカウントでログインできることを確認