### PR TITLE
Resolve #187: お問い合わせ機能の強化（Slack通知・自動返信メール・管理者返信）

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,7 +34,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 20m
-          envs: REPO_URL,BRANCH,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,DB_CONTAINER
+          envs: REPO_URL,BRANCH,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,DB_CONTAINER,RESEND_API_KEY
           script: |
             set -euo pipefail
 
@@ -69,6 +69,20 @@ jobs:
               "${DB_ROOT_PASS}" \
               sql/updates
 
+            # ── CakePHP マイグレーション実行 ──────────────────────────────────
+            echo "── Running CakePHP migrations ───────────────────────────────────"
+            cd "$DEPLOY_PATH/src_web/kamaho-shokusu"
+            php bin/cake migrations migrate
+            cd "$DEPLOY_PATH"
+
+            # ── .env に RESEND_API_KEY を注入 ──────────────────────────────────
+            ENV_FILE="$DEPLOY_PATH/.env"
+            if grep -q "^RESEND_API_KEY=" "$ENV_FILE" 2>/dev/null; then
+              sed -i "s|^RESEND_API_KEY=.*|RESEND_API_KEY=${RESEND_API_KEY}|" "$ENV_FILE"
+            else
+              echo "RESEND_API_KEY=${RESEND_API_KEY}" >> "$ENV_FILE"
+            fi
+
             echo "✅ Deployed: $(git rev-parse --short HEAD) @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
         env:
           REPO_URL:     ${{ secrets.REPO_URL }}
@@ -77,7 +91,8 @@ jobs:
           DB_USER:      ${{ secrets.DB_USER }}
           DB_PASS:      ${{ secrets.DB_PASS }}
           DB_ROOT_PASS: ${{ secrets.DB_ROOT_PASS }}
-          DB_CONTAINER: ${{ secrets.DB_CONTAINER }}
+          DB_CONTAINER:    ${{ secrets.DB_CONTAINER }}
+          RESEND_API_KEY:  ${{ secrets.RESEND_API_KEY }}
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,7 +34,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 20m
-          envs: REPO_URL,BRANCH,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,DB_CONTAINER,RESEND_API_KEY
+          envs: REPO_URL,BRANCH,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,DB_CONTAINER,RESEND_API_KEY,SLACK_CONTACT_WEBHOOK
           script: |
             set -euo pipefail
 
@@ -83,6 +83,12 @@ jobs:
               echo "RESEND_API_KEY=${RESEND_API_KEY}" >> "$ENV_FILE"
             fi
 
+            if grep -q "^SLACK_CONTACT_WEBHOOK=" "$ENV_FILE" 2>/dev/null; then
+              sed -i "s|^SLACK_CONTACT_WEBHOOK=.*|SLACK_CONTACT_WEBHOOK=${SLACK_CONTACT_WEBHOOK}|" "$ENV_FILE"
+            else
+              echo "SLACK_CONTACT_WEBHOOK=${SLACK_CONTACT_WEBHOOK}" >> "$ENV_FILE"
+            fi
+
             echo "✅ Deployed: $(git rev-parse --short HEAD) @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
         env:
           REPO_URL:     ${{ secrets.REPO_URL }}
@@ -92,7 +98,8 @@ jobs:
           DB_PASS:      ${{ secrets.DB_PASS }}
           DB_ROOT_PASS: ${{ secrets.DB_ROOT_PASS }}
           DB_CONTAINER:    ${{ secrets.DB_CONTAINER }}
-          RESEND_API_KEY:  ${{ secrets.RESEND_API_KEY }}
+          RESEND_API_KEY:          ${{ secrets.RESEND_API_KEY }}
+          SLACK_CONTACT_WEBHOOK:   ${{ secrets.SLACK_CONTACT_WEBHOOK }}
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2

--- a/src_web/kamaho-shokusu/config/Migrations/20260501000000_CreateTContactReplies.php
+++ b/src_web/kamaho-shokusu/config/Migrations/20260501000000_CreateTContactReplies.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class CreateTContactReplies extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('t_contact_replies');
+        $table
+            ->addColumn('contact_id', 'integer', ['null' => false])
+            ->addColumn('body', 'text', ['null' => false])
+            ->addColumn('sent_at', 'datetime', ['null' => false])
+            ->addColumn('created', 'datetime', ['null' => false])
+            ->addColumn('modified', 'datetime', ['null' => false])
+            ->addForeignKey('contact_id', 't_contacts', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'NO_ACTION',
+            ])
+            ->create();
+    }
+}

--- a/src_web/kamaho-shokusu/config/app_local.example.php
+++ b/src_web/kamaho-shokusu/config/app_local.example.php
@@ -83,12 +83,22 @@ return [
      */
     'EmailTransport' => [
         'default' => [
-            'host' => 'localhost',
-            'port' => 25,
-            'username' => null,
-            'password' => null,
+            'className' => 'Smtp',
+            'host' => 'smtp.resend.com',
+            'port' => 465,
+            'username' => 'resend',
+            'password' => env('RESEND_API_KEY', ''),
+            'tls' => true,
             'client' => null,
             'url' => env('EMAIL_TRANSPORT_DEFAULT_URL', null),
+        ],
+    ],
+    'Email' => [
+        'default' => [
+            'transport' => 'default',
+            'from' => ['no-reply@kamaho-shokusu.jp' => 'かまほ食数管理システム'],
+            'charset' => 'utf-8',
+            'headerCharset' => 'utf-8',
         ],
     ],
 ];

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -285,6 +285,9 @@ return function (RouteBuilder $routes): void {
         // フィードバック・お問い合わせ
         $builder->connect('/Contacts', ['controller' => 'Contacts', 'action' => 'index']);
         $builder->connect('/Contacts/admin', ['controller' => 'Contacts', 'action' => 'adminIndex'])->setMethods(['GET']);
+        $builder->connect('/Contacts/admin/{id}', ['controller' => 'Contacts', 'action' => 'adminDetail'])
+            ->setPass(['id'])
+            ->setPatterns(['id' => '\d+']);
 
         // フォールバック
         $builder->fallbacks();

--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Model\Table\TContactsTable;
 use App\Service\ContactService;
 use Cake\Http\Response;
 
@@ -78,6 +77,41 @@ class ContactsController extends AppController
         $contacts = $this->contactService->getList($page);
 
         $this->set(compact('contacts', 'page'));
+        return null;
+    }
+
+    /**
+     * 管理者用：問い合わせ詳細・返信送信
+     */
+    public function adminDetail(int $id): ?Response
+    {
+        $this->Authorization->skipAuthorization();
+
+        $user = $this->Authentication->getIdentity();
+        if ($user === null) {
+            return $this->redirect('/MUserInfo/login');
+        }
+
+        if ((int)$user->get('i_admin') !== 1) {
+            $this->Flash->error('管理者のみアクセスできます。');
+            return $this->redirect('/');
+        }
+
+        $contact = $this->contactService->getDetail($id);
+
+        if ($this->request->is('post')) {
+            $replyBody = (string)($this->request->getData('reply_body') ?? '');
+            $result = $this->contactService->sendReply($id, $replyBody);
+
+            if ($result['success']) {
+                $this->Flash->success('返信を送信しました。');
+                return $this->redirect(['action' => 'adminDetail', $id]);
+            }
+
+            $this->Flash->error('返信の送信に失敗しました。');
+        }
+
+        $this->set(compact('contact'));
         return null;
     }
 }

--- a/src_web/kamaho-shokusu/src/Model/Entity/TContactReply.php
+++ b/src_web/kamaho-shokusu/src/Model/Entity/TContactReply.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use Cake\I18n\DateTime;
+use Cake\ORM\Entity;
+
+/**
+ * @property int $id
+ * @property int $contact_id
+ * @property string $body
+ * @property DateTime $sent_at
+ * @property DateTime $created
+ * @property DateTime $modified
+ */
+class TContactReply extends Entity
+{
+    protected array $_accessible = [
+        'contact_id' => true,
+        'body'       => true,
+        'sent_at'    => true,
+    ];
+}

--- a/src_web/kamaho-shokusu/src/Model/Table/TContactRepliesTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/TContactRepliesTable.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+class TContactRepliesTable extends Table
+{
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('t_contact_replies');
+        $this->setPrimaryKey('id');
+        $this->addBehavior('Timestamp');
+
+        $this->belongsTo('TContacts', [
+            'foreignKey' => 'contact_id',
+        ]);
+    }
+
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('contact_id')
+            ->notEmptyString('contact_id');
+
+        $validator
+            ->scalar('body')
+            ->minLength('body', 1, '返信内容を入力してください。')
+            ->maxLength('body', 5000, '返信内容は5000文字以内で入力してください。')
+            ->requirePresence('body', 'create')
+            ->notEmptyString('body', '返信内容は必須です。');
+
+        return $validator;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Model/Table/TContactsTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/TContactsTable.php
@@ -22,6 +22,11 @@ class TContactsTable extends Table
         $this->setTable('t_contacts');
         $this->setPrimaryKey('id');
         $this->addBehavior('Timestamp');
+
+        $this->hasMany('TContactReplies', [
+            'foreignKey' => 'contact_id',
+            'dependent'  => true,
+        ]);
     }
 
     public function validationDefault(Validator $validator): Validator

--- a/src_web/kamaho-shokusu/src/Service/ContactService.php
+++ b/src_web/kamaho-shokusu/src/Service/ContactService.php
@@ -149,7 +149,7 @@ class ContactService
      */
     private function notifySlack(\App\Model\Entity\TContact $entity): void
     {
-        $webhookUrl = env('SLACK_WEBHOOK', '');
+        $webhookUrl = env('SLACK_CONTACT_WEBHOOK', '');
         if ($webhookUrl === '') {
             return;
         }

--- a/src_web/kamaho-shokusu/src/Service/ContactService.php
+++ b/src_web/kamaho-shokusu/src/Service/ContactService.php
@@ -3,23 +3,51 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Model\Table\TContactRepliesTable;
 use App\Model\Table\TContactsTable;
+use Cake\Http\Client;
+use Cake\I18n\DateTime;
 use Cake\Mailer\Mailer;
 use Cake\ORM\TableRegistry;
 
 class ContactService
 {
     private TContactsTable $contacts;
+    private TContactRepliesTable $replies;
+
+    /** カテゴリ別の自動返信メール文面 */
+    private const AUTO_REPLY_TEMPLATES = [
+        'ご意見・ご要望' => [
+            'subject' => '【食数管理システム】ご意見・ご要望を受け付けました',
+            'message' => "この度はご意見・ご要望をお寄せいただき、誠にありがとうございます。\n\nいただいたご意見は、サービス改善の参考にさせていただきます。\n今後ともかまほ食数管理システムをよろしくお願いいたします。",
+        ],
+        '不具合報告' => [
+            'subject' => '【食数管理システム】不具合報告を受け付けました',
+            'message' => "不具合のご報告をいただき、誠にありがとうございます。\n\n担当者が内容を確認し、早急に対応いたします。\n解決までいましばらくお待ちください。",
+        ],
+        '使い方の質問' => [
+            'subject' => '【食数管理システム】お問い合わせを受け付けました',
+            'message' => "お問い合わせいただき、誠にありがとうございます。\n\n担当者が内容を確認の上、順次ご回答いたします。\n今しばらくお待ちくださいますようお願いいたします。",
+        ],
+        'その他' => [
+            'subject' => '【食数管理システム】お問い合わせを受け付けました',
+            'message' => "お問い合わせいただき、誠にありがとうございます。\n\n内容を確認の上、担当者よりご連絡いたします。",
+        ],
+    ];
 
     public function __construct()
     {
         /** @var TContactsTable $table */
         $table = TableRegistry::getTableLocator()->get('TContacts');
         $this->contacts = $table;
+
+        /** @var TContactRepliesTable $replies */
+        $replies = TableRegistry::getTableLocator()->get('TContactReplies');
+        $this->replies = $replies;
     }
 
     /**
-     * 問い合わせを保存してメールを送信する。
+     * 問い合わせを保存してSlack通知・自動返信メールを送信する。
      *
      * @param array $data フォームデータ
      * @param int|null $userId ログインユーザーID
@@ -43,11 +71,19 @@ class ContactService
             return ['success' => false, 'entity' => $entity];
         }
 
-        // 管理者への通知メール（失敗しても保存成功として扱う）
+        try {
+            $this->notifySlack($entity);
+        } catch (\Throwable) {
+        }
+
+        try {
+            $this->sendAutoReply($entity);
+        } catch (\Throwable) {
+        }
+
         try {
             $this->sendAdminNotification($entity);
-        } catch (\Throwable $e) {
-            // メール送信失敗はログのみ
+        } catch (\Throwable) {
         }
 
         return ['success' => true, 'entity' => $entity];
@@ -59,10 +95,149 @@ class ContactService
     public function getList(int $page = 1, int $limit = 30): array
     {
         return $this->contacts->find()
+            ->contain(['TContactReplies'])
             ->orderByDesc('created')
             ->limit($limit)
             ->page($page)
             ->toArray();
+    }
+
+    /**
+     * 問い合わせ1件を返信付きで取得する。
+     *
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException
+     */
+    public function getDetail(int $contactId): \App\Model\Entity\TContact
+    {
+        /** @var \App\Model\Entity\TContact */
+        return $this->contacts->find()
+            ->contain(['TContactReplies' => fn($q) => $q->orderByAsc('created')])
+            ->where(['TContacts.id' => $contactId])
+            ->firstOrFail();
+    }
+
+    /**
+     * 管理者から問い合わせ者へ返信メールを送信し、履歴を保存する。
+     *
+     * @return array{success: bool, errors: array}
+     */
+    public function sendReply(int $contactId, string $replyBody): array
+    {
+        $contact = $this->getDetail($contactId);
+
+        $reply = $this->replies->newEntity([
+            'contact_id' => $contactId,
+            'body'       => trim($replyBody),
+            'sent_at'    => new DateTime(),
+        ]);
+
+        if ($reply->getErrors()) {
+            return ['success' => false, 'errors' => $reply->getErrors()];
+        }
+
+        if (!$this->replies->save($reply)) {
+            return ['success' => false, 'errors' => ['save' => '保存に失敗しました。']];
+        }
+
+        $this->sendReplyMail($contact, trim($replyBody));
+
+        return ['success' => true, 'errors' => []];
+    }
+
+    /**
+     * Slackへ問い合わせ内容を通知する。
+     */
+    private function notifySlack(\App\Model\Entity\TContact $entity): void
+    {
+        $webhookUrl = env('SLACK_WEBHOOK', '');
+        if ($webhookUrl === '') {
+            return;
+        }
+
+        $text = implode("\n", [
+            ':mailbox_with_mail: *新しいお問い合わせが届きました*',
+            '>*カテゴリ：* ' . $entity->category,
+            '>*お名前：* ' . $entity->name,
+            '>*メール：* ' . $entity->email,
+            '>*内容：*',
+            '>```' . $entity->body . '```',
+        ]);
+
+        $http = new Client();
+        $http->post($webhookUrl, json_encode(['text' => $text]), [
+            'type' => 'json',
+        ]);
+    }
+
+    /**
+     * カテゴリに応じた自動返信メールを送信する。
+     */
+    private function sendAutoReply(\App\Model\Entity\TContact $entity): void
+    {
+        if (empty($entity->email)) {
+            return;
+        }
+
+        $template = self::AUTO_REPLY_TEMPLATES[$entity->category]
+            ?? self::AUTO_REPLY_TEMPLATES['その他'];
+
+        $body = implode("\n", [
+            $entity->name . ' 様',
+            '',
+            $template['message'],
+            '',
+            '─────────────────────────────',
+            '【お問い合わせ内容】',
+            'カテゴリ：' . $entity->category,
+            '',
+            $entity->body,
+            '─────────────────────────────',
+            'かまほ食数管理システム',
+            'no-reply@kamaho-shokusu.jp',
+        ]);
+
+        $mailer = new Mailer('default');
+        $mailer
+            ->setTo($entity->email, $entity->name)
+            ->setSubject($template['subject'])
+            ->setEmailFormat('text')
+            ->deliver($body);
+    }
+
+    /**
+     * 管理者から問い合わせ者へ返信メールを送信する。
+     */
+    private function sendReplyMail(\App\Model\Entity\TContact $contact, string $replyBody): void
+    {
+        if (empty($contact->email)) {
+            return;
+        }
+
+        $body = implode("\n", [
+            $contact->name . ' 様',
+            '',
+            'お問い合わせいただきありがとうございます。',
+            '以下の通りご回答申し上げます。',
+            '',
+            '─────────────────────────────',
+            $replyBody,
+            '─────────────────────────────',
+            '',
+            '【元のお問い合わせ内容】',
+            'カテゴリ：' . $contact->category,
+            $contact->body,
+            '─────────────────────────────',
+            'かまほ食数管理システム サポート',
+            'support@kamaho-shokusu.jp',
+        ]);
+
+        $mailer = new Mailer('default');
+        $mailer
+            ->setFrom(['support@kamaho-shokusu.jp' => 'かまほ食数管理システム サポート'])
+            ->setTo($contact->email, $contact->name)
+            ->setSubject('[食数管理システム] Re: ' . $contact->category . 'について')
+            ->setEmailFormat('text')
+            ->deliver($body);
     }
 
     /**

--- a/src_web/kamaho-shokusu/templates/Contacts/admin_detail.php
+++ b/src_web/kamaho-shokusu/templates/Contacts/admin_detail.php
@@ -1,0 +1,75 @@
+<?php
+/** @var \App\View\AppView $this */
+/** @var \App\Model\Entity\TContact $contact */
+$this->assign('title', 'お問い合わせ詳細');
+?>
+
+<div class="d-flex align-items-center mb-3 gap-2">
+    <a href="<?= $this->Url->build(['action' => 'adminIndex']) ?>" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left me-1"></i>一覧へ戻る
+    </a>
+    <h5 class="fw-semibold mb-0">
+        <i class="bi bi-envelope-open me-2 text-primary"></i>お問い合わせ詳細
+    </h5>
+</div>
+
+<!-- 問い合わせ内容 -->
+<div class="card mb-4">
+    <div class="card-header bg-light">
+        <span class="badge bg-secondary me-2"><?= h($contact->category) ?></span>
+        <span class="text-muted small"><?= h($contact->created->format('Y-m-d H:i')) ?></span>
+    </div>
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-2">お名前</dt>
+            <dd class="col-sm-10"><?= h($contact->name) ?></dd>
+            <dt class="col-sm-2">メール</dt>
+            <dd class="col-sm-10">
+                <a href="mailto:<?= h($contact->email) ?>"><?= h($contact->email) ?></a>
+            </dd>
+            <dt class="col-sm-2">内容</dt>
+            <dd class="col-sm-10">
+                <div style="white-space: pre-wrap;"><?= h($contact->body) ?></div>
+            </dd>
+        </dl>
+    </div>
+</div>
+
+<!-- 返信履歴 -->
+<?php if (!empty($contact->t_contact_replies)): ?>
+    <h6 class="fw-semibold mb-2">返信履歴</h6>
+    <?php foreach ($contact->t_contact_replies as $reply): ?>
+        <div class="card mb-2 border-start border-primary border-3">
+            <div class="card-body py-2">
+                <div class="text-muted small mb-1"><?= h($reply->sent_at->format('Y-m-d H:i')) ?> 送信</div>
+                <div style="white-space: pre-wrap;"><?= h($reply->body) ?></div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<!-- 返信フォーム -->
+<div class="card mt-4">
+    <div class="card-header bg-light fw-semibold">
+        <i class="bi bi-reply me-1"></i>返信を送る
+    </div>
+    <div class="card-body">
+        <?= $this->Form->create(null, ['url' => ['action' => 'adminDetail', $contact->id]]) ?>
+        <div class="mb-3">
+            <label class="form-label">返信内容 <span class="text-danger">*</span></label>
+            <?= $this->Form->textarea('reply_body', [
+                'class' => 'form-control',
+                'rows'  => 8,
+                'placeholder' => '返信内容を入力してください...',
+                'required' => true,
+            ]) ?>
+            <div class="form-text">
+                送信先：<?= h($contact->email) ?>（<?= h($contact->name) ?> 様）
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">
+            <i class="bi bi-send me-1"></i>返信を送信する
+        </button>
+        <?= $this->Form->end() ?>
+    </div>
+</div>

--- a/src_web/kamaho-shokusu/templates/Contacts/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Contacts/admin_index.php
@@ -21,6 +21,7 @@ $this->assign('title', 'お問い合わせ一覧（管理者）');
                     <th style="width: 110px;">お名前</th>
                     <th>メール</th>
                     <th>内容</th>
+                    <th style="width: 80px;"></th>
                 </tr>
             </thead>
             <tbody>
@@ -37,12 +38,15 @@ $this->assign('title', 'お問い合わせ一覧（管理者）');
                             </a>
                         </td>
                         <td>
-                            <details>
-                                <summary class="text-muted small" style="cursor: pointer;">
-                                    <?= h(mb_substr($contact->body, 0, 40)) ?><?= mb_strlen($contact->body) > 40 ? '…' : '' ?>
-                                </summary>
-                                <div class="mt-2 small" style="white-space: pre-wrap;"><?= h($contact->body) ?></div>
-                            </details>
+                            <span class="text-muted small">
+                                <?= h(mb_substr($contact->body, 0, 40)) ?><?= mb_strlen($contact->body) > 40 ? '…' : '' ?>
+                            </span>
+                        </td>
+                        <td>
+                            <a href="<?= $this->Url->build(['action' => 'adminDetail', $contact->id]) ?>"
+                               class="btn btn-outline-primary btn-sm">
+                                詳細・返信
+                            </a>
                         </td>
                     </tr>
                 <?php endforeach; ?>


### PR DESCRIPTION
Closes #187

## 変更内容

### Slack通知
- お問い合わせ受信時に `SLACK_WEBHOOK`（GitHub Secrets）経由でSlackへ自動通知
- 通知内容：カテゴリ・お名前・メールアドレス・本文

### 自動返信メール
- カテゴリ（ご意見・ご要望 / 不具合報告 / 使い方の質問 / その他）に応じて返信文面を切り替え
- Resend SMTP経由で送信（`RESEND_API_KEY` を GitHub Secrets・`.env` で管理）

### 管理者返信機能
- 管理画面（`/Contacts/admin/{id}`）から問い合わせ者へ返信メールを送信可能
- 返信履歴を `t_contact_replies` テーブルに保存・管理画面で確認可能
- 送信元：`support@kamaho-shokusu.jp`

### インフラ・設定
- `t_contact_replies` テーブルのマイグレーション追加
- デプロイ時に `bin/cake migrations migrate` を自動実行
- `deployment.yml` に `RESEND_API_KEY` の `.env` 注入処理を追加
- `app_local.example.php` に Resend SMTP 設定テンプレートを追記

## 事前対応（別途手動）
- Resend管理画面での `kamaho-shokusu.jp` ドメイン認証（DNS設定）
- GitHub Secrets への `RESEND_API_KEY` 登録（設定済み）