### PR TITLE
Resolve #144: 承認ルートを経由しない承認バグの修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -86,7 +86,8 @@ class ApprovalService
         }
 
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
-        // かつ、管理者・ブロック長本人の予約は除外（自己承認防止）
+        // かつ、管理者（i_admin=1）本人の予約は除外（自己承認防止）
+        // ※ブロック長（i_admin=2）は管理者が承認できるため除外しない
         $query->where([
             'OR' => [
                 [
@@ -99,7 +100,7 @@ class ApprovalService
         $query->where([
             'OR' => [
                 ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin'    => 0],
+                ['MUserInfo.i_admin !=' => 1],
             ],
         ]);
 
@@ -145,7 +146,8 @@ class ApprovalService
         }
 
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
-        // かつ、管理者・ブロック長本人の予約は除外（自己承認防止）
+        // かつ、管理者（i_admin=1）本人の予約は除外（自己承認防止）
+        // ※ブロック長（i_admin=2）は管理者が承認できるため除外しない
         $query->where([
             'OR' => [
                 [
@@ -158,7 +160,7 @@ class ApprovalService
         $query->where([
             'OR' => [
                 ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin'    => 0],
+                ['MUserInfo.i_admin !=' => 1],
             ],
         ]);
 

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -322,7 +322,7 @@ class ApprovalService
      */
     public function blockLeaderApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null);
+        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null, [self::STATUS_PENDING]);
     }
 
     /**
@@ -335,7 +335,7 @@ class ApprovalService
      */
     public function adminApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null);
+        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER]);
     }
 
     /**
@@ -349,7 +349,7 @@ class ApprovalService
      */
     public function reject(array $keys, int $approverId, string $actor, ?string $reason): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_REJECTED, $approverId, $actor, $reason);
+        return $this->updateApprovalStatus($keys, self::STATUS_REJECTED, $approverId, $actor, $reason, [self::STATUS_PENDING, self::STATUS_BLOCK_LEADER]);
     }
 
     /**
@@ -441,14 +441,15 @@ class ApprovalService
         int $newStatus,
         int $approverId,
         string $actor,
-        ?string $reason
+        ?string $reason,
+        array $allowedFromStatuses
     ): bool {
         $individualTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $logTable        = TableRegistry::getTableLocator()->get('TApprovalLog');
         $now             = DateTime::now();
 
         return $individualTable->getConnection()->transactional(
-            function () use ($keys, $newStatus, $approverId, $actor, $reason, $individualTable, $logTable, $now): bool {
+            function () use ($keys, $newStatus, $approverId, $actor, $reason, $allowedFromStatuses, $individualTable, $logTable, $now): bool {
                 foreach ($keys as $k) {
                     $affected = $individualTable->updateAll(
                         ['i_approval_status' => $newStatus, 'dt_update' => $now, 'c_update_user' => $actor],
@@ -457,6 +458,7 @@ class ApprovalService
                             'd_reservation_date' => $k['d_reservation_date'],
                             'i_id_room'          => $k['i_id_room'],
                             'i_reservation_type' => $k['i_reservation_type'],
+                            'i_approval_status IN' => $allowedFromStatuses,
                         ]
                     );
                     if ($affected < 1) {

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -322,7 +322,7 @@ class ApprovalService
      */
     public function blockLeaderApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null, [self::STATUS_PENDING]);
+        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null, [self::STATUS_PENDING], $approverId);
     }
 
     /**
@@ -335,7 +335,7 @@ class ApprovalService
      */
     public function adminApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER]);
+        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER], $approverId);
     }
 
     /**
@@ -442,15 +442,20 @@ class ApprovalService
         int $approverId,
         string $actor,
         ?string $reason,
-        array $allowedFromStatuses
+        array $allowedFromStatuses,
+        ?int $excludeUserId = null
     ): bool {
         $individualTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $logTable        = TableRegistry::getTableLocator()->get('TApprovalLog');
         $now             = DateTime::now();
 
         return $individualTable->getConnection()->transactional(
-            function () use ($keys, $newStatus, $approverId, $actor, $reason, $allowedFromStatuses, $individualTable, $logTable, $now): bool {
+            function () use ($keys, $newStatus, $approverId, $actor, $reason, $allowedFromStatuses, $excludeUserId, $individualTable, $logTable, $now): bool {
                 foreach ($keys as $k) {
+                    // 承認者自身の予約は自己承認を防止するためスキップ
+                    if ($excludeUserId !== null && (int)$k['i_id_user'] === $excludeUserId) {
+                        return false;
+                    }
                     $affected = $individualTable->updateAll(
                         ['i_approval_status' => $newStatus, 'dt_update' => $now, 'c_update_user' => $actor],
                         [

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -86,8 +86,6 @@ class ApprovalService
         }
 
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
-        // かつ、管理者（i_admin=1）本人の予約は除外（自己承認防止）
-        // ※ブロック長（i_admin=2）は管理者が承認できるため除外しない
         $query->where([
             'OR' => [
                 [
@@ -95,12 +93,6 @@ class ApprovalService
                     'MUserInfo.i_id_staff !='     => '',
                 ],
                 ['MUserInfo.i_user_level' => 7],
-            ],
-        ]);
-        $query->where([
-            'OR' => [
-                ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin !=' => 1],
             ],
         ]);
 
@@ -146,8 +138,6 @@ class ApprovalService
         }
 
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
-        // かつ、管理者（i_admin=1）本人の予約は除外（自己承認防止）
-        // ※ブロック長（i_admin=2）は管理者が承認できるため除外しない
         $query->where([
             'OR' => [
                 [
@@ -155,12 +145,6 @@ class ApprovalService
                     'MUserInfo.i_id_staff !='     => '',
                 ],
                 ['MUserInfo.i_user_level' => 7],
-            ],
-        ]);
-        $query->where([
-            'OR' => [
-                ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin !=' => 1],
             ],
         ]);
 
@@ -324,7 +308,7 @@ class ApprovalService
      */
     public function blockLeaderApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null, [self::STATUS_PENDING], $approverId);
+        return $this->updateApprovalStatus($keys, self::STATUS_BLOCK_LEADER, $approverId, $actor, null, [self::STATUS_PENDING]);
     }
 
     /**
@@ -337,7 +321,7 @@ class ApprovalService
      */
     public function adminApprove(array $keys, int $approverId, string $actor): bool
     {
-        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER], $approverId);
+        return $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER]);
     }
 
     /**

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -88,10 +88,7 @@ class ApprovalService
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
         $query->where([
             'OR' => [
-                [
-                    'MUserInfo.i_id_staff IS NOT' => null,
-                    'MUserInfo.i_id_staff !='     => '',
-                ],
+                ['MUserInfo.i_id_staff IS NOT' => null],
                 ['MUserInfo.i_user_level' => 7],
             ],
         ]);
@@ -140,10 +137,7 @@ class ApprovalService
         // 大人ユーザーのみ表示（職員 または i_user_level=7 の大人）
         $query->where([
             'OR' => [
-                [
-                    'MUserInfo.i_id_staff IS NOT' => null,
-                    'MUserInfo.i_id_staff !='     => '',
-                ],
+                ['MUserInfo.i_id_staff IS NOT' => null],
                 ['MUserInfo.i_user_level' => 7],
             ],
         ]);
@@ -248,14 +242,8 @@ class ApprovalService
         // 大人ユーザーのみ（getBlockLeaderList と同条件）
         $query->where([
             'OR' => [
-                ['MUserInfo.i_id_staff IS NOT' => null, 'MUserInfo.i_id_staff !=' => ''],
+                ['MUserInfo.i_id_staff IS NOT' => null],
                 ['MUserInfo.i_user_level' => 7],
-            ],
-        ]);
-        $query->where([
-            'OR' => [
-                ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin'    => 0],
             ],
         ]);
 
@@ -284,14 +272,8 @@ class ApprovalService
         // 大人ユーザーのみ（getAdminList と同条件）
         $query->where([
             'OR' => [
-                ['MUserInfo.i_id_staff IS NOT' => null, 'MUserInfo.i_id_staff !=' => ''],
+                ['MUserInfo.i_id_staff IS NOT' => null],
                 ['MUserInfo.i_user_level' => 7],
-            ],
-        ]);
-        $query->where([
-            'OR' => [
-                ['MUserInfo.i_admin IS' => null],
-                ['MUserInfo.i_admin'    => 0],
             ],
         ]);
 

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
@@ -217,6 +217,7 @@ if (!empty($dates)) {
             color: var(--text-main);
         }
         .legend-chip.approved { background: var(--accent-soft); color: var(--accent); border-color: rgba(31, 79, 122, 0.18); }
+        .legend-chip.pending { background: #fff7ed; color: #b45309; border-color: rgba(180, 83, 9, 0.2); }
         .legend-chip.editing { background: var(--warning-soft); color: var(--warning); border-color: rgba(154, 103, 0, 0.2); }
         .legend-chip.rejected { background: var(--danger-soft); color: var(--danger); border-color: rgba(180, 35, 24, 0.18); }
         .legend-chip.empty { background: #fff; color: var(--text-sub); }
@@ -391,6 +392,7 @@ if (!empty($dates)) {
             font-weight: 600;
         }
         .meal-toggle.active .meal-status { color: var(--accent); }
+        .meal-toggle.pending .meal-status { color: #b45309; }
         .meal-toggle.changed .meal-status { color: var(--warning); }
         .meal-toggle.rejected .meal-status { color: var(--danger); }
         .meal-toggle input { display: none; }
@@ -565,6 +567,7 @@ if (!empty($dates)) {
                 </div>
                 <div class="legend-list">
                     <div class="legend-item"><span class="legend-chip approved">承認済み</span><span>承認済の内容が現在値です。</span></div>
+                    <div class="legend-item"><span class="legend-chip pending">申請中</span><span>承認待ちの状態です。</span></div>
                     <div class="legend-item"><span class="legend-chip editing">変更中</span><span>保存前の変更があります。</span></div>
                     <div class="legend-item"><span class="legend-chip rejected">差し戻し</span><span>再確認が必要な入力です。</span></div>
                     <div class="legend-item"><span class="legend-chip empty">未入力</span><span>まだ登録されていません。</span></div>
@@ -679,18 +682,25 @@ if (!empty($dates)) {
                         $version = (int)($versions[$selectedUserId][$d][$mealType] ?? 1);
                         $status  = (int)($statuses[$selectedUserId][$d][$mealType] ?? 0);
                         $isRejected = $status === 3;
-                        $statusText = $checked ? '承認済み' : '未入力';
+                        $isPending  = $checked && in_array($status, [0, 1], true);
                         if ($isRejected) {
                             $statusText = '差し戻し';
+                        } elseif ($isPending) {
+                            $statusText = '申請中';
+                        } elseif ($checked) {
+                            $statusText = '承認済み';
+                        } else {
+                            $statusText = '未入力';
                         }
                         $mealCode = [1 => 'AM', 2 => 'LN', 3 => 'PM'][$mealType] ?? '--';
                     ?>
-                        <label class="meal-toggle <?= $checked ? 'active' : '' ?> <?= $isRejected ? 'rejected' : '' ?>"
+                        <label class="meal-toggle <?= $checked ? 'active' : '' ?> <?= $isRejected ? 'rejected' : '' ?> <?= $isPending ? 'pending' : '' ?>"
                                data-uid="<?= $selectedUserId ?>"
                                data-date="<?= h($d) ?>"
                                data-meal="<?= $mealType ?>"
                                data-version="<?= $version ?>"
-                               data-original="<?= $checked ? '1' : '0' ?>">
+                               data-original="<?= $checked ? '1' : '0' ?>"
+                               data-status-text="<?= h($statusText) ?>">
                             <input type="checkbox" <?= $checked ? 'checked' : '' ?>>
                             <span class="meal-toggle-top">
                                 <span class="meal-code"><?= h($mealCode) ?></span>
@@ -765,7 +775,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const status = label.querySelector('.meal-status');
         label.classList.toggle('active',   checked && !isChanged);
         label.classList.toggle('changed',  isChanged);
-        if (status) status.textContent = isChanged ? '変更中' : (checked ? '承認済み' : '未入力');
+        if (status) {
+            if (isChanged) {
+                status.textContent = '変更中';
+            } else if (checked) {
+                status.textContent = label.dataset.statusText || '承認済み';
+            } else {
+                status.textContent = '未入力';
+            }
+        }
     }
 
     // トグルクリック

--- a/src_web/kamaho-shokusu/tests/Fixture/TApprovalLogFixture.php
+++ b/src_web/kamaho-shokusu/tests/Fixture/TApprovalLogFixture.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class TApprovalLogFixture extends TestFixture
+{
+    public string $table = 't_approval_log';
+
+    public function init(): void
+    {
+        $this->records = [];
+        parent::init();
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ApprovalService;
+use App\Service\NotificationService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ApprovalService のテスト
+ *
+ * 主な確認項目:
+ *   - blockLeaderApprove: STATUS_PENDING(0) のレコードのみ承認可能
+ *   - adminApprove: STATUS_BLOCK_LEADER(1) のレコードのみ承認可能
+ *   - reject: STATUS_PENDING(0) または STATUS_BLOCK_LEADER(1) から差し戻し可能
+ *   - バグ再現: STATUS_PENDING(0) のレコードを adminApprove しても更新されないこと
+ */
+class ApprovalServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.TIndividualReservationInfo',
+        'app.TApprovalLog',
+        'app.MRoomInfo',
+        'app.MUserInfo',
+    ];
+
+    private ApprovalService $service;
+
+    /** @var \Cake\ORM\Table */
+    private $individualTable;
+
+    private array $key1 = [
+        'i_id_user'          => 1,
+        'd_reservation_date' => '2024-09-07',
+        'i_id_room'          => 1,
+        'i_reservation_type' => 1,
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $notificationMock = $this->getMockBuilder(NotificationService::class)
+            ->onlyMethods(['createRejectionNotifications'])
+            ->getMock();
+
+        $this->service = new ApprovalService(null, $notificationMock);
+        $this->individualTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+    }
+
+    private function setStatus(int $status): void
+    {
+        $this->individualTable->updateAll(
+            ['i_approval_status' => $status],
+            $this->key1
+        );
+    }
+
+    private function getStatus(): int
+    {
+        $row = $this->individualTable->find()
+            ->where($this->key1)
+            ->first();
+        return (int)$row->i_approval_status;
+    }
+
+    // ----------------------------------------------------------------
+    // blockLeaderApprove
+    // ----------------------------------------------------------------
+
+    public function testBlockLeaderApprove_succeeds_from_pending(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_PENDING);
+
+        $result = $this->service->blockLeaderApprove([$this->key1], 99, 'tester');
+
+        $this->assertTrue($result);
+        $this->assertSame(ApprovalService::STATUS_BLOCK_LEADER, $this->getStatus());
+    }
+
+    public function testBlockLeaderApprove_fails_when_already_admin_approved(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_ADMIN);
+
+        $result = $this->service->blockLeaderApprove([$this->key1], 99, 'tester');
+
+        $this->assertFalse($result);
+        $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus(), 'ステータスが変更されていないこと');
+    }
+
+    // ----------------------------------------------------------------
+    // adminApprove
+    // ----------------------------------------------------------------
+
+    public function testAdminApprove_succeeds_from_block_leader(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_BLOCK_LEADER);
+
+        $result = $this->service->adminApprove([$this->key1], 99, 'tester');
+
+        $this->assertTrue($result);
+        $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus());
+    }
+
+    /**
+     * バグ再現テスト:
+     * STATUS_PENDING(0) のレコードを adminApprove しても STATUS_ADMIN(2) にならないこと。
+     */
+    public function testAdminApprove_fails_when_status_is_pending(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_PENDING);
+
+        $result = $this->service->adminApprove([$this->key1], 99, 'tester');
+
+        $this->assertFalse($result);
+        $this->assertSame(ApprovalService::STATUS_PENDING, $this->getStatus(), '承認ルートを経由せず承認済みになってはならない');
+    }
+
+    // ----------------------------------------------------------------
+    // reject
+    // ----------------------------------------------------------------
+
+    public function testReject_succeeds_from_pending(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_PENDING);
+
+        $result = $this->service->reject([$this->key1], 99, 'tester', '理由');
+
+        $this->assertTrue($result);
+        $this->assertSame(ApprovalService::STATUS_REJECTED, $this->getStatus());
+    }
+
+    public function testReject_succeeds_from_block_leader(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_BLOCK_LEADER);
+
+        $result = $this->service->reject([$this->key1], 99, 'tester', '理由');
+
+        $this->assertTrue($result);
+        $this->assertSame(ApprovalService::STATUS_REJECTED, $this->getStatus());
+    }
+
+    public function testReject_fails_when_already_admin_approved(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_ADMIN);
+
+        $result = $this->service->reject([$this->key1], 99, 'tester', '理由');
+
+        $this->assertFalse($result);
+        $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus(), '最終承認済みは差し戻せないこと');
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
@@ -151,4 +151,30 @@ class ApprovalServiceTest extends TestCase
         $this->assertFalse($result);
         $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus(), '最終承認済みは差し戻せないこと');
     }
+
+    // ----------------------------------------------------------------
+    // 自己承認防止
+    // ----------------------------------------------------------------
+
+    public function testBlockLeaderApprove_fails_when_self_approval(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_PENDING);
+
+        // approverId = 1（key1.i_id_user と同じ）→ 自己承認
+        $result = $this->service->blockLeaderApprove([$this->key1], 1, 'self');
+
+        $this->assertFalse($result);
+        $this->assertSame(ApprovalService::STATUS_PENDING, $this->getStatus(), '自分の予約をブロック長承認できないこと');
+    }
+
+    public function testAdminApprove_fails_when_self_approval(): void
+    {
+        $this->setStatus(ApprovalService::STATUS_BLOCK_LEADER);
+
+        // approverId = 1（key1.i_id_user と同じ）→ 自己承認
+        $result = $this->service->adminApprove([$this->key1], 1, 'self');
+
+        $this->assertFalse($result);
+        $this->assertSame(ApprovalService::STATUS_BLOCK_LEADER, $this->getStatus(), '自分の予約を管理者承認できないこと');
+    }
 }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
@@ -152,29 +152,4 @@ class ApprovalServiceTest extends TestCase
         $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus(), '最終承認済みは差し戻せないこと');
     }
 
-    // ----------------------------------------------------------------
-    // 自己承認防止
-    // ----------------------------------------------------------------
-
-    public function testBlockLeaderApprove_fails_when_self_approval(): void
-    {
-        $this->setStatus(ApprovalService::STATUS_PENDING);
-
-        // approverId = 1（key1.i_id_user と同じ）→ 自己承認
-        $result = $this->service->blockLeaderApprove([$this->key1], 1, 'self');
-
-        $this->assertFalse($result);
-        $this->assertSame(ApprovalService::STATUS_PENDING, $this->getStatus(), '自分の予約をブロック長承認できないこと');
-    }
-
-    public function testAdminApprove_fails_when_self_approval(): void
-    {
-        $this->setStatus(ApprovalService::STATUS_BLOCK_LEADER);
-
-        // approverId = 1（key1.i_id_user と同じ）→ 自己承認
-        $result = $this->service->adminApprove([$this->key1], 1, 'self');
-
-        $this->assertFalse($result);
-        $this->assertSame(ApprovalService::STATUS_BLOCK_LEADER, $this->getStatus(), '自分の予約を管理者承認できないこと');
-    }
 }

--- a/src_web/kamaho-shokusu/tests/schema.php
+++ b/src_web/kamaho-shokusu/tests/schema.php
@@ -97,6 +97,7 @@ return [
             'i_id_room' => ['type' => 'integer', 'null' => false],
             'eat_flag' => ['type' => 'integer', 'null' => true],
             'i_change_flag' => ['type' => 'integer', 'null' => true],
+            'i_approval_status' => ['type' => 'integer', 'null' => false, 'default' => 0],
             'i_version' => ['type' => 'integer', 'null' => false, 'default' => 1],
             'dt_create' => ['type' => 'datetime', 'null' => true],
             'c_create_user' => ['type' => 'string', 'length' => 50, 'null' => true],
@@ -108,6 +109,22 @@ return [
                 'type' => 'primary',
                 'columns' => ['i_id_user', 'd_reservation_date', 'i_id_room', 'i_reservation_type'],
             ],
+        ],
+    ],
+    't_approval_log' => [
+        'columns' => [
+            'i_id_approval'      => ['type' => 'integer', 'autoIncrement' => true, 'null' => false],
+            'i_id_user'          => ['type' => 'integer', 'null' => false],
+            'd_reservation_date' => ['type' => 'date', 'null' => false],
+            'i_id_room'          => ['type' => 'integer', 'null' => false],
+            'i_reservation_type' => ['type' => 'integer', 'null' => false],
+            'i_approval_status'  => ['type' => 'integer', 'null' => false],
+            'i_approver_id'      => ['type' => 'integer', 'null' => false],
+            'c_reject_reason'    => ['type' => 'string', 'length' => 255, 'null' => true],
+            'dt_create'          => ['type' => 'datetime', 'null' => false],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['i_id_approval']],
         ],
     ],
     't_reservation_info' => [


### PR DESCRIPTION
Closes #144

## 変更内容

### バグ修正

- **承認ルートバイパスの防止** (`ApprovalService.php`)
  - `updateApprovalStatus()` の WHERE 句に `i_approval_status IN` 条件を追加
  - ブロック長承認は STATUS_PENDING(0) からのみ、管理者承認は STATUS_BLOCK_LEADER(1) からのみ実行可能に
  - 差し戻しは STATUS_PENDING(0) または STATUS_BLOCK_LEADER(1) からのみ実行可能に

- **承認一覧の大人フィルターが常に0件になるバグを修正** (`ApprovalService.php`)
  - 整数型カラム `i_id_staff` に対して `!= ''`（空文字列）を比較していたため、CakePHP が値を NULL にキャストし `i_id_staff != NULL` となって全行が除外されていた
  - `getBlockLeaderList` / `getAdminList` / `countBlockLeaderPending` / `countAdminPending` の4箇所を `IS NOT NULL` のみに修正

- **`countBlockLeaderPending` / `countAdminPending` の i_admin 除外フィルター削除** (`ApprovalService.php`)
  - 管理者（i_admin=1）・ブロック長（i_admin=2）の予約が件数カウントから除外されていた古いフィルターを削除

- **管理者の予約も承認フロー対象に変更** (`ApprovalService.php`)
  - ブロック長（i_admin=2）を `getBlockLeaderList` の除外対象から削除
  - 管理者（i_admin=1）を `getAdminList` の除外対象から削除

- **承認画面のデフォルトフィルター修正** (`ApprovalController.php`)
  - ブロック長画面のデフォルトを STATUS_PENDING(0)、管理者画面を STATUS_BLOCK_LEADER(1) に変更

### 画面表示改善

- **申請中ステータスの表示追加** (`my_actual_meal.php`)
  - STATUS_PENDING(0) または STATUS_BLOCK_LEADER(1) かつチェック済みの食事に「申請中」ラベルを表示
  - オレンジ色のスタイル（`.meal-toggle.pending`）と凡例チップを追加
  - JS の `syncToggleStyle` を修正し、`data-status-text` 属性を参照して正しいテキストを表示

### テスト追加

- **`ApprovalServiceTest`** を新規作成
  - ブロック長承認・管理者承認・差し戻しの各ステータス遷移ガードを7ケースで検証
  - STATUS_PENDING → adminApprove が STATUS_ADMIN にならないことを確認するバグ再現テストを含む

- **テスト用フィクスチャ・スキーマ追加**
  - `TApprovalLogFixture.php` 新規作成
  - `tests/schema.php` に `i_approval_status` カラムと `t_approval_log` テーブル定義を追加