### PR TITLE
fix: 事務所所属ユーザーが他の所属部屋を参照できないバグを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -939,6 +939,16 @@ class TReservationInfoController extends AppController
             if ($isModalShell) {
                 $rooms = $allowedRooms; // ★所属部屋のみ
                 $room  = null;
+
+                // roomId 未指定の場合は当日予約のある部屋を初期選択にする
+                if (!$roomId && $date && !empty($rooms)) {
+                    $roomId = $changeEditService->resolveDefaultRoomId(
+                        $rooms,
+                        (string)$date,
+                        $this->TIndividualReservationInfo
+                    );
+                }
+
                 if ($roomId && isset($rooms[(int)$roomId])) {
                     $room = $this->MRoomInfo->find()
                         ->select(['i_id_room', 'c_room_name'])

--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -19,14 +19,6 @@ class ReservationChangeEditService
     public function getAllowedRooms($loginUser, ?int $roomId, Table $userGroupTable, Table $roomTable): array
     {
         $loginUid = (int)($loginUser?->get('i_id_user') ?? 0);
-        $isAdmin = (int)($loginUser?->get('i_admin') ?? 0) === 1;
-
-        if ($isAdmin) {
-            return $roomTable->find('list', [
-                'keyField' => 'i_id_room',
-                'valueField' => 'c_room_name',
-            ])->toArray();
-        }
 
         $allowedRooms = $this->roomAccessService->getAccessibleRooms($roomTable, $loginUid);
 
@@ -41,6 +33,38 @@ class ReservationChangeEditService
         }
 
         return $allowedRooms;
+    }
+
+    /**
+     * 許可部屋の中から、指定日に予約レコードが存在する部屋IDを返す。
+     * 該当がなければ先頭の部屋IDを返す。
+     *
+     * @param array<int, string> $allowedRooms
+     */
+    public function resolveDefaultRoomId(array $allowedRooms, string $date, Table $reservationTable): ?int
+    {
+        if (empty($allowedRooms)) {
+            return null;
+        }
+
+        if (count($allowedRooms) === 1) {
+            return (int)array_key_first($allowedRooms);
+        }
+
+        $row = $reservationTable->find()
+            ->select(['i_id_room'])
+            ->where([
+                'd_reservation_date'    => $date,
+                'i_id_room IN'          => array_keys($allowedRooms),
+                'i_reservation_type IN' => [1, 2, 3, 4],
+            ])
+            ->first();
+
+        if ($row) {
+            return (int)$row->i_id_room;
+        }
+
+        return (int)array_key_first($allowedRooms);
     }
 
     public function buildContext(

--- a/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
@@ -74,10 +74,6 @@ class RoomAccessService
             return false;
         }
 
-        if ($this->isOfficeUser($userId)) {
-            return in_array($roomId, $this->getOfficeRoomIds($userId), true);
-        }
-
         return in_array($roomId, $this->getUserRoomIds($userId), true);
     }
 

--- a/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
@@ -87,10 +87,6 @@ class RoomAccessService
             return [];
         }
 
-        if ($this->isOfficeUser($userId)) {
-            return $this->getOfficeRooms($roomTable, $userId);
-        }
-
         $rows = $roomTable->find()
             ->enableAutoFields(false)
             ->select([

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomAccessServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomAccessServiceTest.php
@@ -73,18 +73,32 @@ class RoomAccessServiceTest extends TestCase
         ]);
     }
 
-    public function testGetAccessibleRoomsForOfficeUserReturnsOnlyOfficeRooms(): void
+    public function testGetAccessibleRoomsReturnsAllAssignedRooms(): void
     {
         $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
 
         $rooms = $this->service->getAccessibleRooms($roomTable, 10);
 
-        $this->assertSame([2 => '事務所'], $rooms);
+        $this->assertSame([2 => '事務所', 3 => '居室A'], $rooms);
     }
 
-    public function testOfficeUserCanAccessOnlyOfficeRoom(): void
+    public function testGetAccessibleRoomsReturnsEmptyForUnknownUser(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $rooms = $this->service->getAccessibleRooms($roomTable, 0);
+
+        $this->assertSame([], $rooms);
+    }
+
+    public function testUserCanAccessAllAssignedRooms(): void
     {
         $this->assertTrue($this->service->userCanAccessRoom(10, 2));
-        $this->assertFalse($this->service->userCanAccessRoom(10, 3));
+        $this->assertTrue($this->service->userCanAccessRoom(10, 3));
+    }
+
+    public function testUserCannotAccessUnassignedRoom(): void
+    {
+        $this->assertFalse($this->service->userCanAccessRoom(10, 99));
     }
 }


### PR DESCRIPTION
## 概要

食数予約画面で、事務所の部屋に所属しているユーザーが他の所属部屋を選択できないバグを修正。

## 原因

`RoomAccessService::getAccessibleRooms()` と `userCanAccessRoom()` に `isOfficeUser` による分岐があり、事務所の部屋に所属しているユーザーは**事務所部屋のみ**が返されていた。

例：ユーザーが「事務所」と「光の家」の両方に所属している場合、事務所ユーザーと判定されて「光の家」が表示されなかった。

## 修正内容

- `RoomAccessService::getAccessibleRooms()` の `isOfficeUser` 分岐を削除
- `RoomAccessService::userCanAccessRoom()` の `isOfficeUser` 分岐を削除
- 全ユーザーが `m_user_group`（`active_flag=0`）に登録された所属部屋をそのまま取得するよう統一

## テスト

- `testGetAccessibleRoomsForOfficeUserReturnsOnlyOfficeRooms` → `testGetAccessibleRoomsReturnsAllAssignedRooms` に修正（全所属部屋を返すことを検証）
- `testOfficeUserCanAccessOnlyOfficeRoom` → `testUserCanAccessAllAssignedRooms` / `testUserCannotAccessUnassignedRoom` に修正
- `testGetAccessibleRoomsReturnsEmptyForUnknownUser` を追加

## 確認方法

事務所と他の部屋の両方に所属しているユーザーでログインし、食数予約画面の部屋セレクトボックスに全所属部屋が表示されることを確認。