### PR TITLE
fix: SQLマイグレーションのチェックサムエラーと構文エラーを修正

### DIFF
--- a/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
+++ b/sql/updates/20260411_004_alter_t_individual_reservation_info_add_approval_status.sql
@@ -7,7 +7,14 @@
 --   2 = 管理者承認済（最終）
 --   3 = 差し戻し
 -- ============================================================
-ALTER TABLE t_individual_reservation_info
-    ADD COLUMN IF NOT EXISTS i_approval_status TINYINT NOT NULL DEFAULT 0
-        COMMENT '0:未承認 1:ブロック長承認済 2:管理者承認済(最終) 3:差し戻し'
-        AFTER i_change_flag;
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME   = 't_individual_reservation_info'
+       AND COLUMN_NAME  = 'i_approval_status') = 0,
+    'ALTER TABLE t_individual_reservation_info ADD COLUMN i_approval_status TINYINT NOT NULL DEFAULT 0 COMMENT ''0:未承認 1:ブロック長承認済 2:管理者承認済(最終) 3:差し戻し'' AFTER i_change_flag',
+    'SELECT 1'
+));
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## 変更内容

- `20260411_004`: `ADD COLUMN IF NOT EXISTS` を `INFORMATION_SCHEMA` チェック＋`PREPARE/EXECUTE` に変更（MySQL バージョン非対応の構文エラーを解消）
- `20260411_003`: 適用済みファイルの内容を元に戻してチェックサム一致を確保
- `20260411_005`: 管理者ユーザーの `i_enable` を正しく `0`（有効）に修正する新規ファイルを追加
- 承認画面（管理者・ブロック長）のログアウトボタンを「戻る」ボタンに変更

## Test plan

- [ ] デプロイ時にチェックサムエラー・構文エラーが発生しないことを確認
- [ ] 管理者アカウントでログインできることを確認
- [ ] 承認画面の「戻る」ボタンでダッシュボードに遷移することを確認