### PR TITLE
Resolve #164: 直前編集の同時保存競合時に再試行を促すメッセージを表示

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -21,6 +21,7 @@ use App\Service\ReservationWriteService;
 use App\Service\ReservationDatePolicy;
 use App\Service\ReservationRoomDetailService;
 use App\Service\ReservationViewService;
+use App\Exception\OptimisticLockConflictException;
 use App\Service\ReservationChangeEditService;
 use App\Service\ReservationAddService;
 use App\Service\ApiResponseService;
@@ -1049,6 +1050,19 @@ class TReservationInfoController extends AppController
                     $this->Flash->success(__($payload['message']));
                     return $this->redirect(['action' => 'index']);
 
+                } catch (OptimisticLockConflictException $e) {
+                    // オプティミスティックロック競合: 409 Conflict + 再試行を促すメッセージ
+                    $this->log('直前編集 競合: '.$e->getMessage(), 'warning');
+                    if ($wantsJson) {
+                        return $this->response->withStatus(409)->withType('application/json')
+                            ->withStringBody(json_encode([
+                                'ok' => false,
+                                'status' => 'conflict',
+                                'message' => $e->getMessage(),
+                                'data' => [],
+                            ], JSON_UNESCAPED_UNICODE));
+                    }
+                    $this->Flash->error(__($e->getMessage()));
                 } catch (\Throwable $e) {
                     $this->log('直前編集エラー: '.$e->getMessage(), 'error');
                     if ($wantsJson) {

--- a/src_web/kamaho-shokusu/src/Exception/OptimisticLockConflictException.php
+++ b/src_web/kamaho-shokusu/src/Exception/OptimisticLockConflictException.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Exception;
+
+/**
+ * オプティミスティックロック競合例外
+ *
+ * 複数ユーザーが同じレコードを同時に更新しようとした場合にスローされる。
+ * 呼び出し元はページ再読込を促すメッセージを返すべき。
+ */
+final class OptimisticLockConflictException extends \RuntimeException
+{
+    public function __construct(string $message = '他のユーザーが先に保存しました。ページを再読込して再試行してください。')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Exception\OptimisticLockConflictException;
 use Cake\I18n\DateTime;
 use Cake\ORM\Table;
 
@@ -276,7 +277,7 @@ class ReservationChangeEditService
             foreach ($rowsToUpdate as $item) {
                 $ok = $this->updateReservationRowWithVersion($reservationTable, $item['row'], $item['set']);
                 if (!$ok) {
-                    throw new \RuntimeException('optimistic_conflict');
+                    throw new OptimisticLockConflictException();
                 }
             }
 

--- a/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
+++ b/src_web/kamaho-shokusu/webroot/js/ce-change-edit.js
@@ -347,11 +347,20 @@
                         method: 'POST', headers: headers, credentials: 'same-origin',
                         body: JSON.stringify({ users: usersPayload })
                     })
-                    .then(function(res2){ return res2.json().then(function(j){ return { ok: res2.ok, j: j }; }); })
+                    .then(function(res2){ return res2.json().then(function(j){ return { ok: res2.ok, status: res2.status, j: j }; }); })
                     .then(function(pair2){
-                        var ok2 = pair2.ok, json2 = pair2.j;
+                        var ok2 = pair2.ok, json2 = pair2.j, httpStatus = pair2.status;
                         if (!ok2 || !json2 || json2.status !== 'success'){
-                            alert((json2 && json2.message) || '直前予約の更新に失敗しました。');
+                            var msg = (json2 && json2.message) || '直前予約の更新に失敗しました。';
+                            // 409 競合の場合はページリロードを促す
+                            if (httpStatus === 409 || (json2 && json2.status === 'conflict')) {
+                                if (confirm(msg + '\n\nページを再読込しますか？')) {
+                                    window.location.reload();
+                                    return;
+                                }
+                            } else {
+                                alert(msg);
+                            }
                             if (saveBtn)    saveBtn.disabled = false;
                             if (saveSpinner) saveSpinner.style.display = 'none';
                             return;


### PR DESCRIPTION
Closes #164

## 変更内容
- `App\Exception\OptimisticLockConflictException` を新規作成し、競合を汎用の `RuntimeException` と区別可能に
- `ReservationChangeEditService` で `RuntimeException('optimistic_conflict')` を `OptimisticLockConflictException` に置き換え
- `TReservationInfoController` で競合専用のcatchブロックを追加し、HTTP 409 + 「他のユーザーが先に保存しました。ページを再読込して再試行してください。」メッセージを返却
- `ce-change-edit.js` で409レスポンス受信時に `confirm` ダイアログを表示し、OKでページ再読込を促す