### PR TITLE
Resolve #163: 直前編集POSTのサーバー側allowEdit権限チェックを追加

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -153,6 +153,13 @@ class ReservationChangeEditService
         $skipped = [];
 
         try {
+            // ログインユーザーの編集権限を確定する（buildUsersForJson と同一ロジック）
+            $loginUid    = $loginUser ? (int)$loginUser->get('i_id_user') : 0;
+            $canEditAll  = $loginUser && (
+                (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
+                (int)($loginUser->get('i_user_level') ?? -1) === 0
+            );
+
             $allowedMap = array_fill_keys(array_map('intval', $userIdList), true);
             $targetUserIds = [];
             foreach ($usersData as $uid => $_) {
@@ -209,6 +216,12 @@ class ReservationChangeEditService
                 $userId = (int)$userIdRaw;
                 if (!isset($allowedMap[$userId])) {
                     $skipped[] = "利用者ID {$userId} はこの部屋の所属ではないためスキップされました。";
+                    continue;
+                }
+
+                // サーバー側 allowEdit チェック: 管理者・職員以外は自分以外の予約を変更できない
+                if (!$canEditAll && $userId !== $loginUid) {
+                    $skipped[] = "利用者ID {$userId} の予約を変更する権限がありません。";
                     continue;
                 }
 


### PR DESCRIPTION
Closes #163

## 変更内容
- `ReservationChangeEditService::processUpdate()` にログインユーザーの編集権限チェックを追加
- 管理者（`i_admin=1`）または職員（`i_user_level=0`）以外は自分以外のユーザーの予約をAPIで変更できないよう制限
- `buildUsersForJson()` の `allowEdit` ロジックと同一の判定をサーバー側にも適用し、フロント・サーバー間の整合性を確保
- 権限不足の場合は `skipped` 配列にメッセージを追加してスキップ（トランザクションは継続）