### PR TITLE
fix: セキュリティ脆弱性対応 composer/composer 2.9.7 へアップデート

### DIFF
--- a/src_web/kamaho-shokusu/composer.lock
+++ b/src_web/kamaho-shokusu/composer.lock
@@ -2538,16 +2538,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.5",
+            "version": "2.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6"
+                "reference": "82a2fbd1372a98d7915cfb092acf05207d9b4113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
-                "reference": "72a8f8e653710e18d83e5dd531eb5a71fc3223e6",
+                "url": "https://api.github.com/repos/composer/composer/zipball/82a2fbd1372a98d7915cfb092acf05207d9b4113",
+                "reference": "82a2fbd1372a98d7915cfb092acf05207d9b4113",
                 "shasum": ""
             },
             "require": {
@@ -2635,7 +2635,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.5"
+                "source": "https://github.com/composer/composer/tree/2.9.7"
             },
             "funding": [
                 {
@@ -2647,7 +2647,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-29T10:40:53+00:00"
+            "time": "2026-04-14T11:31:52+00:00"
         },
         {
             "name": "composer/metadata-minifier",


### PR DESCRIPTION
## 対応した脆弱性

| パッケージ | 旧バージョン | 新バージョン | 概要 |
|---|---|---|---|
| composer/composer | 2.9.5 | 2.9.7 | Perforce リポジトリ経由のコマンドインジェクション（High）|

- PHPUnit 10.5.63 は既に修正済みバージョンのため変更なし

## 変更内容

- `composer.lock`: composer/composer を 2.9.5 → 2.9.7 に更新