### PR TITLE
ci: PRのソースブランチを検証するワークフローを追加

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -1,0 +1,33 @@
+name: Branch Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  branch-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch for PR to main
+        if: github.base_ref == 'main'
+        run: |
+          if [[ "${{ github.head_ref }}" != release/* ]]; then
+            echo "ERROR: main へのPRは release/* ブランチからのみ許可されています。"
+            echo "現在のブランチ: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "OK: ${{ github.head_ref }} -> main"
+
+      - name: Check source branch for PR to develop
+        if: github.base_ref == 'develop'
+        run: |
+          if [[ "${{ github.head_ref }}" != feature/* ]] && \
+             [[ "${{ github.head_ref }}" != fix/* ]] && \
+             [[ "${{ github.head_ref }}" != hotfix/* ]]; then
+            echo "ERROR: develop へのPRは feature/・fix/・hotfix/ ブランチからのみ許可されています。"
+            echo "現在のブランチ: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "OK: ${{ github.head_ref }} -> develop"


### PR DESCRIPTION
## 概要

develop・main へのPRのソースブランチを自動検証するGitHub Actionsワークフローを追加。

## ルール

| ベースブランチ | 許可されるソースブランチ |
|---|---|
| `develop` | `feature/*` / `fix/*` / `hotfix/*` |
| `main` | `release/*` |

## ブランチ保護ルール（別途設定済み）

`develop` / `main` ともに以下を必須化：
- このワークフロー（`branch-check`）の通過
- PHPUnit の通過
- レビュー承認 1人