### PR TITLE
Resolve #166: buildUsersForJsonの$isAdmin変数名を$canEditAllに変更

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -117,12 +117,16 @@ class ReservationChangeEditService
 
     public function buildUsersForJson(array $users, $loginUser): array
     {
-        $isAdmin  = ($loginUser && ($loginUser->get('i_admin') === 1 || (int)$loginUser->get('i_user_level') === 0));
+        // 管理者（i_admin=1）または職員（i_user_level=0）は全ユーザーを編集できる
+        $canEditAll = $loginUser && (
+            (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
+            (int)($loginUser->get('i_user_level') ?? -1) === 0
+        );
         $loginUid = $loginUser?->get('i_id_user');
 
         $usersForJson = [];
         foreach ($users as $u) {
-            $allowEdit = $isAdmin || ($loginUid && (int)$loginUid === (int)$u['id']);
+            $allowEdit = $canEditAll || ($loginUid && (int)$loginUid === (int)$u['id']);
             $usersForJson[] = [
                 'id'           => $u['id'],
                 'name'         => $u['name'],


### PR DESCRIPTION
Closes #166

## 変更内容
- `ReservationChangeEditService::buildUsersForJson()` 内の `$isAdmin` を `$canEditAll` にリネーム
- 「管理者または職員は全ユーザーを編集できる」という意図をコメントで明示
- 動作変更なし（純粋なリファクタリング）