### PR TITLE
Resolve #135: 本番環境でのDBマイグレーション自動化

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -73,11 +73,11 @@ jobs:
         env:
           REPO_URL:     ${{ secrets.REPO_URL }}
           BRANCH:       main
-          DB_NAME:      ${{ secrets.PROD_DB_NAME }}
-          DB_USER:      ${{ secrets.PROD_DB_USER }}
-          DB_PASS:      ${{ secrets.PROD_DB_PASS }}
-          DB_ROOT_PASS: ${{ secrets.PROD_DB_ROOT_PASS }}
-          DB_CONTAINER: ${{ secrets.PROD_DB_CONTAINER }}
+          DB_NAME:      ${{ secrets.DB_NAME }}
+          DB_USER:      ${{ secrets.DB_USER }}
+          DB_PASS:      ${{ secrets.DB_PASS }}
+          DB_ROOT_PASS: ${{ secrets.DB_ROOT_PASS }}
+          DB_CONTAINER: ${{ secrets.DB_CONTAINER }}
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,11 +34,11 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 20m
+          envs: REPO_URL,BRANCH,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,DB_CONTAINER
           script: |
             set -euo pipefail
 
             DEPLOY_PATH="/home/ubuntu/shokusuu1"
-            REPO_URL="${{ secrets.REPO_URL }}"   # 例: git@github.com:oohashikazuyuki/shokusuu1.git
             BRANCH="${BRANCH:-main}"
 
             # デプロイ先へ移動（初回は空ディレクトリ想定）
@@ -47,7 +47,7 @@ jobs:
 
             # 初回 clone or 既存更新
             if [ ! -d .git ]; then
-              if [ -z "$REPO_URL" ]; then
+              if [ -z "${REPO_URL:-}" ]; then
                 echo "ERROR: secrets.REPO_URL が未設定です（例: git@github.com:oohashikazuyuki/shokusuu1.git）。" >&2
                 exit 1
               fi
@@ -60,17 +60,24 @@ jobs:
               git reset --hard "origin/$BRANCH"
             fi
 
-            # 必要に応じて有効化（例）
-            # if [ -f docker-compose.yml ] || [ -f compose.yml ]; then
-            #   docker compose pull
-            #   docker compose up -d --remove-orphans
-            #   docker image prune -f
-            # fi
-            # if [ -f bin/cake ]; then
-            #   php bin/cake cache clear_all || true
-            # fi
+            # ── SQL更新適用（sql/updates/*.sql を1回ずつ実行） ────────────────
+            echo "── Applying SQL migrations ──────────────────────────────────────"
+            ./scripts/apply_sql_updates.sh \
+              "${DB_CONTAINER}" \
+              "${DB_NAME}" \
+              root \
+              "${DB_ROOT_PASS}" \
+              sql/updates
 
             echo "✅ Deployed: $(git rev-parse --short HEAD) @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        env:
+          REPO_URL:     ${{ secrets.REPO_URL }}
+          BRANCH:       main
+          DB_NAME:      ${{ secrets.PROD_DB_NAME }}
+          DB_USER:      ${{ secrets.PROD_DB_USER }}
+          DB_PASS:      ${{ secrets.PROD_DB_PASS }}
+          DB_ROOT_PASS: ${{ secrets.PROD_DB_ROOT_PASS }}
+          DB_CONTAINER: ${{ secrets.PROD_DB_CONTAINER }}
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
Closes #135

## 変更内容

- `.github/workflows/deployment.yml` に `apply_sql_updates.sh` の実行ステップを追加
  - `sql/updates/*.sql` を順番に適用（未適用のものだけ実行）
  - `schema_sql_history` テーブルで適用済みを管理（冪等性の確保）
  - 適用結果をデプロイログに出力
- Secret名を既存パターンに合わせて統一（`DB_NAME` / `DB_USER` / `DB_PASS` / `DB_ROOT_PASS` / `DB_CONTAINER`）

## 設定済み Secrets

| Secret | 内容 |
|--------|------|
| `DB_NAME` | 既存 |
| `DB_USER` | 既存 |
| `DB_PASS` | 既存 |
| `DB_ROOT_PASS` | 今回追加 |
| `DB_CONTAINER` | 今回追加（`kamakura-shokusu_web_db`）|