### PR TITLE
Resolve #142: 承認画面のデフォルトフィルターと件数カウントのバグを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -50,7 +50,7 @@ class ApprovalController extends AppController
         $filterRoomId = $this->request->getQuery('room_id') ? (int)$this->request->getQuery('room_id') : null;
         $filterStatus = $this->request->getQuery('status') !== null && $this->request->getQuery('status') !== ''
             ? (int)$this->request->getQuery('status')
-            : ApprovalService::STATUS_BLOCK_LEADER;
+            : ApprovalService::STATUS_PENDING;
         $dateFrom = $this->request->getQuery('date_from') ?? date('Y-m-d', strtotime('monday this week'));
         $dateTo   = $this->request->getQuery('date_to')   ?? date('Y-m-d', strtotime('sunday this week'));
 

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -246,6 +246,7 @@ class ApprovalService
 
         $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $query = $table->find()
+            ->contain(['MUserInfo'])
             ->where([
                 'TIndividualReservationInfo.i_id_room IN' => $roomIds,
                 'TIndividualReservationInfo.i_approval_status' => self::STATUS_PENDING,
@@ -258,6 +259,20 @@ class ApprovalService
             $query->where(['TIndividualReservationInfo.d_reservation_date <=' => $dateTo]);
         }
 
+        // 大人ユーザーのみ（getBlockLeaderList と同条件）
+        $query->where([
+            'OR' => [
+                ['MUserInfo.i_id_staff IS NOT' => null, 'MUserInfo.i_id_staff !=' => ''],
+                ['MUserInfo.i_user_level' => 7],
+            ],
+        ]);
+        $query->where([
+            'OR' => [
+                ['MUserInfo.i_admin IS' => null],
+                ['MUserInfo.i_admin'    => 0],
+            ],
+        ]);
+
         return $query->count();
     }
 
@@ -268,6 +283,7 @@ class ApprovalService
     {
         $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $query = $table->find()
+            ->contain(['MUserInfo'])
             ->where([
                 'TIndividualReservationInfo.i_approval_status' => self::STATUS_BLOCK_LEADER,
             ]);
@@ -278,6 +294,20 @@ class ApprovalService
         if ($dateTo !== null) {
             $query->where(['TIndividualReservationInfo.d_reservation_date <=' => $dateTo]);
         }
+
+        // 大人ユーザーのみ（getAdminList と同条件）
+        $query->where([
+            'OR' => [
+                ['MUserInfo.i_id_staff IS NOT' => null, 'MUserInfo.i_id_staff !=' => ''],
+                ['MUserInfo.i_user_level' => 7],
+            ],
+        ]);
+        $query->where([
+            'OR' => [
+                ['MUserInfo.i_admin IS' => null],
+                ['MUserInfo.i_admin'    => 0],
+            ],
+        ]);
 
         return $query->count();
     }


### PR DESCRIPTION
Closes #142

## 変更内容

### バグ1: blockLeaderIndex のデフォルトフィルターを修正
**対象ファイル:** `src/Controller/ApprovalController.php`

- `blockLeaderIndex` のデフォルト `filterStatus` を `STATUS_BLOCK_LEADER`(1) → `STATUS_PENDING`(0) に修正
- 修正前: ブロック長が画面を開くとデフォルトで「ブロック長承認済み」の予約が表示され、未承認レコードが見えなかった
- 修正後: デフォルトで「未承認」の予約が表示され、ブロック長が正しく承認操作できる

### バグ2: countBlockLeaderPending / countAdminPending に大人・管理者除外フィルターを追加
**対象ファイル:** `src/Service/ApprovalService.php`

- `countBlockLeaderPending()` に大人フィルター・管理者除外フィルターを追加
- `countAdminPending()` に同フィルターを追加
- `getBlockLeaderList()` / `getAdminList()` と同条件（`i_id_staff` あり OR `i_user_level=7`、かつ `i_admin=0/NULL`）に統一
- 修正前: 子供や管理者・ブロック長の予約も未承認件数にカウントされていた