### PR TITLE
Resolve #158: 直前編集モーダルで職員IDが付与されていないと画面が固まるバグを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -67,6 +67,8 @@ class ReservationChangeEditService
                 'MUserInfo.i_del_flag'   => 0,
             ])
             ->enableHydration(false)->all()->extract('i_id_user')->toList();
+        // 職員IDが未付与（null）のレコードを除外して予期しない動作を防ぐ
+        $baseUserIds = array_values(array_filter($baseUserIds, fn($id) => $id !== null && $id > 0));
         if (empty($baseUserIds)) {
             $baseUserIds = [-1];
         }

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1519,6 +1519,16 @@ function unlockForChildren(wrap){
                 } else {
                     console.warn('[loadInto] ADD_RESERVATION.init not found. UI might be misconfigured.');
                 }
+
+                // 直前編集モーダル（ce-change-edit.js）の初期化を明示的に呼び出す
+                // shown.bs.modal はHTML読み込み前に発火する場合があるため、ここで確実に初期化する
+                if (window.CE_CHANGE_EDIT && typeof window.CE_CHANGE_EDIT.init === 'function') {
+                    try {
+                        window.CE_CHANGE_EDIT.init(host);
+                    } catch (e) {
+                        console.error('Error during CE_CHANGE_EDIT.init():', e);
+                    }
+                }
                 // ★★★★★ 修正箇所ここまで ★★★★★
 
                 ensureAddModalCompat(host);


### PR DESCRIPTION
Closes #158

## 変更内容

### バグ修正

- **`treservation_index.inline.js` — `loadInto()` 関数に `CE_CHANGE_EDIT.init()` の明示的な呼び出しを追加**
  - `shown.bs.modal` イベントは Bootstrap のアニメーション完了後（約 300ms）に発火するが、サーバーレスポンスが遅い場合はモーダル HTML の読み込みよりも先に発火してしまう
  - その結果、`#ce-root` が DOM に存在せず `CE_CHANGE_EDIT.init` が呼ばれないまま、`#ce-tbody` が「読み込み中...」のままフリーズしていた
  - HTML 読み込み完了後に `CE_CHANGE_EDIT.init(host)` を明示的に呼び出すことで、タイミングに関わらず直前編集モーダルが確実に初期化されるよう修正

- **`ReservationChangeEditService.php` — `buildContext()` に null ユーザー ID のフィルタリングを追加**
  - `m_user_group` テーブルに職員 ID（`i_id_user`）が未付与（null）のレコードが存在する場合、`$baseUserIds` にそのまま含まれてしまい予期しない挙動を引き起こす可能性があった
  - `array_filter` により null および 0 以下の値を除外する防御的処理を追加