### PR TITLE
Resolve #158: ビジネスロジック例外エラーのハンドリング対応

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -880,14 +880,19 @@ class TReservationInfoController extends AppController
      */
     public function changeEdit($roomId = null, $date = null, $mealType = null): ?Response
     {
-        $this->authorizeReservation('changeEdit');
-
-        // 応答種別（try/catch の両スコープで参照するため外側で定義する）
+        // 応答種別を先に確定させてから認可チェックに渡す。
+        // こうすることで AJAX リクエスト時の ForbiddenException が
+        // CakePHP のエラーハンドラーではなく JSON レスポンスとして返るため、
+        // loadInto() 側でビジネスロジックエラーのメッセージを表示できる。
         $wantsJson =
             $this->request->is('ajax') ||
             $this->request->getQuery('ajax') === '1' || // ★ クエリで強制的に JSON を要求
             $this->request->accepts('application/json') ||
             $this->request->getParam('_ext') === 'json';
+
+        if ($denied = $this->authorizeReservation('changeEdit', [], $wantsJson)) {
+            return $denied;
+        }
 
         try {
             // ---- パラメータ補完（route/query/POST 両対応）----

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1486,7 +1486,18 @@ function unlockForChildren(wrap){
                 });
 
                 if (!response.ok) {
-                    throw new Error('HTTP ' + response.status);
+                    // サーバーが JSON エラーを返している場合はそのメッセージを取り出す
+                    var errMessage = 'HTTP ' + response.status;
+                    try {
+                        var ct = response.headers.get('content-type') || '';
+                        if (ct.indexOf('application/json') !== -1) {
+                            var errJson = await response.json();
+                            if (errJson && errJson.message) {
+                                errMessage = errJson.message;
+                            }
+                        }
+                    } catch (_) {}
+                    throw new Error(errMessage);
                 }
 
                 var htmlText = await response.text();
@@ -1541,11 +1552,17 @@ function unlockForChildren(wrap){
                 installModalSaveBridge(host, modalEl || host);
 
             } catch(err) {
+                // HTTP ステータス表示など技術的な文字列はユーザーに見せない
+                var rawMsg = (err && err.message) ? String(err.message) : '';
+                var isTechnical = !rawMsg || /^HTTP \d/.test(rawMsg) || rawMsg === '空のレスポンス';
+                var displayMsg = isTechnical
+                    ? 'ページを再読み込みするか、管理者にお問い合わせください。'
+                    : rawMsg.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
                 container.innerHTML =
                     '<div class="alert alert-danger" role="alert">' +
                     '<h4 class="alert-heading">エラー</h4>' +
                     '<p>読み込みに失敗しました</p>' +
-                    '<hr><p class="mb-0"><small>ページを再読み込みするか、管理者にお問い合わせください。</small></p>' +
+                    '<hr><p class="mb-0"><small>' + displayMsg + '</small></p>' +
                     '</div>';
             }
         }


### PR DESCRIPTION
Closes #158

## 変更内容

### PHP（`TReservationInfoController.php`）
- `changeEdit()` で `$wantsJson` の計算を `authorizeReservation()` より先に行うよう変更
  - 変更前: 権限エラー時に `ForbiddenException` がそのままスローされ、CakePHP がエラーページ (HTML 403) を返す → `loadInto()` が汎用エラーを表示するだけだった
  - 変更後: AJAX リクエストの場合は `ForbiddenException` を JSON レスポンス `{"ok":false,"message":"権限がありません。"}` に変換して返すことで、エラー内容を JS 側に伝播できるようにした

### JS（`treservation_index.inline.js`）
- `loadInto()` の `!response.ok` 処理にて、レスポンスの `Content-Type` が `application/json` の場合は `message` フィールドを読み取るよう修正
- `catch` ブロックを改修し、サーバーが返したビジネスロジックエラーのメッセージをモーダル内に表示するよう対応
  - `HTTP 403` 等の技術的な文字列はユーザー向け汎用文言に置換し、意味のあるメッセージだけを表示
  - XSS 対策として表示前に HTML エスケープを実施