### PR TITLE
Resolve #147: 直前編集モーダルのデザイン崩れ修正・UI再設計

### DIFF
--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 直前編集ビュー（ExcelライクUI）
+ * 直前編集ビュー（再設計版）
  */
 
 $selectedRoomId = null;
@@ -21,102 +21,275 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
      data-base="<?= h($basePath) ?>"
      data-date="<?= h($date) ?>"
      data-mealtype="<?= h($mealType) ?>">
+
     <style>
-        /* change_edit モーダル内スタイル（bodyへの適用を避けるため #ce-root にスコープ） */
-        #ce-root { background:#eef2f6; }
-        #ce-root .excel-header { background:#e9edf3; border-radius:10px; padding:10px 12px; }
-        #ce-root .sub-bar { background:#1f2937; color:#fff; padding:8px 14px; border-radius:8px; }
-        #ce-root .meal-count { color:#22c55e; font-weight:700; margin-left:4px; }
-        #ce-root .excel-card { background:#fff; border-radius:12px; border:1px solid #e2e8f0; }
-        #ce-root .excel-table th { font-size:.75rem; color:#8a96a3; text-transform:uppercase; }
-        #ce-root .meal-toggle { display:none; }
-        #ce-root .meal-btn {
-            width:36px; height:28px; border-radius:6px;
-            background:#e5e7eb; display:inline-flex; align-items:center; justify-content:center;
-            color:#1f2937; font-weight:700; cursor:pointer;
+        /* ===== 直前編集モーダル スタイル（#ce-rootスコープ） ===== */
+
+        #ce-root {
+            font-size: .9rem;
         }
-        #ce-root .meal-toggle:checked + .meal-btn { background:#2563eb; color:#fff; }
-        #ce-root .meal-toggle:disabled + .meal-btn { background:#cbd5e1; color:#64748b; cursor:not-allowed; }
+
+        /* 警告ヘッダバナー */
+        #ce-root .ce-warning-banner {
+            background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+            color: #fff;
+            padding: .65rem 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: .75rem;
+            flex-wrap: wrap;
+        }
+        #ce-root .ce-warning-banner .ce-date-label {
+            font-size: 1rem;
+            font-weight: 700;
+            letter-spacing: .02em;
+        }
+        #ce-root .ce-warning-banner .ce-warning-note {
+            font-size: .78rem;
+            opacity: .9;
+            white-space: nowrap;
+        }
+
+        /* 部屋セレクタ + 検索バー */
+        #ce-root .ce-toolbar {
+            background: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+            padding: .5rem .75rem;
+            display: flex;
+            align-items: center;
+            gap: .5rem;
+            flex-wrap: wrap;
+        }
+        #ce-root .ce-toolbar .form-control,
+        #ce-root .ce-toolbar .form-select {
+            font-size: .85rem;
+            height: 2rem;
+            padding-top: .25rem;
+            padding-bottom: .25rem;
+        }
+        #ce-root #ce-name-search { max-width: 180px; }
+        #ce-root .ce-toolbar .form-select { max-width: 160px; }
+
+        /* 食数サマリーバー */
+        #ce-root .ce-summary-bar {
+            background: #fff;
+            border-bottom: 1px solid #e9ecef;
+            padding: .4rem .75rem;
+            display: flex;
+            align-items: center;
+            gap: .5rem 1rem;
+            flex-wrap: wrap;
+            font-size: .82rem;
+        }
+        #ce-root .ce-meal-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: .3rem;
+            padding: .15rem .55rem;
+            border-radius: 999px;
+            font-weight: 600;
+            border: 1px solid transparent;
+        }
+        #ce-root .ce-meal-pill.morning { background: #fff3cd; border-color: #ffc107; color: #664d03; }
+        #ce-root .ce-meal-pill.lunch   { background: #d1e7dd; border-color: #198754; color: #0a3622; }
+        #ce-root .ce-meal-pill.dinner  { background: #cff4fc; border-color: #0dcaf0; color: #055160; }
+        #ce-root .ce-meal-pill.bento   { background: #f8d7da; border-color: #dc3545; color: #58151c; }
+        #ce-root .ce-meal-pill .ce-count { font-size: .9em; }
+
+        /* テーブル */
+        #ce-root .ce-table-wrap {
+            overflow-x: auto;
+            overflow-y: auto;
+        }
+        #ce-root #ce-table {
+            margin-bottom: 0;
+            min-width: 380px;
+        }
+        #ce-root #ce-table thead th {
+            background: #f8f9fa;
+            font-size: .78rem;
+            font-weight: 700;
+            text-align: center;
+            vertical-align: middle;
+            white-space: nowrap;
+            padding: .4rem .3rem;
+            border-bottom: 2px solid #dee2e6;
+            position: sticky;
+            top: 0;
+            z-index: 1;
+        }
+        #ce-root #ce-table thead th:first-child {
+            text-align: left;
+            padding-left: .75rem;
+            min-width: 140px;
+        }
+        /* 列カラー */
+        #ce-root #ce-table thead th.col-morning { color: #856404; border-top: 3px solid #ffc107; }
+        #ce-root #ce-table thead th.col-lunch   { color: #146c43; border-top: 3px solid #198754; }
+        #ce-root #ce-table thead th.col-dinner  { color: #055160; border-top: 3px solid #0dcaf0; }
+        #ce-root #ce-table thead th.col-bento   { color: #842029; border-top: 3px solid #dc3545; }
+
+        #ce-root #ce-table td {
+            text-align: center;
+            vertical-align: middle;
+            padding: .35rem .3rem;
+        }
+        #ce-root #ce-table td:first-child {
+            text-align: left;
+            padding-left: .75rem;
+            font-weight: 500;
+        }
+        #ce-root #ce-table tbody tr:hover { background: #f0f4ff; }
+        #ce-root #ce-table tbody tr.ce-row-hidden { display: none; }
+
+        /* チェックボックス */
+        #ce-root .meal-checkbox,
+        #ce-root #ce-table thead input[type="checkbox"] {
+            width: 1.15rem;
+            height: 1.15rem;
+            cursor: pointer;
+            accent-color: #0d6efd;
+        }
+        #ce-root .meal-checkbox:disabled { cursor: not-allowed; opacity: .45; }
+        #ce-root .meal-checkbox[data-locked="1"] { accent-color: #6c757d; }
+
+        /* 変更あり行ハイライト */
+        #ce-root #ce-table tbody tr.ce-row-changed { background: #fff8e1 !important; }
+
+        /* ロック済みバッジ */
+        #ce-root .ce-locked-label {
+            font-size: .7rem;
+            color: #6c757d;
+            display: block;
+            line-height: 1;
+        }
+
+        /* フッターアクション */
+        #ce-root .ce-footer {
+            background: #f8f9fa;
+            border-top: 1px solid #dee2e6;
+            padding: .6rem .75rem;
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: .5rem;
+        }
+        #ce-root .ce-footer .btn { font-size: .85rem; }
+
+        /* 保存中スピナー */
+        #ce-root #ce-save-spinner { display: none; }
     </style>
 
-    <div class="container py-3">
-        <div class="excel-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
-            <div class="d-flex align-items-center gap-2">
-                <input type="search" class="form-control" placeholder="氏名検索" style="max-width:220px;">
-                <button class="btn btn-outline-primary btn-sm" type="button">月曜日の設定を全曜日にコピー</button>
-            </div>
-            <div class="d-flex align-items-center gap-2">
-                <?php if (!empty($rooms)): ?>
-                    <?php if (count($rooms) > 1): ?>
-                        <?= $this->Form->control('i_id_room', [
-                            'type'      => 'select',
-                            'label'     => false,
-                            'options'   => $rooms,
-                            'empty'     => false,
-                            'value'     => $selectedRoomId,
-                            'class'     => 'form-select',
-                            'required'  => true,
-                            'id'        => 'ce-room-select',
-                            'data-date' => $date,
-                        ]) ?>
-                    <?php else: ?>
-                        <div class="form-control-plaintext"><?= h($selectedRoomName ?: '（部屋未設定）') ?></div>
-                        <?= $this->Form->hidden('i_id_room', ['value'=>$selectedRoomId, 'id'=>'ce-room-hidden']) ?>
-                    <?php endif; ?>
-                <?php else: ?>
-                    <div class="text-muted small">部屋が設定されていません。</div>
-                <?php endif; ?>
-                <button class="btn btn-success btn-sm" type="button" onclick="document.getElementById('change-edit-form').requestSubmit()">確定・保存</button>
-            </div>
+    <!-- 警告バナー -->
+    <div class="ce-warning-banner">
+        <div class="d-flex align-items-center gap-2">
+            <i class="bi bi-exclamation-triangle-fill fs-5"></i>
+            <span class="ce-date-label">直前編集：<?= h($date) ?></span>
         </div>
-
-        <div class="sub-bar mt-2 d-flex align-items-center gap-3 flex-wrap">
-            <span>表示中：<strong><?= h($date) ?></strong></span>
-            <span>朝食：<span class="meal-count">-</span></span>
-            <span>昼食：<span class="meal-count">-</span></span>
-            <span>夕食：<span class="meal-count">-</span></span>
-            <span>弁当：<span class="meal-count">-</span></span>
-        </div>
-
-        <div class="excel-card mt-3 p-3">
-            <?= $this->Form->create(null, ['id'=>'change-edit-form', 'url'=>['action'=>'changeEdit']]) ?>
-            <?= $this->Form->hidden('d_reservation_date', ['value'=>$date, 'id'=>'ce-date-hidden']) ?>
-            <?= $this->Form->hidden('meal_type', ['value'=>$mealType, 'id'=>'ce-mealtype-hidden']) ?>
-            <?php if ($selectedRoomId): ?>
-                <?= $this->Form->hidden('i_id_room', ['value'=>$selectedRoomId, 'id'=>'ce-room-hidden']) ?>
-            <?php endif; ?>
-
-            <div id="ce-table-wrap" class="table-responsive">
-                <table class="table excel-table align-middle" id="ce-table">
-                    <thead>
-                    <tr>
-                        <th>職員氏名 / 所属</th>
-                        <th class="text-center">朝<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除"></th>
-                        <th class="text-center">昼<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除"></th>
-                        <th class="text-center">夜<br><input type="checkbox" id="select-all-3" aria-label="夜 全選択/解除"></th>
-                        <th class="text-center">弁当<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除"></th>
-                    </tr>
-                    </thead>
-                    <tbody id="ce-tbody">
-                    <tr><td colspan="6" class="text-center text-muted">読み込み中...</td></tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <div class="mt-3 d-flex gap-2">
-                <?= $this->Form->button(__('保存'), ['class'=>'btn btn-primary']) ?>
-            </div>
-            <?= $this->Form->end() ?>
-        </div>
+        <span class="ce-warning-note">
+            <i class="bi bi-info-circle me-1"></i>この日はすでに発注済みです。変更内容をよく確認してください。
+        </span>
     </div>
-</div>
 
-<?php
-// 既存の JS を利用するためのスクリプトは元のまま動作します
-?>
-<script>
-    (function(){
-        // 既存 change_edit.php のJSロジックをそのまま動かすために、
-        // 必要なDOMは保持しています。
-    })();
-</script>
+    <!-- ツールバー（部屋選択・検索） -->
+    <div class="ce-toolbar">
+        <i class="bi bi-search text-muted" aria-hidden="true"></i>
+        <input type="search" id="ce-name-search" class="form-control" placeholder="氏名で絞り込み" autocomplete="off">
+
+        <?php if (!empty($rooms) && count($rooms) > 1): ?>
+            <i class="bi bi-door-open text-muted ms-1" aria-hidden="true"></i>
+            <?= $this->Form->control('i_id_room', [
+                'type'      => 'select',
+                'label'     => false,
+                'options'   => $rooms,
+                'empty'     => false,
+                'value'     => $selectedRoomId,
+                'class'     => 'form-select',
+                'required'  => true,
+                'id'        => 'ce-room-select',
+                'data-date' => $date,
+            ]) ?>
+        <?php elseif ($selectedRoomId): ?>
+            <span class="text-muted small ms-1">
+                <i class="bi bi-door-open me-1"></i><?= h($selectedRoomName ?: '（部屋未設定）') ?>
+            </span>
+        <?php endif; ?>
+    </div>
+
+    <!-- 食数サマリー -->
+    <div class="ce-summary-bar">
+        <span class="text-muted fw-semibold me-1">食数：</span>
+        <span class="ce-meal-pill morning">
+            <i class="bi bi-brightness-high-fill"></i>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名
+        </span>
+        <span class="ce-meal-pill lunch">
+            <i class="bi bi-sun-fill"></i>昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名
+        </span>
+        <span class="ce-meal-pill dinner">
+            <i class="bi bi-moon-fill"></i>夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名
+        </span>
+        <span class="ce-meal-pill bento">
+            <i class="bi bi-box-seam-fill"></i>弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名
+        </span>
+    </div>
+
+    <!-- フォーム＋テーブル -->
+    <?= $this->Form->create(null, ['id' => 'change-edit-form', 'url' => ['action' => 'changeEdit']]) ?>
+    <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
+    <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
+    <?php if ($selectedRoomId): ?>
+        <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
+    <?php endif; ?>
+
+    <div class="ce-table-wrap">
+        <table class="table table-sm table-bordered" id="ce-table">
+            <thead>
+                <tr>
+                    <th class="text-start">
+                        氏名
+                    </th>
+                    <th class="col-morning">
+                        <i class="bi bi-brightness-high-fill d-block mb-1"></i>朝<br>
+                        <input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除">
+                    </th>
+                    <th class="col-lunch">
+                        <i class="bi bi-sun-fill d-block mb-1"></i>昼<br>
+                        <input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除">
+                    </th>
+                    <th class="col-dinner">
+                        <i class="bi bi-moon-fill d-block mb-1"></i>夕<br>
+                        <input type="checkbox" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除">
+                    </th>
+                    <th class="col-bento">
+                        <i class="bi bi-box-seam-fill d-block mb-1"></i>弁当<br>
+                        <input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除">
+                    </th>
+                </tr>
+            </thead>
+            <tbody id="ce-tbody">
+                <tr>
+                    <td colspan="5" class="text-center py-4 text-muted">
+                        <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <!-- フッター -->
+    <div class="ce-footer">
+        <span id="ce-change-count" class="text-muted small me-auto"></span>
+        <span id="ce-save-spinner" class="text-muted small">
+            <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>保存中...
+        </span>
+        <?= $this->Form->button('<i class="bi bi-floppy-fill me-1"></i>変更を保存', [
+            'type'   => 'submit',
+            'class'  => 'btn btn-primary btn-sm',
+            'id'     => 'ce-save-btn',
+            'escape' => false,
+        ]) ?>
+    </div>
+    <?= $this->Form->end() ?>
+
+</div>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -22,20 +22,21 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
      data-date="<?= h($date) ?>"
      data-mealtype="<?= h($mealType) ?>">
     <style>
-        body { background:#eef2f6; }
-        .excel-header { background:#e9edf3; border-radius:10px; padding:10px 12px; }
-        .sub-bar { background:#1f2937; color:#fff; padding:8px 14px; border-radius:8px; }
-        .meal-count { color:#22c55e; font-weight:700; margin-left:4px; }
-        .excel-card { background:#fff; border-radius:12px; border:1px solid #e2e8f0; }
-        .excel-table th { font-size:.75rem; color:#8a96a3; text-transform:uppercase; }
-        .meal-toggle { display:none; }
-        .meal-btn {
+        /* change_edit モーダル内スタイル（bodyへの適用を避けるため #ce-root にスコープ） */
+        #ce-root { background:#eef2f6; }
+        #ce-root .excel-header { background:#e9edf3; border-radius:10px; padding:10px 12px; }
+        #ce-root .sub-bar { background:#1f2937; color:#fff; padding:8px 14px; border-radius:8px; }
+        #ce-root .meal-count { color:#22c55e; font-weight:700; margin-left:4px; }
+        #ce-root .excel-card { background:#fff; border-radius:12px; border:1px solid #e2e8f0; }
+        #ce-root .excel-table th { font-size:.75rem; color:#8a96a3; text-transform:uppercase; }
+        #ce-root .meal-toggle { display:none; }
+        #ce-root .meal-btn {
             width:36px; height:28px; border-radius:6px;
             background:#e5e7eb; display:inline-flex; align-items:center; justify-content:center;
             color:#1f2937; font-weight:700; cursor:pointer;
         }
-        .meal-toggle:checked + .meal-btn { background:#2563eb; color:#fff; }
-        .meal-toggle:disabled + .meal-btn { background:#cbd5e1; color:#64748b; cursor:not-allowed; }
+        #ce-root .meal-toggle:checked + .meal-btn { background:#2563eb; color:#fff; }
+        #ce-root .meal-toggle:disabled + .meal-btn { background:#cbd5e1; color:#64748b; cursor:not-allowed; }
     </style>
 
     <div class="container py-3">
@@ -89,12 +90,11 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
                 <table class="table excel-table align-middle" id="ce-table">
                     <thead>
                     <tr>
-                        <th style="width:60px;">ID</th>
                         <th>職員氏名 / 所属</th>
-                        <th class="text-center">MORNING<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除"></th>
-                        <th class="text-center">LUNCH<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除"></th>
-                        <th class="text-center">DINNER<br><input type="checkbox" id="select-all-3" aria-label="夜 全選択/解除"></th>
-                        <th class="text-center">BENTO<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除"></th>
+                        <th class="text-center">朝<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除"></th>
+                        <th class="text-center">昼<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除"></th>
+                        <th class="text-center">夜<br><input type="checkbox" id="select-all-3" aria-label="夜 全選択/解除"></th>
+                        <th class="text-center">弁当<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除"></th>
                     </tr>
                     </thead>
                     <tbody id="ce-tbody">

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 直前編集ビュー（再設計版）
+ * 直前編集ビュー
  */
 
 $selectedRoomId = null;
@@ -23,39 +23,35 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
      data-mealtype="<?= h($mealType) ?>">
 
     <style>
-        /* ===== 直前編集モーダル スタイル（#ce-rootスコープ） ===== */
+        /* ===== 直前編集モーダル（#ce-rootスコープ） ===== */
+        #ce-root { font-size: .88rem; }
 
-        #ce-root {
-            font-size: .9rem;
-        }
-
-        /* 警告ヘッダバナー */
+        /* 警告ヘッダ */
         #ce-root .ce-warning-banner {
-            background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
-            color: #fff;
-            padding: .65rem 1rem;
+            background: #fff3cd;
+            border-bottom: 1px solid #ffc107;
+            padding: .5rem .85rem;
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: .75rem;
+            gap: .5rem;
             flex-wrap: wrap;
+            color: #664d03;
         }
         #ce-root .ce-warning-banner .ce-date-label {
-            font-size: 1rem;
             font-weight: 700;
-            letter-spacing: .02em;
+            font-size: .92rem;
         }
         #ce-root .ce-warning-banner .ce-warning-note {
             font-size: .78rem;
-            opacity: .9;
-            white-space: nowrap;
+            color: #856404;
         }
 
-        /* 部屋セレクタ + 検索バー */
+        /* ツールバー */
         #ce-root .ce-toolbar {
             background: #f8f9fa;
             border-bottom: 1px solid #dee2e6;
-            padding: .5rem .75rem;
+            padding: .4rem .75rem;
             display: flex;
             align-items: center;
             gap: .5rem;
@@ -63,142 +59,103 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
         }
         #ce-root .ce-toolbar .form-control,
         #ce-root .ce-toolbar .form-select {
-            font-size: .85rem;
-            height: 2rem;
-            padding-top: .25rem;
-            padding-bottom: .25rem;
+            font-size: .83rem;
+            height: 1.9rem;
+            padding-top: .2rem;
+            padding-bottom: .2rem;
         }
-        #ce-root #ce-name-search { max-width: 180px; }
-        #ce-root .ce-toolbar .form-select { max-width: 160px; }
+        #ce-root #ce-name-search { max-width: 170px; }
+        #ce-root .ce-toolbar .form-select { max-width: 150px; }
 
         /* 食数サマリーバー */
         #ce-root .ce-summary-bar {
             background: #fff;
             border-bottom: 1px solid #e9ecef;
-            padding: .4rem .75rem;
+            padding: .35rem .75rem;
             display: flex;
             align-items: center;
-            gap: .5rem 1rem;
+            gap: .4rem 1rem;
             flex-wrap: wrap;
-            font-size: .82rem;
+            font-size: .8rem;
+            color: #495057;
         }
-        #ce-root .ce-meal-pill {
-            display: inline-flex;
-            align-items: center;
-            gap: .3rem;
-            padding: .15rem .55rem;
-            border-radius: 999px;
-            font-weight: 600;
-            border: 1px solid transparent;
-        }
-        #ce-root .ce-meal-pill.morning { background: #fff3cd; border-color: #ffc107; color: #664d03; }
-        #ce-root .ce-meal-pill.lunch   { background: #d1e7dd; border-color: #198754; color: #0a3622; }
-        #ce-root .ce-meal-pill.dinner  { background: #cff4fc; border-color: #0dcaf0; color: #055160; }
-        #ce-root .ce-meal-pill.bento   { background: #f8d7da; border-color: #dc3545; color: #58151c; }
-        #ce-root .ce-meal-pill .ce-count { font-size: .9em; }
+        #ce-root .ce-summary-bar .ce-sum-label { font-weight: 600; }
+        #ce-root .ce-summary-bar .ce-count { font-weight: 700; color: #0d6efd; }
 
         /* テーブル */
-        #ce-root .ce-table-wrap {
-            overflow-x: auto;
-            overflow-y: auto;
-        }
-        #ce-root #ce-table {
-            margin-bottom: 0;
-            min-width: 380px;
-        }
+        #ce-root .ce-table-wrap { overflow-x: auto; overflow-y: auto; }
+        #ce-root #ce-table { margin-bottom: 0; min-width: 360px; }
+
         #ce-root #ce-table thead th {
-            background: #f8f9fa;
+            background: #f1f3f5;
             font-size: .78rem;
-            font-weight: 700;
+            font-weight: 600;
             text-align: center;
             vertical-align: middle;
             white-space: nowrap;
-            padding: .4rem .3rem;
+            padding: .4rem .4rem;
             border-bottom: 2px solid #dee2e6;
             position: sticky;
             top: 0;
             z-index: 1;
+            color: #495057;
         }
         #ce-root #ce-table thead th:first-child {
             text-align: left;
             padding-left: .75rem;
             min-width: 140px;
         }
-        /* 列カラー */
-        #ce-root #ce-table thead th.col-morning { color: #856404; border-top: 3px solid #ffc107; }
-        #ce-root #ce-table thead th.col-lunch   { color: #146c43; border-top: 3px solid #198754; }
-        #ce-root #ce-table thead th.col-dinner  { color: #055160; border-top: 3px solid #0dcaf0; }
-        #ce-root #ce-table thead th.col-bento   { color: #842029; border-top: 3px solid #dc3545; }
 
         #ce-root #ce-table td {
             text-align: center;
             vertical-align: middle;
-            padding: .35rem .3rem;
+            padding: .3rem .4rem;
         }
         #ce-root #ce-table td:first-child {
             text-align: left;
             padding-left: .75rem;
-            font-weight: 500;
         }
-        #ce-root #ce-table tbody tr:hover { background: #f0f4ff; }
+        #ce-root #ce-table tbody tr:hover { background: #f8f9fa; }
         #ce-root #ce-table tbody tr.ce-row-hidden { display: none; }
+        #ce-root #ce-table tbody tr.ce-row-changed { background: #e8f4e8 !important; }
 
         /* チェックボックス */
         #ce-root .meal-checkbox,
         #ce-root #ce-table thead input[type="checkbox"] {
-            width: 1.15rem;
-            height: 1.15rem;
+            width: 1.1rem;
+            height: 1.1rem;
             cursor: pointer;
-            accent-color: #0d6efd;
         }
-        #ce-root .meal-checkbox:disabled { cursor: not-allowed; opacity: .45; }
-        #ce-root .meal-checkbox[data-locked="1"] { accent-color: #6c757d; }
+        #ce-root .meal-checkbox:disabled { cursor: not-allowed; opacity: .4; }
 
-        /* 変更あり行ハイライト */
-        #ce-root #ce-table tbody tr.ce-row-changed { background: #fff8e1 !important; }
-
-        /* ロック済みバッジ */
-        #ce-root .ce-locked-label {
-            font-size: .7rem;
-            color: #6c757d;
-            display: block;
-            line-height: 1;
-        }
-
-        /* フッターアクション */
+        /* フッター */
         #ce-root .ce-footer {
             background: #f8f9fa;
             border-top: 1px solid #dee2e6;
-            padding: .6rem .75rem;
+            padding: .5rem .75rem;
             display: flex;
             align-items: center;
             justify-content: flex-end;
             gap: .5rem;
         }
-        #ce-root .ce-footer .btn { font-size: .85rem; }
-
-        /* 保存中スピナー */
+        #ce-root .ce-footer .btn { font-size: .83rem; }
         #ce-root #ce-save-spinner { display: none; }
+        #ce-root #ce-change-count { font-size: .78rem; color: #6c757d; }
     </style>
 
-    <!-- 警告バナー -->
+    <!-- 警告ヘッダ -->
     <div class="ce-warning-banner">
-        <div class="d-flex align-items-center gap-2">
-            <i class="bi bi-exclamation-triangle-fill fs-5"></i>
-            <span class="ce-date-label">直前編集：<?= h($date) ?></span>
-        </div>
-        <span class="ce-warning-note">
-            <i class="bi bi-info-circle me-1"></i>この日はすでに発注済みです。変更内容をよく確認してください。
+        <span class="ce-date-label">
+            &#9888; 直前編集：<?= h($date) ?>
         </span>
+        <span class="ce-warning-note">発注済みです。変更内容をよく確認してください。</span>
     </div>
 
-    <!-- ツールバー（部屋選択・検索） -->
+    <!-- ツールバー -->
     <div class="ce-toolbar">
-        <i class="bi bi-search text-muted" aria-hidden="true"></i>
         <input type="search" id="ce-name-search" class="form-control" placeholder="氏名で絞り込み" autocomplete="off">
 
         <?php if (!empty($rooms) && count($rooms) > 1): ?>
-            <i class="bi bi-door-open text-muted ms-1" aria-hidden="true"></i>
             <?= $this->Form->control('i_id_room', [
                 'type'      => 'select',
                 'label'     => false,
@@ -211,27 +168,17 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
                 'data-date' => $date,
             ]) ?>
         <?php elseif ($selectedRoomId): ?>
-            <span class="text-muted small ms-1">
-                <i class="bi bi-door-open me-1"></i><?= h($selectedRoomName ?: '（部屋未設定）') ?>
-            </span>
+            <span class="text-muted small"><?= h($selectedRoomName ?: '（部屋未設定）') ?></span>
         <?php endif; ?>
     </div>
 
     <!-- 食数サマリー -->
     <div class="ce-summary-bar">
-        <span class="text-muted fw-semibold me-1">食数：</span>
-        <span class="ce-meal-pill morning">
-            <i class="bi bi-brightness-high-fill"></i>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名
-        </span>
-        <span class="ce-meal-pill lunch">
-            <i class="bi bi-sun-fill"></i>昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名
-        </span>
-        <span class="ce-meal-pill dinner">
-            <i class="bi bi-moon-fill"></i>夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名
-        </span>
-        <span class="ce-meal-pill bento">
-            <i class="bi bi-box-seam-fill"></i>弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名
-        </span>
+        <span class="ce-sum-label">食数：</span>
+        <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
+        <span>昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
+        <span>夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名</span>
+        <span>弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
     </div>
 
     <!-- フォーム＋テーブル -->
@@ -246,25 +193,11 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
         <table class="table table-sm table-bordered" id="ce-table">
             <thead>
                 <tr>
-                    <th class="text-start">
-                        氏名
-                    </th>
-                    <th class="col-morning">
-                        <i class="bi bi-brightness-high-fill d-block mb-1"></i>朝<br>
-                        <input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除">
-                    </th>
-                    <th class="col-lunch">
-                        <i class="bi bi-sun-fill d-block mb-1"></i>昼<br>
-                        <input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除">
-                    </th>
-                    <th class="col-dinner">
-                        <i class="bi bi-moon-fill d-block mb-1"></i>夕<br>
-                        <input type="checkbox" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除">
-                    </th>
-                    <th class="col-bento">
-                        <i class="bi bi-box-seam-fill d-block mb-1"></i>弁当<br>
-                        <input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除">
-                    </th>
+                    <th class="text-start">氏名</th>
+                    <th>朝<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
+                    <th>昼<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
+                    <th>夕<br><input type="checkbox" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
+                    <th>弁当<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
                 </tr>
             </thead>
             <tbody id="ce-tbody">
@@ -279,16 +212,11 @@ $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('me
 
     <!-- フッター -->
     <div class="ce-footer">
-        <span id="ce-change-count" class="text-muted small me-auto"></span>
+        <span id="ce-change-count" class="me-auto"></span>
         <span id="ce-save-spinner" class="text-muted small">
             <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>保存中...
         </span>
-        <?= $this->Form->button('<i class="bi bi-floppy-fill me-1"></i>変更を保存', [
-            'type'   => 'submit',
-            'class'  => 'btn btn-primary btn-sm',
-            'id'     => 'ce-save-btn',
-            'escape' => false,
-        ]) ?>
+        <button type="submit" class="btn btn-primary btn-sm" id="ce-save-btn">変更を保存</button>
     </div>
     <?= $this->Form->end() ?>
 

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/modals.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/modals.php
@@ -32,26 +32,37 @@ $pastDateUnavailableMessage = (string)Configure::read(
 </div>
 
 <div class="modal fade modal-warning" id="lateNoticeModal" tabindex="-1" aria-labelledby="lateNoticeTitle" aria-hidden="true" role="alertdialog" aria-modal="true">
-    <div class="modal-dialog modal-dialog-centered"><div class="modal-content">
+    <div class="modal-dialog modal-dialog-centered modal-sm-fullwidth">
+        <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="lateNoticeTitle"><i class="bi bi-exclamation-triangle-fill"></i>警告：直前の変更・追加</h5>
+                <h5 class="modal-title" id="lateNoticeTitle">
+                    <i class="bi bi-exclamation-triangle-fill"></i>警告：直前の変更・追加
+                </h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="とじる"></button>
             </div>
-            <div class="modal-body">
-                <div id="lateNoticeBody" class="alert alert-danger mb-3"></div>
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="lateAgreeCheck" aria-describedby="lateAgreeHelp">
-                    <label class="form-check-label" for="lateAgreeCheck">
-                        <strong>発注済みであること</strong>を理解しました（内容をよく確認します）
-                    </label>
-                    <div id="lateAgreeHelp" class="form-text">チェックすると「同意して進む」ボタンが有効になります。</div>
+            <div class="modal-body p-0">
+                <div id="lateNoticeBody" class="late-notice-info px-3 pt-3 pb-2"></div>
+                <hr class="my-0">
+                <div class="late-notice-agree px-3 py-3">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="lateAgreeCheck" aria-describedby="lateAgreeHelp">
+                        <label class="form-check-label fw-semibold" for="lateAgreeCheck">
+                            発注済みであることを理解しました（内容をよく確認します）
+                        </label>
+                        <div id="lateAgreeHelp" class="form-text mt-1">チェックすると「同意して進む」ボタンが有効になります。</div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
-                <a id="lateProceed" href="#" class="btn btn-primary disabled" aria-disabled="true" tabindex="-1" role="button">同意して進む</a>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">同意しない（戻る）</button>
+                <a id="lateProceed" href="#" class="btn btn-danger disabled" aria-disabled="true" tabindex="-1" role="button">
+                    <i class="bi bi-check-lg me-1"></i>同意して進む
+                </a>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                    <i class="bi bi-x-lg me-1"></i>戻る
+                </button>
             </div>
-        </div></div>
+        </div>
+    </div>
 </div>
 
 <div class="modal fade" id="mealCalUserModal" tabindex="-1" aria-labelledby="mealCalUserModalLabel" aria-hidden="true">

--- a/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
@@ -85,10 +85,25 @@
             color:#fff;
         }
         .modal-warning .modal-title i { margin-right:.4rem; }
-        .modal-warning .modal-body .alert { margin-bottom:0; }
-        .modal-warning .btn-primary { background:#dc3545; border-color:#dc3545; }
-        .modal-warning .btn-primary:disabled,
-        .modal-warning .btn-primary.disabled { background:#dc3545; border-color:#dc3545; opacity:.65; }
+
+        /* 直前編集モーダル：情報エリア */
+        .late-notice-info { background:#fff8f8; }
+        .late-notice-alert { font-size:.92rem; }
+        .late-notice-detail { font-size:.92rem; }
+        .late-notice-detail dt { padding:.2rem 0; }
+        .late-notice-detail dd { padding:.2rem 0; }
+
+        /* 直前編集モーダル：同意エリア */
+        .late-notice-agree { background:#fff; }
+        .late-notice-agree .form-text { color:#6c757d; font-size:.82rem; }
+
+        /* ネストモーダル（quickDayModal内から開く場合）のz-index対応 */
+        #lateNoticeModal { z-index: 1065; }
+        #lateNoticeModal + .modal-backdrop { z-index: 1060; }
+
+        .modal-warning .btn-danger { background:#dc3545; border-color:#dc3545; }
+        .modal-warning .btn-danger:disabled,
+        .modal-warning .btn-danger.disabled { background:#dc3545; border-color:#dc3545; opacity:.65; }
 
         /* モード切替の見出し行（子画面） */
         .mode-bar {

--- a/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
+++ b/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
@@ -72,19 +72,44 @@
             for (var t = 1; t <= 4; t++){
                 var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
                 if (!cb) continue;
-                var isChecked  = cb.checked;
-                var wasChecked = cb.getAttribute('data-initial-checked') === '1';
-                if (isChecked !== wasChecked) { hasChange = true; break; }
+                if (cb.checked !== (cb.getAttribute('data-initial-checked') === '1')) { hasChange = true; break; }
             }
-            if (hasChange){
-                changed++;
-                tr.classList.add('ce-row-changed');
-            } else {
-                tr.classList.remove('ce-row-changed');
-            }
+            if (hasChange){ changed++; tr.classList.add('ce-row-changed'); }
+            else { tr.classList.remove('ce-row-changed'); }
         });
         var el = container.querySelector('#ce-change-count');
         if (el) el.textContent = changed > 0 ? changed + '件の変更があります' : '';
+    }
+
+    // ---- ヘッダーチェックボックスの状態を行の状態から再計算（indeterminate対応）
+    function updateHeaderStates(container){
+        for (var t = 1; t <= 4; t++){
+            var header = container.querySelector('#select-all-' + t);
+            if (!header) continue;
+            // disabled / locked でないチェックボックスのみ対象
+            var allCbs = Array.prototype.slice.call(
+                container.querySelectorAll(
+                    '#ce-tbody tr[data-user-id] input.meal-checkbox[data-reservation-type="' + t + '"]'
+                )
+            ).filter(function(cb){ return !cb.disabled && cb.dataset.locked !== '1'; });
+
+            if (allCbs.length === 0){ header.checked = false; header.indeterminate = false; continue; }
+            var checkedCount = allCbs.filter(function(cb){ return cb.checked; }).length;
+            if (checkedCount === 0){
+                header.checked = false; header.indeterminate = false;
+            } else if (checkedCount === allCbs.length){
+                header.checked = true; header.indeterminate = false;
+            } else {
+                header.checked = false; header.indeterminate = true;
+            }
+        }
+    }
+
+    // ---- まとめてUI更新
+    function updateAll(container){
+        updateSummary(container);
+        updateChangeCount(container);
+        updateHeaderStates(container);
     }
 
     // ---- 行 HTML 生成
@@ -125,51 +150,41 @@
     }
 
     // ---- 列一括切替（昼食⇔弁当排他制御）
+    // イベントは発火せず直接値を書き換え、最後に updateAll で一括更新する
     function toggleColumn(container, reservationType, checked){
         var tbody = container.querySelector('#ce-tbody');
         if (!tbody) return;
-        tbody.querySelectorAll('input.meal-checkbox[data-reservation-type="' + reservationType + '"]').forEach(function(cb){
-            if (cb.disabled || cb.dataset.locked === '1') return;
+        tbody.querySelectorAll('tr[data-user-id]').forEach(function(tr){
+            var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + reservationType + '"]');
+            if (!cb || cb.disabled || cb.dataset.locked === '1') return;
             cb.checked = !!checked;
-            var tr = cb.closest('tr');
-            if (!tr) return;
+            // 昼(2)をONにしたら弁当(4)をOFF
             if (reservationType === 2 && checked){
                 var bento = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');
-                if (bento && !bento.disabled && bento.dataset.locked !== '1') { bento.checked = false; bento.dispatchEvent(new Event('change')); }
+                if (bento && !bento.disabled && bento.dataset.locked !== '1') bento.checked = false;
             }
+            // 弁当(4)をONにしたら昼(2)をOFF
             if (reservationType === 4 && checked){
                 var lunch = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
-                if (lunch && !lunch.disabled && lunch.dataset.locked !== '1') { lunch.checked = false; lunch.dispatchEvent(new Event('change')); }
+                if (lunch && !lunch.disabled && lunch.dataset.locked !== '1') lunch.checked = false;
             }
-            cb.dispatchEvent(new Event('change'));
         });
+        updateAll(container);
     }
 
     // ---- ヘッダー全選択チェックボックスのバインド
     function bindHeaderChecks(container){
-        ['select-all-1','select-all-2','select-all-3','select-all-4'].forEach(function(id){
-            var h = container.querySelector('#' + id);
+        [1, 2, 3, 4].forEach(function(t){
+            var h = container.querySelector('#select-all-' + t);
             if (!h) return;
+            // 既存のリスナーをリセット（cloneで置き換え）
             var clone = h.cloneNode(true);
             h.parentNode.replaceChild(clone, h);
-        });
-        var h1 = container.querySelector('#select-all-1');
-        if (h1) h1.addEventListener('change', function(e){ toggleColumn(container, 1, !!e.target.checked); updateSummary(container); updateChangeCount(container); });
-        var h2 = container.querySelector('#select-all-2');
-        if (h2) h2.addEventListener('change', function(e){
-            toggleColumn(container, 2, !!e.target.checked);
-            var h4 = container.querySelector('#select-all-4');
-            if (e.target.checked && h4) h4.checked = false;
-            updateSummary(container); updateChangeCount(container);
-        });
-        var h3 = container.querySelector('#select-all-3');
-        if (h3) h3.addEventListener('change', function(e){ toggleColumn(container, 3, !!e.target.checked); updateSummary(container); updateChangeCount(container); });
-        var h4 = container.querySelector('#select-all-4');
-        if (h4) h4.addEventListener('change', function(e){
-            toggleColumn(container, 4, !!e.target.checked);
-            var h2b = container.querySelector('#select-all-2');
-            if (e.target.checked && h2b) h2b.checked = false;
-            updateSummary(container); updateChangeCount(container);
+            clone.addEventListener('change', function(e){
+                // indeterminate状態でクリックするとchecked=trueになるのでそのまま利用
+                toggleColumn(container, t, !!e.target.checked);
+                // toggleColumn内でupdateAll済み（ヘッダー状態も含む）
+            });
         });
     }
 
@@ -253,36 +268,37 @@
             // UIガード
             installUncheckGuards(tbody);
 
-            // 行レベルの昼食⇔弁当排他制御
+            // 行レベルのchangeイベント（排他制御 + UI一括更新）
             tbody.querySelectorAll('tr[data-user-id]').forEach(function(tr){
                 var lunchCb = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
                 var bentoCb = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');
-                if (lunchCb && bentoCb){
-                    lunchCb.addEventListener('change', function(){
-                        if (lunchCb.checked && !lunchCb.disabled && lunchCb.dataset.locked !== '1'){
-                            if (!bentoCb.disabled && bentoCb.dataset.locked !== '1') bentoCb.checked = false;
-                        }
-                        updateSummary(container); updateChangeCount(container);
-                    });
-                    bentoCb.addEventListener('change', function(){
-                        if (bentoCb.checked && !bentoCb.disabled && bentoCb.dataset.locked !== '1'){
-                            if (!lunchCb.disabled && lunchCb.dataset.locked !== '1') lunchCb.checked = false;
-                        }
-                        updateSummary(container); updateChangeCount(container);
-                    });
-                } else {
-                    // 朝・夕のchange→サマリー更新
-                    [1, 3].forEach(function(t){
-                        var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
-                        if (cb) cb.addEventListener('change', function(){ updateSummary(container); updateChangeCount(container); });
-                    });
-                }
+
+                // 朝・夕：変更があればUI更新のみ
+                [1, 3].forEach(function(t){
+                    var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
+                    if (cb) cb.addEventListener('change', function(){ updateAll(container); });
+                });
+
+                // 昼：ONにしたら弁当をOFF
+                if (lunchCb) lunchCb.addEventListener('change', function(){
+                    if (lunchCb.checked && !lunchCb.disabled && lunchCb.dataset.locked !== '1'){
+                        if (bentoCb && !bentoCb.disabled && bentoCb.dataset.locked !== '1') bentoCb.checked = false;
+                    }
+                    updateAll(container);
+                });
+
+                // 弁当：ONにしたら昼をOFF
+                if (bentoCb) bentoCb.addEventListener('change', function(){
+                    if (bentoCb.checked && !bentoCb.disabled && bentoCb.dataset.locked !== '1'){
+                        if (lunchCb && !lunchCb.disabled && lunchCb.dataset.locked !== '1') lunchCb.checked = false;
+                    }
+                    updateAll(container);
+                });
             });
 
             bindHeaderChecks(container);
             bindNameSearch(container);
-            updateSummary(container);
-            updateChangeCount(container);
+            updateAll(container);
 
             // フォーム送信
             var csrfMeta  = document.querySelector('meta[name="csrfToken"]');

--- a/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
+++ b/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
@@ -6,188 +6,201 @@
         return s.replace(/[&<>"']/g, function(m){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]; });
     }
 
-    // ---- ユーザー判定:isStaffプロパティを優先
+    // ---- ユーザー判定
     function isStaffUser(u){
-        if (u && typeof u.isStaff === 'boolean') {
-            return u.isStaff;
-        }
-        // フォールバック
+        if (u && typeof u.isStaff === 'boolean') return u.isStaff;
         return Number((u && (u.i_user_level != null ? u.i_user_level : u.userLevel))) === 0;
     }
 
-    // ---- mealType の取得（複数フォールバック）
+    // ---- mealType 取得
     function resolveMealType(container){
         var hidden = container.querySelector('#ce-mealtype-hidden');
         if (hidden && hidden.value) return String(hidden.value);
-
         var root = container.querySelector('#ce-root') || container;
         var dt = root && root.getAttribute('data-mealtype');
         if (dt) return String(dt);
-
-        if (window.mealEditParams && window.mealEditParams.mealType != null) {
-            return String(window.mealEditParams.mealType);
-        }
-
+        if (window.mealEditParams && window.mealEditParams.mealType != null) return String(window.mealEditParams.mealType);
         try {
-            var usp = new URLSearchParams(location.search);
-            var q = usp.get('mealType');
-            if (q != null && q !== '') return String(q);
-        } catch(_e){/* nop */}
-
-        return ''; // 未取得
+            var q = new URLSearchParams(location.search).get('mealType');
+            if (q) return String(q);
+        } catch(_e){}
+        return '';
     }
 
     // ---- API URL
-    //   TReservationInfo/change-edit/{roomId}/{date}/{mealType}
     function apiUrl(base, roomId, dateStr, mealType){
-        // 1) __BASE_PATH を最優先で利用（例: "/kamaho-shokusu"）
-        var rootBase = (typeof window.__BASE_PATH === 'string' && window.__BASE_PATH)
-            ? window.__BASE_PATH
-            : (base || '/');
-
-        // 2) 末尾スラッシュ調整
-        if (rootBase.slice(-1) !== '/') {
-            rootBase += '/';
-        }
-
-        // 3) 既存ルートに合わせて CamelCase + "change-edit" のままにする
-        return rootBase
-            + 'TReservationInfo/change-edit/'
-            + encodeURIComponent(roomId) + '/'
-            + encodeURIComponent(dateStr) + '/'
-            + encodeURIComponent(mealType);
+        var rootBase = (typeof window.__BASE_PATH === 'string' && window.__BASE_PATH) ? window.__BASE_PATH : (base || '/');
+        if (rootBase.slice(-1) !== '/') rootBase += '/';
+        return rootBase + 'TReservationInfo/change-edit/' + encodeURIComponent(roomId) + '/' + encodeURIComponent(dateStr) + '/' + encodeURIComponent(mealType);
     }
 
+    // ---- ローディング表示
     function showLoading(tbody){
         tbody.innerHTML =
-            '<tr>' +
-            '  <td colspan="5" class="text-center">' +
-            '    <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>' +
-            '    <span class="ms-2">読み込み中...</span>' +
-            '  </td>' +
-            '</tr>';
-    }
-    function showMsg(tbody, msg, isError){
-        tbody.innerHTML = '<tr><td colspan="5" class="text-center ' + (isError?'text-danger':'text-muted') + '">' + esc(msg) + '</td></tr>';
+            '<tr><td colspan="5" class="text-center py-4 text-muted">' +
+            '<div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...' +
+            '</td></tr>';
     }
 
-    // ---- 行HTML
+    function showMsg(tbody, msg, isError){
+        tbody.innerHTML =
+            '<tr><td colspan="5" class="text-center py-3 ' + (isError ? 'text-danger' : 'text-muted') + '">' +
+            (isError ? '<i class="bi bi-exclamation-circle me-1"></i>' : '') + esc(msg) +
+            '</td></tr>';
+    }
+
+    // ---- 食数サマリー更新
+    function updateSummary(container){
+        var counts = {1: 0, 2: 0, 3: 0, 4: 0};
+        container.querySelectorAll('#ce-tbody tr[data-user-id]').forEach(function(tr){
+            for (var t = 1; t <= 4; t++){
+                var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
+                if (cb && cb.checked) counts[t]++;
+            }
+        });
+        for (var t = 1; t <= 4; t++){
+            var el = container.querySelector('[data-meal-summary="' + t + '"]');
+            if (el) el.textContent = counts[t];
+        }
+    }
+
+    // ---- 変更件数カウンター更新
+    function updateChangeCount(container){
+        var changed = 0;
+        container.querySelectorAll('#ce-tbody tr[data-user-id]').forEach(function(tr){
+            var hasChange = false;
+            for (var t = 1; t <= 4; t++){
+                var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
+                if (!cb) continue;
+                var isChecked  = cb.checked;
+                var wasChecked = cb.getAttribute('data-initial-checked') === '1';
+                if (isChecked !== wasChecked) { hasChange = true; break; }
+            }
+            if (hasChange){
+                changed++;
+                tr.classList.add('ce-row-changed');
+            } else {
+                tr.classList.remove('ce-row-changed');
+            }
+        });
+        var el = container.querySelector('#ce-change-count');
+        if (el) el.textContent = changed > 0 ? changed + '件の変更があります' : '';
+    }
+
+    // ---- 行 HTML 生成
     function createRowHTML(user, flagsByType){
-        var uId   = esc(user.id);
-        var uName = esc(user.name);
-        var allow = !!user.allowEdit;
+        var uId     = esc(user.id);
+        var uName   = esc(user.name);
+        var allow   = !!user.allowEdit;
         var isStaff = isStaffUser(user);
         var userLevel = (user && (user.i_user_level != null ? user.i_user_level : user.userLevel));
 
         var cells = '';
-        for (var t=1; t<=4; t++){
+        for (var t = 1; t <= 4; t++){
             var f = flagsByType[t] || {};
             var initiallyOn = Number(f.i_change_flag || 0) === 1;
-            var eatFlag = Number(f.eat_flag || 0);
-            var checked  = initiallyOn ? ' checked' : '';
-            // allowEditがfalseの場合は常にdisabled
-            var disabled = allow ? '' : ' disabled';
-            var initAttr = initiallyOn ? ' data-initial-checked="1"' : '';
-            var eatAttr = eatFlag === 1 ? ' data-eat-flag="1"' : '';
+            var eatFlag     = Number(f.eat_flag || 0);
+            var checked     = initiallyOn ? ' checked' : '';
+            var disabled    = allow ? '' : ' disabled';
+            var initAttr    = initiallyOn ? ' data-initial-checked="1"' : '';
+            var eatAttr     = eatFlag === 1 ? ' data-eat-flag="1"' : '';
 
-            cells += '' +
+            cells +=
                 '<td class="text-center">' +
-                '  <input type="checkbox"' +
-                '         name="users['+uId+']['+t+']"' +
-                '         class="meal-checkbox"' +
-                '         data-reservation-type="'+t+'"' +
-                '         data-user-id="'+uId+'"' +
-                '         value="1"'+checked+disabled+initAttr+eatAttr+'>' +
+                '<input type="checkbox"' +
+                ' name="users[' + uId + '][' + t + ']"' +
+                ' class="meal-checkbox"' +
+                ' data-reservation-type="' + t + '"' +
+                ' data-user-id="' + uId + '"' +
+                ' value="1"' + checked + disabled + initAttr + eatAttr + '>' +
                 '</td>';
         }
+
         var staffAttr = isStaff ? ' data-is-staff="1"' : '';
-        var levelAttr = (userLevel != null && userLevel !== '') ? ' data-user-level="'+esc(userLevel)+'"' : '';
-        return '<tr data-user-id="'+uId+'"' + staffAttr + levelAttr + '><td>'+uName+'</td>' + cells + '</tr>';
+        var levelAttr = (userLevel != null && userLevel !== '') ? ' data-user-level="' + esc(userLevel) + '"' : '';
+        return '<tr data-user-id="' + uId + '"' + staffAttr + levelAttr + '>' +
+            '<td>' + uName + '</td>' +
+            cells +
+            '</tr>';
     }
 
-    // ---- 列一括切替（昼食⇔弁当排他制御強化）
+    // ---- 列一括切替（昼食⇔弁当排他制御）
     function toggleColumn(container, reservationType, checked){
         var tbody = container.querySelector('#ce-tbody');
         if (!tbody) return;
-
-        tbody.querySelectorAll('input.meal-checkbox[data-reservation-type="'+reservationType+'"]').forEach(function(cb){
+        tbody.querySelectorAll('input.meal-checkbox[data-reservation-type="' + reservationType + '"]').forEach(function(cb){
             if (cb.disabled || cb.dataset.locked === '1') return;
             cb.checked = !!checked;
-
             var tr = cb.closest('tr');
             if (!tr) return;
-
-            // 昼食(2)と弁当(4)の排他制御
-            if (reservationType === 2 && checked) {
+            if (reservationType === 2 && checked){
                 var bento = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');
-                if (bento && !bento.disabled && bento.dataset.locked !== '1') {
-                    bento.checked = false;
-                    bento.dispatchEvent(new Event('change'));
-                }
+                if (bento && !bento.disabled && bento.dataset.locked !== '1') { bento.checked = false; bento.dispatchEvent(new Event('change')); }
             }
-            if (reservationType === 4 && checked) {
+            if (reservationType === 4 && checked){
                 var lunch = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
-                if (lunch && !lunch.disabled && lunch.dataset.locked !== '1') {
-                    lunch.checked = false;
-                    lunch.dispatchEvent(new Event('change'));
-                }
+                if (lunch && !lunch.disabled && lunch.dataset.locked !== '1') { lunch.checked = false; lunch.dispatchEvent(new Event('change')); }
             }
-
             cb.dispatchEvent(new Event('change'));
         });
     }
 
-    // ---- 列ヘッダ
+    // ---- ヘッダー全選択チェックボックスのバインド
     function bindHeaderChecks(container){
         ['select-all-1','select-all-2','select-all-3','select-all-4'].forEach(function(id){
-            var h = container.querySelector('#'+id);
+            var h = container.querySelector('#' + id);
             if (!h) return;
             var clone = h.cloneNode(true);
             h.parentNode.replaceChild(clone, h);
         });
-
         var h1 = container.querySelector('#select-all-1');
-        if (h1) h1.addEventListener('change', function(e){ toggleColumn(container, 1, !!e.target.checked); });
-
+        if (h1) h1.addEventListener('change', function(e){ toggleColumn(container, 1, !!e.target.checked); updateSummary(container); updateChangeCount(container); });
         var h2 = container.querySelector('#select-all-2');
         if (h2) h2.addEventListener('change', function(e){
             toggleColumn(container, 2, !!e.target.checked);
             var h4 = container.querySelector('#select-all-4');
             if (e.target.checked && h4) h4.checked = false;
+            updateSummary(container); updateChangeCount(container);
         });
-
         var h3 = container.querySelector('#select-all-3');
-        if (h3) h3.addEventListener('change', function(e){ toggleColumn(container, 3, !!e.target.checked); });
-
+        if (h3) h3.addEventListener('change', function(e){ toggleColumn(container, 3, !!e.target.checked); updateSummary(container); updateChangeCount(container); });
         var h4 = container.querySelector('#select-all-4');
         if (h4) h4.addEventListener('change', function(e){
             toggleColumn(container, 4, !!e.target.checked);
             var h2b = container.querySelector('#select-all-2');
             if (e.target.checked && h2b) h2b.checked = false;
+            updateSummary(container); updateChangeCount(container);
         });
     }
 
-    // ---- UIガード: 職員の予約済みチェックは解除させない
-    function installUncheckGuards(tbody) {
+    // ---- 氏名検索バインド
+    function bindNameSearch(container){
+        var input = container.querySelector('#ce-name-search');
+        if (!input || input.dataset.searchBound === '1') return;
+        input.dataset.searchBound = '1';
+        input.addEventListener('input', function(){
+            var q = input.value.trim().toLowerCase();
+            container.querySelectorAll('#ce-tbody tr[data-user-id]').forEach(function(tr){
+                var name = (tr.querySelector('td:first-child') || {}).textContent || '';
+                tr.classList.toggle('ce-row-hidden', q !== '' && name.toLowerCase().indexOf(q) === -1);
+            });
+        });
+    }
+
+    // ---- 職員の既存予約チェックボックスをロック
+    function installUncheckGuards(tbody){
         if (!tbody || !(tbody instanceof HTMLElement)) return;
-
-        // 職員ユーザーの予約済み(i_change_flag=1)チェックボックスをロック
-        const lockTargetList = tbody.querySelectorAll('tr[data-is-staff="1"] input.meal-checkbox[data-initial-checked="1"]');
-
-        console.log('ロック対象の職員CB数:', lockTargetList.length);
-
-        lockTargetList.forEach(cb => {
-            // allowEdit=falseで既にdisabledの場合もあるが、そうでなければロックする
-            if (cb.checked && !cb.disabled) {
+        tbody.querySelectorAll('tr[data-is-staff="1"] input.meal-checkbox[data-initial-checked="1"]').forEach(function(cb){
+            if (cb.checked && !cb.disabled){
                 cb.disabled = true;
                 cb.dataset.locked = '1';
-                if (!cb.title) cb.title = '職員の予約は直前変更画面からは解除できません。';
+                cb.title = '職員の予約は直前変更画面からは解除できません。';
                 cb.classList.add('deletion-blocked');
             }
         });
     }
 
-    // ---- 一覧取得＆描画
+    // ---- 一覧取得 & 描画
     function fetchAndRender(container){
         var root       = container.querySelector('#ce-root') || container;
         var base       = root.getAttribute('data-base') || '/';
@@ -203,179 +216,160 @@
         var date   = (dateHidden && dateHidden.value);
         var meal   = resolveMealType(container);
 
-        if (!roomId) { showMsg(tbody, '部屋が選択されていません。', true); return; }
-        if (!date)   { showMsg(tbody, '日付が不正です。', true); return; }
-        if (!meal)   { showMsg(tbody, '食種(mealType)が不正です。', true); return; }
+        if (!roomId){ showMsg(tbody, '部屋が選択されていません。', true); return; }
+        if (!date)  { showMsg(tbody, '日付が不正です。', true); return; }
+        if (!meal)  { showMsg(tbody, '食種(mealType)が不正です。', true); return; }
 
         showLoading(tbody);
 
-        // タイムアウト付きフェッチ（AbortController 非対応ブラウザ対策付き）
-        var ctrl = null;
-        var signal = undefined;
-        var to = null;
-
-        if (typeof AbortController !== 'undefined') {
-            ctrl = new AbortController();
-            signal = ctrl.signal;
-            to = setTimeout(function(){
-                try { ctrl.abort(); } catch(_e){}
-            }, 12000);
+        var ctrl = null, signal, to = null;
+        if (typeof AbortController !== 'undefined'){
+            ctrl = new AbortController(); signal = ctrl.signal;
+            to = setTimeout(function(){ try { ctrl.abort(); } catch(_e){} }, 12000);
         }
 
         fetch(apiUrl(base, roomId, date, meal), {
             method: 'GET',
-            headers: { 'Accept':'application/json', 'X-Requested-With':'XMLHttpRequest' },
+            headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
             credentials: 'same-origin',
             signal: signal
         })
-            .then(function(res){
-                return res.json().then(function(j){ return { ok: res.ok, j:j }; });
-            })
-            .then(function(pair){
-                var ok = pair.ok, json = pair.j;
+        .then(function(res){ return res.json().then(function(j){ return { ok: res.ok, j: j }; }); })
+        .then(function(pair){
+            var ok = pair.ok, json = pair.j;
+            if (!ok || !json || json.status !== 'success' || !json.data){
+                showMsg(tbody, (json && json.message) || '一覧取得に失敗しました。', true); return;
+            }
 
-                if (!ok || !json || json.status !== 'success' || !json.data) {
-                    showMsg(tbody, (json && json.message) || '一覧取得に失敗しました。', true); return;
-                }
+            var users = Array.isArray(json.data.users) ? json.data.users : [];
+            var flags = json.data.userReservations || {};
 
-                var users = Array.isArray(json.data.users) ? json.data.users : [];
-                var flags = json.data.userReservations || {};
+            if (users.length === 0){ showMsg(tbody, '該当する利用者がいません。'); return; }
 
-                if (users.length === 0) { showMsg(tbody, '該当する利用者がいません。'); return; }
+            var html = '';
+            users.forEach(function(u){ html += createRowHTML(u, flags[String(u.id)] || {}); });
+            tbody.innerHTML = html;
 
-                var html = '';
-                users.forEach(function(u) {
-                    html += createRowHTML(u, flags[String(u.id)] || {});
-                });
-                tbody.innerHTML = html;
+            // UIガード
+            installUncheckGuards(tbody);
 
-                // UIガード（職員の予約解除をブロック）
-                installUncheckGuards(tbody);
-
-                // 行レベルの昼食⇔弁当排他制御
-                tbody.querySelectorAll('tr[data-user-id]').forEach(function(tr){
-                    var lunchCb = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
-                    var bentoCb = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');
-                    if (lunchCb && bentoCb) {
-                        lunchCb.addEventListener('change', function(){
-                            if (lunchCb.checked && !lunchCb.disabled && lunchCb.dataset.locked !== '1') {
-                                if (bentoCb && !bentoCb.disabled && bentoCb.dataset.locked !== '1') {
-                                    bentoCb.checked = false;
-                                }
-                            }
-                        });
-                        bentoCb.addEventListener('change', function(){
-                            if (bentoCb.checked && !bentoCb.disabled && bentoCb.dataset.locked !== '1') {
-                                if (lunchCb && !lunchCb.disabled && lunchCb.dataset.locked !== '1') {
-                                    lunchCb.checked = false;
-                                }
-                            }
-                        });
-                    }
-                });
-
-                // ヘッダ全選択/解除
-                bindHeaderChecks(container);
-
-                // 保存(JSON POST)
-                var csrfMeta  = document.querySelector('meta[name="csrfToken"]');
-                var csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : null;
-                if (form && form.dataset.submitBound !== '1') {
-                    form.dataset.submitBound = '1';
-                    form.addEventListener('submit', function(e){
-                        e.preventDefault();
-
-                        var rId = (roomSelect && roomSelect.value) || (roomHidden && roomHidden.value);
-                        var d   = (dateHidden && dateHidden.value);
-                        var m   = resolveMealType(container);
-
-                        if (!rId || !d) { alert('部屋または日付が不正です。'); return; }
-                        if (!m)         { alert('食種(mealType)が不正です。'); return; }
-
-                        var usersPayload = {};
-                        var trs = tbody.querySelectorAll('tr[data-user-id]');
-                        Array.prototype.forEach.call(trs, function(tr){
-                            var uid = tr.getAttribute('data-user-id');
-                            if (!uid) return;
-                            var obj = {};
-                            var hasChange = false;
-                            for (var t=1; t<=4; t++){
-                                var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="'+t+'"]');
-                                if (!cb) continue;
-
-                                var isChecked = !!cb.checked;
-                                var wasChecked = cb.getAttribute('data-initial-checked') === '1';
-                                var changeFlag = 0; // 0:変更なし, 1:食べる, 2:食べない
-
-                                if (isChecked && !wasChecked) {
-                                    changeFlag = 1; // 新規予約
-                                } else if (!isChecked && wasChecked) {
-                                    changeFlag = 2; // 予約取消
-                                }
-
-                                if (changeFlag > 0) {
-                                    obj[String(t)] = { i_change_flag: changeFlag };
-                                    hasChange = true;
-                                }
-                            }
-                            if (hasChange) {
-                                usersPayload[String(uid)] = obj;
-                            }
-                        });
-
-                        if (Object.keys(usersPayload).length === 0) {
-                            alert('変更された項目がありません。');
-                            return;
+            // 行レベルの昼食⇔弁当排他制御
+            tbody.querySelectorAll('tr[data-user-id]').forEach(function(tr){
+                var lunchCb = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
+                var bentoCb = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');
+                if (lunchCb && bentoCb){
+                    lunchCb.addEventListener('change', function(){
+                        if (lunchCb.checked && !lunchCb.disabled && lunchCb.dataset.locked !== '1'){
+                            if (!bentoCb.disabled && bentoCb.dataset.locked !== '1') bentoCb.checked = false;
                         }
-
-                        var headers = { 'Content-Type':'application/json', 'Accept':'application/json', 'X-Requested-With':'XMLHttpRequest' };
-                        if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
-
-                        fetch(apiUrl(base, rId, d, m), {
-                            method:'POST', headers: headers, credentials:'same-origin',
-                            body: JSON.stringify({ users: usersPayload })
-                        })
-                            .then(function(res2){ return res2.json().then(function(j){ return { ok: res2.ok, j:j }; }); })
-                            .then(function(pair2){
-                                var ok2 = pair2.ok, json2 = pair2.j;
-                                if (!ok2 || !json2 || json2.status !== 'success') {
-                                    alert((json2 && json2.message) || '直前予約の更新に失敗しました。'); return;
-                                }
-
-                                // ---- 成功時の処理 ----
-                                alert('直前予約を更新しました。');
-
-                                // モーダルを閉じる
-                                var modalEl = container.closest('.modal');
-                                if (modalEl) {
-                                    var modalInstance = bootstrap.Modal.getInstance(modalEl);
-                                    if (modalInstance) {
-                                        modalInstance.hide();
-                                    }
-                                }
-
-                                // ページをリロードして変更を反映
-                                window.location.reload();
-                            })
-                            .catch(function(){ alert('保存リクエスト送信に失敗しました。'); });
+                        updateSummary(container); updateChangeCount(container);
+                    });
+                    bentoCb.addEventListener('change', function(){
+                        if (bentoCb.checked && !bentoCb.disabled && bentoCb.dataset.locked !== '1'){
+                            if (!lunchCb.disabled && lunchCb.dataset.locked !== '1') lunchCb.checked = false;
+                        }
+                        updateSummary(container); updateChangeCount(container);
+                    });
+                } else {
+                    // 朝・夕のchange→サマリー更新
+                    [1, 3].forEach(function(t){
+                        var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
+                        if (cb) cb.addEventListener('change', function(){ updateSummary(container); updateChangeCount(container); });
                     });
                 }
-
-                // 部屋変更→再取得
-                if (roomSelect && roomSelect.dataset.changeBound !== '1') {
-                    roomSelect.dataset.changeBound = '1';
-                    roomSelect.addEventListener('change', function(){ fetchAndRender(container); });
-                }
-            })
-            .catch(function(err){
-                console.error('一覧取得エラー:', err);
-                showMsg(tbody, '一覧取得に失敗しました。', true);
-            })
-            .finally(function(){
-                if (to) clearTimeout(to);
             });
+
+            bindHeaderChecks(container);
+            bindNameSearch(container);
+            updateSummary(container);
+            updateChangeCount(container);
+
+            // フォーム送信
+            var csrfMeta  = document.querySelector('meta[name="csrfToken"]');
+            var csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : null;
+            if (form && form.dataset.submitBound !== '1'){
+                form.dataset.submitBound = '1';
+                form.addEventListener('submit', function(e){
+                    e.preventDefault();
+
+                    var rId = (roomSelect && roomSelect.value) || (roomHidden && roomHidden.value);
+                    var d   = (dateHidden && dateHidden.value);
+                    var m   = resolveMealType(container);
+
+                    if (!rId || !d){ alert('部屋または日付が不正です。'); return; }
+                    if (!m)        { alert('食種(mealType)が不正です。'); return; }
+
+                    var usersPayload = {};
+                    tbody.querySelectorAll('tr[data-user-id]').forEach(function(tr){
+                        var uid = tr.getAttribute('data-user-id');
+                        if (!uid) return;
+                        var obj = {}, hasChange = false;
+                        for (var t = 1; t <= 4; t++){
+                            var cb = tr.querySelector('input.meal-checkbox[data-reservation-type="' + t + '"]');
+                            if (!cb) continue;
+                            var isChecked  = !!cb.checked;
+                            var wasChecked = cb.getAttribute('data-initial-checked') === '1';
+                            var flag = 0;
+                            if (isChecked  && !wasChecked) flag = 1;
+                            if (!isChecked && wasChecked)  flag = 2;
+                            if (flag > 0){ obj[String(t)] = { i_change_flag: flag }; hasChange = true; }
+                        }
+                        if (hasChange) usersPayload[String(uid)] = obj;
+                    });
+
+                    if (Object.keys(usersPayload).length === 0){ alert('変更された項目がありません。'); return; }
+
+                    var saveBtn    = container.querySelector('#ce-save-btn');
+                    var saveSpinner = container.querySelector('#ce-save-spinner');
+                    if (saveBtn)    { saveBtn.disabled = true; }
+                    if (saveSpinner){ saveSpinner.style.display = 'inline-flex'; }
+
+                    var headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
+                    if (csrfToken) headers['X-CSRF-Token'] = csrfToken;
+
+                    fetch(apiUrl(base, rId, d, m), {
+                        method: 'POST', headers: headers, credentials: 'same-origin',
+                        body: JSON.stringify({ users: usersPayload })
+                    })
+                    .then(function(res2){ return res2.json().then(function(j){ return { ok: res2.ok, j: j }; }); })
+                    .then(function(pair2){
+                        var ok2 = pair2.ok, json2 = pair2.j;
+                        if (!ok2 || !json2 || json2.status !== 'success'){
+                            alert((json2 && json2.message) || '直前予約の更新に失敗しました。');
+                            if (saveBtn)    saveBtn.disabled = false;
+                            if (saveSpinner) saveSpinner.style.display = 'none';
+                            return;
+                        }
+                        // 成功：モーダルを閉じてリロード
+                        var modalEl = container.closest('.modal');
+                        if (modalEl && window.bootstrap){
+                            var inst = bootstrap.Modal.getInstance(modalEl);
+                            if (inst) inst.hide();
+                        }
+                        window.location.reload();
+                    })
+                    .catch(function(){
+                        alert('保存リクエスト送信に失敗しました。');
+                        if (saveBtn)    saveBtn.disabled = false;
+                        if (saveSpinner) saveSpinner.style.display = 'none';
+                    });
+                });
+            }
+
+            // 部屋変更 → 再取得
+            if (roomSelect && roomSelect.dataset.changeBound !== '1'){
+                roomSelect.dataset.changeBound = '1';
+                roomSelect.addEventListener('change', function(){ fetchAndRender(container); });
+            }
+        })
+        .catch(function(err){
+            console.error('一覧取得エラー:', err);
+            showMsg(tbody, '一覧取得に失敗しました。', true);
+        })
+        .finally(function(){ if (to) clearTimeout(to); });
     }
 
+    // ---- 初期化
     function init(scope){
         var container = scope || document;
         var form = container.querySelector('#change-edit-form');
@@ -383,14 +377,9 @@
 
         var sel = container.querySelector('#ce-room-select');
         var hid = container.querySelector('#ce-room-hidden');
-        
-        if (sel) {
-            // セレクトボックスがある場合：値が未設定なら最初のオプションを選択
-            if (!sel.value && sel.options.length > 0) {
-                sel.value = sel.options[0].value;
-            }
-        } else if (hid && !hid.value) {
-            // hiddenフィールドのみの場合：値が空なら警告
+        if (sel){
+            if (!sel.value && sel.options.length > 0) sel.value = sel.options[0].value;
+        } else if (hid && !hid.value){
             console.warn('部屋IDが設定されていません');
         }
 
@@ -403,34 +392,30 @@
 
     // 直描画時
     document.addEventListener('DOMContentLoaded', function(){
-        var root = document.getElementById('ce-root');
-        if (root) init(document);
+        if (document.getElementById('ce-root')) init(document);
     });
 
-    // モーダル表示時
+    // モーダル表示時（shown.bs.modal）
     document.addEventListener('shown.bs.modal', function(ev){
         var modal = ev.target;
-        if (!modal) return;
-        if (modal.querySelector && modal.querySelector('#ce-root')) window.CE_CHANGE_EDIT.init(modal);
+        if (modal && modal.querySelector && modal.querySelector('#ce-root')) window.CE_CHANGE_EDIT.init(modal);
     });
 })();
 
 
-// 食数予約: 利用者一覧取得と描画（本番互換版）
+// ---- 食数予約：利用者一覧取得と描画
 (function(){
     if (!window.GET_USERS_BY_ROOM_TPL) return;
 
     function buildUsersUrl(roomId){
-        const tpl = window.GET_USERS_BY_ROOM_TPL;
+        var tpl = window.GET_USERS_BY_ROOM_TPL;
         if (!tpl) return '';
-        if (tpl.includes('__RID__')) return tpl.replace('__RID__', encodeURIComponent(roomId));
-        return tpl;
+        return tpl.includes('__RID__') ? tpl.replace('__RID__', encodeURIComponent(roomId)) : tpl;
     }
 
     function normalizeUser(u){
         return {
-            id: u.id,
-            name: u.name || '',
+            id: u.id, name: u.name || '',
             breakfast: (u.breakfast ?? u.morning) || false,
             lunch: (u.lunch ?? u.noon) || false,
             dinner: (u.dinner ?? u.night) || false,
@@ -439,81 +424,49 @@
         };
     }
 
+    function escapeHtml(s){
+        return String(s || '').replace(/[&<>"']/g, function(m){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]; });
+    }
+
     async function safeFetchJson(url){
-        const res = await fetch(url, {
-            headers: {
-                'Accept':'application/json',
-                'X-Requested-With':'XMLHttpRequest'
-            },
-            credentials:'same-origin'
-        });
-        const text = await res.text();
-        try {
-            return JSON.parse(text);
-        } catch(e){
-            if (/Warning|Notice|Fatal/i.test(text)) {
-                console.error('JSON破損（PHP警告混入の可能性）', text.slice(0,200));
-            } else {
-                console.error('JSON parse失敗', text.slice(0,200));
-            }
-            return null;
-        }
+        var res = await fetch(url, { headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' });
+        var text = await res.text();
+        try { return JSON.parse(text); }
+        catch(e){ console.error('JSON parse失敗', text.slice(0, 200)); return null; }
     }
 
     async function fetchUsers(roomId){
-        const url = buildUsersUrl(roomId);
+        var url = buildUsersUrl(roomId);
         if (!url) return [];
-        const json = await safeFetchJson(url);
+        var json = await safeFetchJson(url);
         if (!json) return [];
-
-        let arr = [];
-        if (Array.isArray(json.users)) {
-            arr = json.users;
-        } else if (json.data && Array.isArray(json.data.users)) {
-            arr = json.data.users;
-        } else if (Array.isArray(json.usersByRoom)) {
-            arr = json.usersByRoom;
-        } else {
-            console.warn('ユーザ配列未検出', json);
-            return [];
-        }
+        var arr = Array.isArray(json.users) ? json.users
+            : (json.data && Array.isArray(json.data.users)) ? json.data.users
+            : Array.isArray(json.usersByRoom) ? json.usersByRoom : [];
         return arr.map(normalizeUser);
     }
 
     function renderUsers(users){
-        const tbody = document.getElementById('user-checkboxes');
+        var tbody = document.getElementById('user-checkboxes');
         if (!tbody) return;
-        if (users.length === 0){
-            tbody.innerHTML = '<tr><td colspan="6">利用者が取得できませんでした。</td></tr>';
-            return;
-        }
-        tbody.innerHTML = users.map(u => `
-      <tr data-user-id="${u.id}">
-        <td>${escapeHtml(u.name)}</td>
-        <td>${escapeHtml(u.room_name)}</td>
-        <td class="text-center"><input type="checkbox" ${u.breakfast ? 'checked':''} disabled></td>
-        <td class="text-center"><input type="checkbox" ${u.lunch ? 'checked':''} disabled></td>
-        <td class="text-center"><input type="checkbox" ${u.dinner ? 'checked':''} disabled></td>
-        <td class="text-center"><input type="checkbox" ${u.bento ? 'checked':''} disabled></td>
-      </tr>
-    `).join('');
-    }
-
-    function escapeHtml(s){
-        return String(s||'').replace(/[&<>"']/g, m => ({
-            '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
-        }[m]));
+        if (users.length === 0){ tbody.innerHTML = '<tr><td colspan="6">利用者が取得できませんでした。</td></tr>'; return; }
+        tbody.innerHTML = users.map(function(u){
+            return '<tr data-user-id="' + u.id + '">' +
+                '<td>' + escapeHtml(u.name) + '</td>' +
+                '<td>' + escapeHtml(u.room_name) + '</td>' +
+                '<td class="text-center"><input type="checkbox" ' + (u.breakfast ? 'checked' : '') + ' disabled></td>' +
+                '<td class="text-center"><input type="checkbox" ' + (u.lunch     ? 'checked' : '') + ' disabled></td>' +
+                '<td class="text-center"><input type="checkbox" ' + (u.dinner    ? 'checked' : '') + ' disabled></td>' +
+                '<td class="text-center"><input type="checkbox" ' + (u.bento     ? 'checked' : '') + ' disabled></td>' +
+                '</tr>';
+        }).join('');
     }
 
     async function init(){
-        const rid = window.__PRIMARY_ROOM_ID || (window.__USER_INFO && window.__USER_INFO.roomId) || 1;
-        const users = await fetchUsers(rid);
-        renderUsers(users);
+        var rid = window.__PRIMARY_ROOM_ID || (window.__USER_INFO && window.__USER_INFO.roomId) || 1;
+        renderUsers(await fetchUsers(rid));
     }
 
     document.addEventListener('DOMContentLoaded', init);
-    window.refreshUsersByRoom = async function(roomId){
-        const users = await fetchUsers(roomId);
-        renderUsers(users);
-    };
+    window.refreshUsersByRoom = async function(roomId){ renderUsers(await fetchUsers(roomId)); };
 })();

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -654,6 +654,22 @@ function openModalById(id){
                 openModalById('conflictModal');
             }
 
+            function makeLateNoticeHtml(date, mealIdx, action) {
+                var actionLabel = action
+                    ? '<span class="badge bg-danger ms-1">' + action + '</span>'
+                    : '';
+                return '<div class="late-notice-alert alert alert-danger mb-0">'
+                    + '<i class="bi bi-exclamation-circle-fill me-1"></i>'
+                    + 'この期間はすでに<strong>発注済</strong>です。内容をよく確認してください。'
+                    + '</div>'
+                    + '<dl class="late-notice-detail row g-0 mt-2 mb-1">'
+                    + '<dt class="col-4 text-muted small">対象日</dt>'
+                    + '<dd class="col-8 fw-semibold mb-1">' + date + '</dd>'
+                    + '<dt class="col-4 text-muted small">食事種別</dt>'
+                    + '<dd class="col-8 fw-semibold mb-1">' + mealJaFull[mealIdx] + actionLabel + '</dd>'
+                    + '</dl>';
+            }
+
             function showLateNotice(html, onAgree){
                 var body = document.getElementById('lateNoticeBody');
                 var agree = document.getElementById('lateAgreeCheck');
@@ -837,7 +853,7 @@ function openModalById(id){
                                 showConflict(
                                     'この日（' + date + '）は<strong>' + labelFrom + '</strong>の予約があります。<br><strong>' + labelFrom + '</strong>を先に<strong>取り消し</strong>てから、<strong>' + labelTo + '</strong>を登録してもよろしいですか？',
                                     async function(){
-                                        var html = '日付：<strong>' + date + '</strong><br>対象：<strong>' + mealJaFull[mealIdx] + '</strong><br><br>この期間はすでに<strong>発注済</strong>です。登録内容をよく確認してください。';
+                                        var html = makeLateNoticeHtml(date, mealIdx, null);
                                         withLateAgreement(html, async function(){
                                             try { await resolveConflictSequence(date, mealIdx, true, btn, mealKey); }
                                             catch (ee) { notifyUser((ee && ee.message) || '競合解消に失敗しました。', 'danger'); }
@@ -859,7 +875,7 @@ function openModalById(id){
                                 showConflict(
                                     ((e && e.message) || '昼食と弁当は同時に予約できません。') + '<br><small class="text-muted">（競合先の予約を先にOFFしてから目的の予約をONにします）</small>',
                                     async function(){
-                                        var html = '日付：<strong>' + date + '</strong><br>対象：<strong>' + mealJaFull[mealIdx] + '</strong><br><br>この期間はすでに<strong>発注済</strong>です。登録内容をよく確認してください。';
+                                        var html = makeLateNoticeHtml(date, mealIdx, null);
                                         withLateAgreement(html, async function(){
                                             try {
                                                 btn.disabled = true; btn.style.opacity = .65;
@@ -886,7 +902,7 @@ function openModalById(id){
                         }
                     }
 
-                    var bodyHtml = '日付：<strong>' + date + '</strong><br>対象：<strong>' + mealJaFull[mealIdx] + '</strong><br><br>この期間はすでに<strong>発注済</strong>です。' + (nextVal ? '追加' : 'キャンセル') + 'してよいか、内容をよく確認してください。';
+                    var bodyHtml = makeLateNoticeHtml(date, mealIdx, nextVal ? '追加' : 'キャンセル');
                     withLateAgreement(bodyHtml, doToggle);
                 }, false);
             });

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1537,6 +1537,15 @@ function unlockForChildren(wrap){
                 }
                 // ★★★★★ 修正箇所ここまで ★★★★★
 
+                // 直前編集フォーム（change_edit.php）初期化
+                if (window.CE_CHANGE_EDIT && typeof window.CE_CHANGE_EDIT.init === 'function') {
+                    try {
+                        window.CE_CHANGE_EDIT.init(host);
+                    } catch (e) {
+                        console.error('Error during CE_CHANGE_EDIT.init():', e);
+                    }
+                }
+
                 ensureAddModalCompat(host);
 
                 // ★ 昼食⇔弁当排他制御をAjax描画直後にも適用


### PR DESCRIPTION
Closes #147

## 変更内容

### バグ修正
- `change_edit.php` のテーブルヘッダが6列・JS生成行が5列のミスマッチを解消（IDカラム削除）
- AJAXロード後に `CE_CHANGE_EDIT.init()` が呼ばれていなかったため、テーブルデータが「読み込み中」のまま固まるバグを修正
- `change_edit.php` の `body { background }` インラインスタイルがページ全体に漏れる問題を修正（`#ce-root` スコープへ変更）
- `lateNoticeModal` の `btn-primary` → `btn-danger` に変更し警告色を統一

### UI再設計（change_edit.php）
- 警告バナーを黄色帯（`#fff3cd`）で表示し「直前編集・発注済み」を明示
- ツールバーに氏名検索・部屋選択を集約
- 食数サマリーバーを追加（朝/昼/夕/弁当を動的に表示）
- テーブルを5列に正規化（名前・朝・昼・夕・弁当）
- フッターに変更件数カウンター・保存中スピナーを追加
- 保存ボタンを `Form->button()` からプレーン `<button>` に変更し、HTMLタグがそのまま表示されるバグを修正

### 昼⇔弁当 排他制御（ce-change-edit.js）
- 個別行で昼をONにすると弁当をOFF、弁当をONにすると昼をOFFに
- ヘッダー一括切替でも昼/弁当の排他制御を正しく適用
- `toggleColumn()` をイベント多重発火なしの直接書き換え方式に刷新

### ヘッダーチェックボックスの indeterminate 対応
- `updateHeaderStates()` を実装し、行の状態から全選択／一部選択（−）／未選択の3状態を動的更新
- `updateAll()` で summary・changeCount・headerStates を一括更新

### lateNoticeModal のUX改善
- モーダルボディを情報エリアと同意エリアに分離して視覚的階層を整理
- 注入HTMLを `<br>` 羅列から `<dl>` 構造化HTMLに変更
- ネストモーダルの z-index 対応を追加