### PR TITLE
refactor: #191 Fat Controller 解消 - ビジネスロジックをService層へ分離

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MMealPriceInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MMealPriceInfoController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\ApiResponseService;
+use App\Service\MealSummaryExportService;
 use Authorization\Exception\ForbiddenException;
 
 /**
@@ -14,17 +15,13 @@ class MMealPriceInfoController extends AppController
 {
 
     protected $MMealPriceInfo;
-    protected $TIndividualReservationInfo;
-    protected $MUserInfo;
-
-
+    private MealSummaryExportService $mealSummaryExportService;
 
     public function initialize(): void
     {
         parent::initialize();
         $this->MMealPriceInfo = $this->fetchTable('MMealPriceInfo');
-        $this->TIndividualReservationInfo = $this->fetchTable('TIndividualReservationInfo');
-        $this->MUserInfo = $this->fetchTable('MUserInfo');
+        $this->mealSummaryExportService = new MealSummaryExportService();
     }
 
     /**
@@ -184,87 +181,10 @@ class MMealPriceInfoController extends AppController
         $this->autoRender = false;
         $apiResponse = new ApiResponseService();
 
-        // リクエストから年度と月を取得
-        $year = $this->request->getQuery('year', date('Y'));
-        $month = $this->request->getQuery('month', date('n')); // 月が指定されていなければ現在の月をデフォルトとする
+        $year  = (int)$this->request->getQuery('year', date('Y'));
+        $month = (int)$this->request->getQuery('month', date('n'));
 
-        // 食事単価を取得 (年度単位)
-        $mealPricesData = $this->MMealPriceInfo->find()
-            ->select(['i_morning_price', 'i_lunch_price', 'i_dinner_price', 'i_bento_price'])
-            ->where(['i_fiscal_year' => $year])
-            ->first();
-
-        $mealPrices = [
-            'morning' => $mealPricesData->i_morning_price ?? 0,
-            'lunch'   => $mealPricesData->i_lunch_price ?? 0,
-            'dinner'  => $mealPricesData->i_dinner_price ?? 0,
-            'bento'   => $mealPricesData->i_bento_price ?? 0,
-        ];
-
-        // 職員IDが存在するユーザーを取得
-        $users = $this->MUserInfo->find()
-            ->select(['i_id_user', 'c_user_name', 'i_id_staff'])
-            ->where(['i_id_staff IS NOT' => null,'i_del_flag' => 0]) // 職員IDが null でないユーザー
-            ->all();
-
-        // 該当月のデータを収集
-        $monthlyData = [];
-
-        foreach ($users as $user) {
-            // 食事の回数を初期化
-            $mealCounts = [
-                'bento'   => 0,
-                'morning' => 0,
-                'lunch'   => 0,
-                'dinner'  => 0,
-            ];
-
-            // 該当ユーザーの食事の回数を集計
-            $reservationRows = $this->TIndividualReservationInfo->find()
-                ->select(['i_reservation_type', 'eat_flag', 'i_change_flag', 'i_approval_status'])
-                ->where([
-                    'i_id_user' => $user->i_id_user,
-                    'YEAR(d_reservation_date)' => $year,
-                    'MONTH(d_reservation_date)' => $month,
-                    'i_approval_status' => 2,
-                ])
-                ->toArray();
-
-            foreach ($reservationRows as $row) {
-                $effectiveFlag = $row->i_change_flag !== null
-                    ? (int)$row->i_change_flag
-                    : (int)($row->eat_flag ?? 0);
-                if ($effectiveFlag !== 1) {
-                    continue;
-                }
-
-                if ((int)$row->i_reservation_type === 4) {
-                    $mealCounts['bento']++;
-                } elseif ((int)$row->i_reservation_type === 1) {
-                    $mealCounts['morning']++;
-                } elseif ((int)$row->i_reservation_type === 2) {
-                    $mealCounts['lunch']++;
-                } elseif ((int)$row->i_reservation_type === 3) {
-                    $mealCounts['dinner']++;
-                }
-            }
-
-            // 食事料金の計算
-            $mealTotalPrice = (
-                $mealCounts['bento'] * $mealPrices['bento'] +
-                $mealCounts['morning'] * $mealPrices['morning'] +
-                $mealCounts['lunch'] * $mealPrices['lunch'] +
-                $mealCounts['dinner'] * $mealPrices['dinner']
-            );
-
-            // 結果を格納
-            $monthlyData[] = [
-                'name' => $user->c_user_name,
-                'staff_id' => $user->i_id_staff,
-                'meal_counts' => $mealCounts,
-                'total_price' => $mealTotalPrice,
-            ];
-        }
+        $monthlyData = $this->mealSummaryExportService->aggregate($year, $month);
 
         return $apiResponse->success($this->response, ['rows' => $monthlyData]);
     }

--- a/src_web/kamaho-shokusu/src/Controller/MRoomInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MRoomInfoController.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Service\RoomService;
 use Authorization\Exception\ForbiddenException;
-use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
 
 /**
@@ -14,8 +14,7 @@ use Cake\I18n\DateTime;
  */
 class MRoomInfoController extends AppController
 {
-    public $MUserGroup;
-    public $MUserInfo;
+    private RoomService $roomService;
 
     public function initialize(): void
     {
@@ -24,8 +23,7 @@ class MRoomInfoController extends AppController
         $this->viewBuilder()->setOption('serialize', true);
         $this->viewBuilder()->setLayout('default');
 
-       $this->MUserGroup = $this->fetchTable('MUserGroup');
-       $this->MUserInfo = $this->fetchTable('MUserInfo');
+        $this->roomService = new RoomService();
     }
 
     /**
@@ -58,7 +56,6 @@ class MRoomInfoController extends AppController
      */
     public function view($id = null)
     {
-        // ネームドアーギュメントを使用して部屋情報を取得しつつ、関連するユーザーグループを結合して取得
         $mRoomInfo = $this->MRoomInfo->get($id, ['contain' => ['MUserGroup']]);
         try {
             $this->Authorization->authorize($mRoomInfo, 'view');
@@ -67,22 +64,7 @@ class MRoomInfoController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        // MUserGroupが存在するかどうかをチェックし、存在しない場合は空の配列を使用
-        $userGroups = $mRoomInfo->m_user_group ? $mRoomInfo->m_user_group : [];
-
-        // ユーザーIDのリストを作成
-        $userIds = array_map(function($group) {
-            return $group->i_id_user;
-        }, $userGroups);
-
-        // 空のリストを渡さないよう、安全確保
-        if (!empty($userIds)) {
-            $users = $this->MUserInfo->find('all', [
-                'conditions' => ['MUserInfo.i_id_user IN' => $userIds],
-            ])->toArray();
-        } else {
-            $users = [];
-        }
+        $users = $this->roomService->getUsersForRoom($mRoomInfo);
 
         $this->set(compact('mRoomInfo', 'users'));
     }
@@ -104,17 +86,13 @@ class MRoomInfoController extends AppController
 
         if ($this->request->is('post')) {
             $data = $this->request->getData();
-            $mRoomInfo->dt_create = DateTime::now('Asia/Tokyo');
+            $mRoomInfo->dt_create    = DateTime::now('Asia/Tokyo');
             $user = $this->request->getAttribute('identity');
             if ($user) {
                 $mRoomInfo->c_create_user = $user->get('c_user_name');
             }
-            $mRoomInfo->i_del_flg = 0;
-            $maxDispNo = (int)($this->MRoomInfo->find()
-                ->select(['max_disp_no' => 'MAX(i_disp_no)'])
-                ->first()
-                ?->max_disp_no ?? 0);
-            $mRoomInfo->i_disp_no = $maxDispNo + 1;
+            $mRoomInfo->i_del_flg  = 0;
+            $mRoomInfo->i_disp_no  = $this->roomService->nextDisplayNo();
 
             $mRoomInfo = $this->MRoomInfo->patchEntity($mRoomInfo, $data);
 
@@ -181,14 +159,10 @@ class MRoomInfoController extends AppController
             $this->Flash->error(__('あなたは削除権限がありません。'));
             return $this->redirect(['action' => 'index']);
         }
-        $mRoomInfo->i_del_flg = 1;
-        $user = $this->request->getAttribute('identity');
-        if($user) {
-            $mRoomInfo->c_update_user = $user->get('c_user_name');
-        }
-        $mRoomInfo->dt_update = DateTime::now('Asia/Tokyo');
+        $user      = $this->request->getAttribute('identity');
+        $updatedBy = $user?->get('c_user_name');
 
-        if ($this->MRoomInfo->save($mRoomInfo)) {
+        if ($this->roomService->softDelete($mRoomInfo, $updatedBy)) {
             $this->Flash->success(__('部屋情報を削除しました。'));
         } else {
             $this->Flash->error(__('部屋情報を削除できませんでした。もう一度お試しください。'));

--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -4,15 +4,30 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\ApiResponseService;
+use App\Service\UserBulkImportService;
+use App\Service\UserCreateService;
+use App\Service\UserDeletionService;
+use App\Service\UserEditService;
+use App\Service\UserPermissionService;
+use App\Service\UserRestoreService;
+use App\Service\UserRoomAssignmentService;
 use Authorization\Exception\ForbiddenException;
 use Cake\Event\EventInterface;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\GoneException;
+
 class MUserInfoController extends AppController
 {
-    protected $MUserGroup;
     protected $MUserInfo;
     protected $MRoomInfo;
+
+    private UserBulkImportService   $userBulkImportService;
+    private UserCreateService       $userCreateService;
+    private UserDeletionService     $userDeletionService;
+    private UserEditService         $userEditService;
+    private UserPermissionService   $userPermissionService;
+    private UserRestoreService      $userRestoreService;
+    private UserRoomAssignmentService $userRoomAssignmentService;
 
     public function initialize(): void
     {
@@ -21,15 +36,21 @@ class MUserInfoController extends AppController
         $this->viewBuilder()->setLayout('default');
         $this->viewBuilder()->setOption('serialize', true);
 
-        $this->MUserGroup = $this->fetchTable('MUserGroup');
         $this->MUserInfo = $this->fetchTable('MUserInfo');
         $this->MRoomInfo = $this->fetchTable('MRoomInfo');
+
+        $this->userBulkImportService    = new UserBulkImportService();
+        $this->userCreateService        = new UserCreateService();
+        $this->userDeletionService      = new UserDeletionService();
+        $this->userEditService          = new UserEditService();
+        $this->userPermissionService    = new UserPermissionService();
+        $this->userRestoreService       = new UserRestoreService();
+        $this->userRoomAssignmentService = new UserRoomAssignmentService();
     }
 
     public function beforeFilter(EventInterface $event)
     {
         parent::beforeFilter($event);
-        // 必要に応じて importForm / importJson を追加してください
         $this->Authentication->addUnauthenticatedActions(['login']);
     }
 
@@ -45,7 +66,7 @@ class MUserInfoController extends AppController
 
         $this->viewBuilder()->setLayout('default');
         $this->viewBuilder()->setOption('serialize', true);
-        $this->set('title','ユーザー一括登録');
+        $this->set('title', 'ユーザー一括登録');
     }
 
     public function import()
@@ -56,13 +77,6 @@ class MUserInfoController extends AppController
 
     /**
      * クライアント（ブラウザ）でパース済みの JSON を受け取り登録します。
-     * 期待payload:
-     * {
-     *   "records": [
-     *     {"login_id":"u001","name":"山田 太郎","role":"職員","password":"(任意)","_row":2},
-     *     ...
-     *   ]
-     * }
      */
     public function importJson()
     {
@@ -71,7 +85,6 @@ class MUserInfoController extends AppController
         $resource = $this->MUserInfo->newEmptyEntity();
         $this->Authorization->authorize($resource, 'importJson');
 
-        // JSON 取得
         $payload = $this->request->getData();
         if (empty($payload)) {
             $payload = json_decode((string)$this->request->getBody(), true) ?? [];
@@ -81,293 +94,16 @@ class MUserInfoController extends AppController
             throw new BadRequestException('records 配列が必要です。');
         }
 
-        // i_disp_no の採番準備
-        $maxDispNoRow = $this->MUserInfo->find()
-            ->select(['max_no' => $this->MUserInfo->find()->func()->max('i_disp_no')])
-            ->first();
-        $nextDispNo = ($maxDispNoRow && $maxDispNoRow->max_no !== null)
-            ? ((int)$maxDispNoRow->max_no + 1)
-            : 1;
-
-        $results = [
-            'processed' => 0,
-            'created'   => 0,
-            'skipped'   => 0,
-            'failed'    => 0,
-            'errors'    => [] // [rowNo => [messages...]]
-        ];
-        $identity = $this->request->getAttribute('identity');
+        $identity   = $this->request->getAttribute('identity');
         $createUser = $identity ? $identity->get('c_user_name') : 'インポート';
 
-        $conn = $this->MUserInfo->getConnection();
-        $conn->begin();
-
         try {
-            foreach ($records as $rec) {
-                $rowNo    = (int)($rec['_row'] ?? 0);
-                $loginId  = trim((string)($rec['login_id'] ?? ''));
-                $name     = trim((string)($rec['name'] ?? ''));
-                $roleRaw  = (string)($rec['role'] ?? '');
-                $passRaw  = (string)($rec['password'] ?? '');
-                $staffId  = trim((string)($rec['staff_id'] ?? ''));
-                $ageRaw         = (string)($rec['age'] ?? '');
-                $genderInput    = (string)($rec['i_user_gender'] ?? ($rec['gender'] ?? ''));
-                $ageGroupInput  = (string)($rec['age_group'] ?? '');
-                $roomName1 = trim((string)($rec['room_name1'] ?? ''));
-                $roomName2 = trim((string)($rec['room_name2'] ?? ''));
-
-                // 必須チェック（role 必須）
-                if ($loginId === '' || $name === '' || $roleRaw === '') {
-                    $results['failed']++;
-                    $results['processed']++;
-                    $results['errors'][$rowNo][] = '必須項目（login_id, name, role）のいずれかが空です。';
-                    continue;
-                }
-
-                // 既存重複（c_login_account）
-                if ($this->MUserInfo->exists(['c_login_account' => $loginId])) {
-                    $results['skipped']++;
-                    $results['processed']++;
-                    $results['errors'][$rowNo][] = 'c_login_account が既に存在します。';
-                    continue;
-                }
-
-                // 役割 正規化（0:職員, 1:児童, 3:その他）: role のみ使用
-                $level = $this->normalizeRole($roleRaw);
-                if ($level === null) {
-                    $results['failed']++;
-                    $results['processed']++;
-                    $results['errors'][$rowNo][] = 'role の値が不正です（職員/児童/その他 または 0/1/3 を指定してください）。';
-                    continue;
-                }
-
-                // 職員(0) の場合は staff_id 必須
-                if ($level === 0 && $staffId === '') {
-                    $results['failed']++;
-                    $results['processed']++;
-                    $results['errors'][$rowNo][] = 'role=職員 のため staff_id が必須です。';
-                    continue;
-                }
-
-                // パスワード（未指定時は自動生成）→ ハッシュは beforeSave で実施
-                if ($passRaw === '') {
-                    $passRaw = bin2hex(random_bytes(6)); // 12桁
-                }
-
-                // 年齢 正規化（任意）
-                $ageVal = null;
-                if ($ageRaw !== '') {
-                    $ageInt = (int)$ageRaw;
-                    if ($ageInt > 0) {
-                        $ageVal = $ageInt;
-                    }
-                }
-
-                // 性別 正規化（男性=1, 女性=2 ／ 任意）
-                $genderVal = null;
-                if ($genderInput !== '') {
-                    $g = mb_strtolower(trim((string)$genderInput), 'UTF-8');
-                    if (is_numeric($g)) {
-                        $gi = (int)$g;
-                        if (in_array($gi, [1,2], true)) $genderVal = $gi;
-                    } else {
-                        if ($g === '1' || $g === '男' || $g === '男性' || $g === 'male' || $g === 'm') $genderVal = 1;
-                        if ($g === '2' || $g === '女' || $g === '女性' || $g === 'female' || $g === 'f') $genderVal = 2;
-                    }
-                }
-
-                // 年代グループ 正規化（1..7 ／ 任意）
-                $ageGroupCode = null;
-                if ($ageGroupInput !== '') {
-                    $ageGroupCode = $this->normalizeAgeGroup($ageGroupInput);
-                }
-
-                // Entity 作成
-                $newData = [
-                    'c_login_account' => $loginId,
-                    'c_user_name'     => $name,
-                    'i_user_level'    => $level,
-                    'c_login_passwd'  => $passRaw, // beforeSaveでハッシュ化
-                    'i_del_flag'      => 0,
-                    'i_enable'        => 0,
-                    'i_disp_no'       => $nextDispNo++,
-                    'dt_create'       => date('Y-m-d H:i:s'),
-                    'c_create_user'   => $createUser,
-                ];
-                if ($ageVal !== null) {
-                    $newData['i_user_age'] = $ageVal;
-                }
-                if ($genderVal !== null) {
-                    $newData['i_user_gender'] = $genderVal;
-                }
-                if ($ageGroupCode !== null) {
-                    $newData['i_user_rank'] = $ageGroupCode;
-                }
-                if ($level === 0) {
-                    $newData['i_id_staff'] = $staffId;
-                }
-
-                $entity = $this->MUserInfo->newEntity($newData);
-
-                if ($entity->getErrors()) {
-                    $results['failed']++;
-                    foreach ($entity->getErrors() as $field => $msgs) {
-                        foreach ($msgs as $msg) {
-                            $results['errors'][$rowNo][] = "{$field}: {$msg}";
-                        }
-                    }
-                    $results['processed']++;
-                    continue;
-                }
-
-                if ($this->MUserInfo->save($entity)) {
-                    $results['created']++;
-                    // 部屋名から部屋IDを検索し、MUserGroupに所属情報を登録（最大2件）
-                    $userId = $entity->i_id_user;
-                    $roomNames = [];
-                    if ($roomName1 !== '') $roomNames[] = $roomName1;
-                    if ($roomName2 !== '') $roomNames[] = $roomName2;
-                    foreach ($roomNames as $roomName) {
-                        $room = $this->MRoomInfo->find()->where(['c_room_name' => $roomName])->first();
-                        if ($room && $userId) {
-                            $userGroup = $this->MUserGroup->newEntity([
-                                'i_id_user' => $userId,
-                                'i_id_room' => $room->i_id_room,
-                                'active_flag' => 0,
-                                'dt_create' => date('Y-m-d H:i:s'),
-                                'c_create_user' => $createUser,
-                            ]);
-                            $this->MUserGroup->save($userGroup);
-                        } else if ($roomName !== '') {
-                            $results['errors'][$rowNo][] = "部屋名 '{$roomName}' が見つかりません";
-                        }
-                    }
-                } else {
-                    $results['failed']++;
-                    $results['errors'][$rowNo][] = '保存に失敗しました。';
-                }
-
-                $results['processed']++;
-            }
-
-            $conn->commit();
+            $results = $this->userBulkImportService->import($records, $createUser);
         } catch (\Throwable $e) {
-            $conn->rollback();
             throw new BadRequestException('インポート処理でエラー: ' . $e->getMessage());
         }
 
         $this->set(['ok' => true, 'summary' => $results, '_serialize' => ['ok', 'summary']]);
-    }
-
-
-    /**
-     * 役割名 → i_user_level（0:職員, 1:児童, 3:その他）へ正規化
-     * 許容:
-     *  - 数値: 0/1/3（全角数字も可）
-     *  - 日本語: 「職員/スタッフ/教職員」→0、「児童/子ども/子供/生徒/利用者/ユーザー」→1、「その他/外部/ゲスト/臨時」→3（部分一致OK）
-     *  - 英語: staff→0, child/user→1, other→3
-     */
-    private function normalizeRole(string $raw): ?int
-    {
-        // 前処理：前後空白除去・全角→半角（英数/スペース）、小文字化
-        $v = trim($raw);
-        if ($v === '') {
-            return null;
-        }
-        if (function_exists('mb_convert_kana')) {
-            // n:数字, a:英字, s:スペース を半角へ
-            $v = mb_convert_kana($v, 'nas', 'UTF-8');
-        }
-        $vLower = mb_strtolower($v, 'UTF-8');
-
-        // 1) 数値（"０"など全角数字にも対応）
-        if (is_numeric($vLower)) {
-            $n = (int)$vLower;
-            return in_array($n, [0, 1, 3], true) ? $n : null;
-        }
-
-        // 2) 完全一致（英語/日本語の代表表記）
-        $exactMap = [
-            // 0: 職員
-            'staff' => 0, '職員' => 0, 'スタッフ' => 0, '教職員' => 0,
-            // 1: 児童/利用者
-            'child' => 1, 'user' => 1, '利用者' => 1, '児童' => 1, 'こども' => 1, '子ども' => 1, '子供' => 1, '生徒' => 1, 'ユーザー' => 1,
-            // 3: その他
-            'other' => 3, 'その他' => 3, '外部' => 3, 'ゲスト' => 3, '臨時' => 3,'ボランティア'=>3
-        ];
-        if (array_key_exists($vLower, $exactMap)) {
-            return $exactMap[$vLower];
-        }
-
-        // 3) 部分一致（表記ゆれ・複合語も拾う）
-        $containsAny = function (string $haystack, array $needles): bool {
-            foreach ($needles as $needle) {
-                if ($needle === '') continue;
-                if (mb_strpos($haystack, $needle, 0, 'UTF-8') !== false) {
-                    return true;
-                }
-            }
-            return false;
-        };
-
-        // 職員系 → 0
-        if ($containsAny($vLower, ['職員', 'スタッフ', '教職員'])) {
-            return 0;
-        }
-        // 児童/利用者系 → 1
-        if ($containsAny($vLower, ['児童', '子ども', '子供', 'こども', '生徒', '利用者', 'ユーザー'])) {
-            return 1;
-        }
-        // その他/外部系 → 3
-        if ($containsAny($vLower, ['その他', '外部', 'ゲスト', '臨時'])) {
-            return 3;
-        }
-
-        // 英語の部分一致フォールバック
-        if ($containsAny($vLower, ['staff'])) return 0;
-        if ($containsAny($vLower, ['child', 'user'])) return 1;
-        if ($containsAny($vLower, ['other'])) return 3;
-
-        return null;
-    }
-
-    /**
-     * 年代（age_group）表記 → コード（1..7）へ正規化
-     * 1:3~5才, 2:低学年, 3:中学年, 4:高学年, 5:中学生, 6:高校生, 7:大人
-     */
-    private function normalizeAgeGroup(string $raw): ?int
-    {
-        $v = trim($raw);
-        if ($v === '') return null;
-
-        // 数値なら1..7のみ許可
-        if (is_numeric($v)) {
-            $n = (int)$v;
-            return ($n >= 1 && $n <= 7) ? $n : null;
-        }
-
-        if (function_exists('mb_convert_kana')) {
-            $v = mb_convert_kana($v, 'as', 'UTF-8');
-        }
-        $v = str_replace(['歳','才','　'], ['','',''], $v);
-        $vLower = mb_strtolower($v, 'UTF-8');
-
-        // マップ（部分一致許容）
-        $pairs = [
-            ['3~5', 1], ['3-5', 1], ['3〜5', 1], ['3～5', 1],
-            ['低学年', 2],
-            ['中学年', 3],
-            ['高学年', 4],
-            ['中学生', 5],
-            ['高校生', 6],
-            ['大人',   7], ['成人', 7],
-        ];
-        foreach ($pairs as [$key, $code]) {
-            if (mb_strpos($vLower, $key, 0, 'UTF-8') !== false) {
-                return $code;
-            }
-        }
-        return null;
     }
 
     public function index()
@@ -380,15 +116,11 @@ class MUserInfoController extends AppController
             return $this->redirect(['action' => 'login']);
         }
 
-        // ログインユーザー情報取得
-        $user = $this->request->getAttribute('identity');
-        $isAdmin = $user->i_admin === 1;
+        $user          = $this->request->getAttribute('identity');
+        $isAdmin       = $user->i_admin === 1;
         $currentUserId = $user->i_id_user;
+        $showDeleted   = $isAdmin && $this->request->getQuery('show_deleted') === '1';
 
-        // 削除済みユーザー表示フラグ（管理者のみ）
-        $showDeleted = $isAdmin && $this->request->getQuery('show_deleted') === '1';
-
-        // 管理者は全件、一般ユーザーは自分だけを取得
         $query = $this->MUserInfo->find()
             ->where(['i_del_flag' => $showDeleted ? 1 : 0])
             ->contain(['MUserGroup' => ['MRoomInfo']]);
@@ -397,157 +129,78 @@ class MUserInfoController extends AppController
             $query->where(['i_id_user' => $currentUserId]);
         }
 
-        $mUserInfo = $this->paginate($query,['limit' => 200,'maxLimit' => 200]);
+        $mUserInfo = $this->paginate($query, ['limit' => 200, 'maxLimit' => 200]);
 
-        // 所属部屋データの整理
         $userRooms = [];
-        foreach ($mUserInfo as $user) {
-            if (!empty($user->m_user_group)) {
-                foreach ($user->m_user_group as $group) {
+        foreach ($mUserInfo as $u) {
+            if (!empty($u->m_user_group)) {
+                foreach ($u->m_user_group as $group) {
                     if (!empty($group->m_room_info)) {
-                        $userRooms[$user->i_id_user][] = $group->m_room_info->c_room_name;
+                        $userRooms[$u->i_id_user][] = $group->m_room_info->c_room_name;
                     }
                 }
             } else {
-                $userRooms[$user->i_id_user] = [];
+                $userRooms[$u->i_id_user] = [];
             }
         }
 
-        // ビューに必要なデータを渡す
         $this->set(compact('mUserInfo', 'userRooms', 'isAdmin', 'currentUserId', 'showDeleted'));
-    }
-
-    private function getUserRooms($userId)
-    {
-        if ($userId === null) {
-            return ['未所属'];
-        }
-
-        $this->fetchTable('MUserGroup');
-        $this->fetchTable('MRoomInfo');
-
-        $userRooms = $this->MUserGroup->find()
-            ->where([
-                'MUserGroup.i_id_user' => $userId,
-                'MUserGroup.active_flag' => 0
-            ])
-            ->contain(['MRoomInfo'])
-            ->all();
-
-        if ($userRooms->isEmpty()) {
-            return ['未所属'];
-        }
-
-        $rooms = [];
-        foreach ($userRooms as $userRoom) {
-            if (!empty($userRoom->m_room_info)) {
-                $rooms[] = $userRoom->m_room_info->c_room_name;
-            }
-        }
-
-        return $rooms;
-    }
-
-    private function castGroupData(array $groupData): array {
-        return array_map(function ($group) {
-            return [
-                'i_id_room' => isset($group['i_id_room']) ? (int)$group['i_id_room'] : 0,
-                'c_create_user' => $group['c_create_user'],
-                'dt_create' => $group['dt_create']
-            ];
-        }, $groupData);
     }
 
     public function add()
     {
         $this->request->allowMethod(['get', 'post']);
 
-        // i_disp_noフィールドの最大値取得
-        $maxDispNoQuery = $this->MUserInfo->find()
-            ->select(['max_disp_no' => $this->MUserInfo->find()->func()->max('i_disp_no')])
-            ->first();
-        $maxDispNo = $maxDispNoQuery ? $maxDispNoQuery->max_disp_no + 1 : 1;
+        $maxDispNo  = $this->userCreateService->nextDisplayNo();
+        $mUserInfo  = $this->MUserInfo->newEmptyEntity();
 
-        $mUserInfo = $this->MUserInfo->newEmptyEntity();
         try {
             $this->Authorization->authorize($mUserInfo, 'add');
         } catch (ForbiddenException $e) {
             $this->Flash->error(__('あなたは追加権限がありません。'));
             return $this->redirect(['action' => 'index']);
         }
-        $mUserInfo->i_del_flag = 0;
-        $mUserInfo->dt_create = date('Y-m-d H:i:s');
-        $mUserInfo->i_enable = 0;
-        $mUserInfo->i_disp_no = $maxDispNo;
-        $mUserInfo->i_user_age = (int)$this->request->getData('age');
+
+        $mUserInfo->i_del_flag   = 0;
+        $mUserInfo->dt_create    = date('Y-m-d H:i:s');
+        $mUserInfo->i_enable     = 0;
+        $mUserInfo->i_disp_no    = $maxDispNo;
+        $mUserInfo->i_user_age   = (int)$this->request->getData('age');
         $mUserInfo->i_user_level = (int)$this->request->getData('role');
         if ($mUserInfo->i_user_level === 0) {
             $mUserInfo->i_id_staff = $this->request->getData('staff_id');
         }
         $mUserInfo->i_user_gender = (int)$this->request->getData('i_user_gender');
-        $mUserInfo->i_user_rank = (int)$this->request->getData('age_group');
+        $mUserInfo->i_user_rank   = (int)$this->request->getData('age_group');
 
         if ($this->request->is('post')) {
             $data = $this->request->getData();
 
-            // デフォルトユーザー名の設定
             if (empty($data['c_user_name'])) {
                 $data['c_user_name'] = 'デフォルトユーザー名';
             }
 
-            // ログインIDの重複チェック
-            $existingUser = $this->MUserInfo->find()
-                ->where(['c_login_account' => $data['c_login_account']])
-                ->first();
-
-            if ($existingUser) {
+            if ($this->userCreateService->loginAccountExists($data['c_login_account'])) {
                 $this->Flash->error(__('このログインIDは既に使用されています。他のIDをお試しください。'));
             } else {
-                // 作成ユーザーの設定
-                $user = $this->request->getAttribute('identity');
+                $user              = $this->request->getAttribute('identity');
                 $data['c_create_user'] = $user ? $user->get('c_user_name') : '不明なユーザー';
 
                 try {
-                    // patchEntityでMUserInfoにデータをパッチ
                     $mUserInfo = $this->MUserInfo->patchEntity($mUserInfo, $data);
 
-                    // バリデーションエラーの確認
                     if ($mUserInfo->hasErrors()) {
                         throw new \Exception('バリデーションエラーが発生しました。');
                     }
 
-                    // ユーザー情報の保存
-                    if ($this->MUserInfo->save($mUserInfo)) {
+                    $groupData = $data['MUserGroup'] ?? [];
+                    $createdBy = $user ? $user->get('c_user_name') : '不明なユーザー';
+
+                    if ($this->userCreateService->saveWithRooms($mUserInfo, $groupData, $createdBy)) {
                         $this->Flash->success(__('ユーザー情報が保存されました。'));
-                        $i_id_user = $mUserInfo->i_id_user;
-
-                        // MUserGroupデータを手動で作成・保存
-                        $userGroups = [];
-                        foreach ($data['MUserGroup'] as $groupData) {
-                            if (!empty($groupData['i_id_room'])) {
-                                $userGroups[] = $this->MUserGroup->newEntity([
-                                    'i_id_user' => (int)$i_id_user,
-                                    'i_id_room' => (int)$groupData['i_id_room'],
-                                    'active_flag' => 0,
-                                    'dt_create' => date('Y-m-d H:i:s'),
-                                    'c_create_user' => $user ? $user->get('c_user_name') : '不明なユーザー'
-                                ]);
-                            }
-                        }
-
-                        // userGroupsが空でない場合に保存を実行
-                        if (!empty($userGroups)) {
-                            if ($this->MUserGroup->saveMany($userGroups)) {
-                                $this->Flash->success(__('部屋の所属情報が保存されました。'));
-                            } else {
-                                $this->Flash->error(__('部屋の所属情報の保存に失敗しました。'));
-                            }
-                        }
-
                         return $this->redirect(['action' => 'index']);
-                    } else {
-                        $this->Flash->error(__('ユーザー情報の保存に失敗しました。もう一度お試しください。'));
                     }
+                    $this->Flash->error(__('ユーザー情報の保存に失敗しました。もう一度お試しください。'));
                 } catch (\Exception $e) {
                     $this->Flash->error(__('予期しないエラーが発生しました。もう一度お試しください。'));
                 }
@@ -555,11 +208,11 @@ class MUserInfoController extends AppController
         }
 
         $rooms = $this->MRoomInfo->find('list', [
-            'keyField' => 'i_id_room',
-            'valueField' => 'c_room_name'
+            'keyField'   => 'i_id_room',
+            'valueField' => 'c_room_name',
         ])->toArray();
 
-        $ages = range(1, 80);
+        $ages  = range(1, 80);
         $roles = [0 => '職員', 1 => '児童', 3 => 'その他'];
         $this->set(compact('mUserInfo', 'rooms', 'ages', 'roles'));
     }
@@ -568,9 +221,7 @@ class MUserInfoController extends AppController
     {
         $this->request->allowMethod(['get', 'post', 'put', 'patch']);
 
-        $mUserInfo = $this->MUserInfo->get($id, [
-            'contain' => ['MUserGroup']
-        ]);
+        $mUserInfo = $this->MUserInfo->get($id, ['contain' => ['MUserGroup']]);
 
         try {
             $this->Authorization->authorize($mUserInfo, 'edit');
@@ -581,55 +232,29 @@ class MUserInfoController extends AppController
 
         if ($this->request->is(['patch', 'post', 'put'])) {
             $data = $this->request->getData();
-            // フィールド名の修正とnullチェック (c_user_nameがnullの場合のデフォルト値を設定)
-            $data['c_user_name'] = $data['c_user_name'] ?? 'デフォルトユーザー名';
-            $user = $this->request->getAttribute('identity');
+            $data['c_user_name']   = $data['c_user_name'] ?? 'デフォルトユーザー名';
+            $user                  = $this->request->getAttribute('identity');
             $data['c_update_user'] = $user ? $user->get('c_user_name') : '不明なユーザー';
-            $data['dt_update'] = date('Y-m-d H:i:s');
+            $data['dt_update']     = date('Y-m-d H:i:s');
 
-            // MUserGroupデータのセットアップ
-            $newUserGroups = [];
+            $roomIds = [];
             if (!empty($data['rooms'])) {
                 foreach ($data['rooms'] as $roomId => $activeFlag) {
                     if ($activeFlag === '1') {
-                        $newUserGroups[] = $this->MUserInfo->MUserGroup->newEntity([
-                            'i_id_user' => $id,
-                            'i_id_room' => (int)$roomId,
-                            'active_flag' => 0, // 元のコードのロジックに従って 0 を設定
-                            'dt_create' => date('Y-m-d H:i:s'),
-                            'dt_update' => date('Y-m-d H:i:s'),
-                            'c_update_user' => $user ? $user->get('c_user_name') : '不明なユーザー',
-                        ]);
+                        $roomIds[] = (int)$roomId;
                     }
                 }
             }
 
-            // トランザクション開始
-            $conn = $this->MUserInfo->getConnection();
-            $conn->begin();
+            $updatedBy = $user ? $user->get('c_user_name') : '不明なユーザー';
 
             try {
-                // 現在のMUserGroup関係を削除
-                $this->MUserInfo->MUserGroup->deleteAll(['i_id_user' => $id]);
-
-                // パッチを適用して関連付けを設定
-                $mUserInfo = $this->MUserInfo->patchEntity($mUserInfo, $data, ['associated' => ['MUserGroup']]);
-                $mUserInfo->m_user_group = $newUserGroups;
-
-                // 保存処理
-                if ($this->MUserInfo->save($mUserInfo, ['associated' => ['MUserGroup']])) {
-                    $conn->commit();
+                if ($this->userEditService->updateWithRooms($mUserInfo, $data, $roomIds, $updatedBy)) {
                     $this->Flash->success(__('ユーザー情報が更新されました。'));
-                    $mUserInfo->dt_update = date('Y-m-d H:i:s');
                     return $this->redirect(['action' => 'index']);
-                } else {
-                    // デバッグメッセージ2: 保存失敗
-                    $this->Flash->error(__('ユーザー情報の保存に失敗しました。もう一度お試しください。'));
-                    $conn->rollback();
                 }
+                $this->Flash->error(__('ユーザー情報の保存に失敗しました。もう一度お試しください。'));
             } catch (\Exception $e) {
-                // ロールバックを行い、エラー処理
-                $conn->rollback();
                 $this->Flash->error(__('予期しないエラーが発生しました。もう一度お試しください。'));
             }
         }
@@ -648,26 +273,18 @@ class MUserInfoController extends AppController
 
     public function updateAdminStatus()
     {
-        // POSTメソッドのみを許可
         $this->request->allowMethod(['post']);
         $apiResponse = new ApiResponseService();
 
-        // リクエストデータを取得
-        $data = $this->request->getData(); // JSONデータから取得
+        $data   = $this->request->getData();
         $userId = $data['i_id_user'] ?? null;
         $isAdmin = $data['i_admin'] ?? null;
 
-        // 必須データがない場合、BadRequestを返す
         if (is_null($userId) || is_null($isAdmin)) {
             return $apiResponse->error($this->response, 'ユーザーIDまたは管理者権限が指定されていません。', 400);
         }
 
-        // ユーザーデータを取得し更新処理を実行
-        $this->fetchTable('MUserInfo');
-        $user = $this->MUserInfo->find()
-            ->where(['i_id_user' => (int)$userId])
-            ->first();
-
+        $user = $this->MUserInfo->find()->where(['i_id_user' => (int)$userId])->first();
         if (!$user) {
             return $apiResponse->error($this->response, '対象ユーザーが見つかりません。', 404);
         }
@@ -678,16 +295,13 @@ class MUserInfoController extends AppController
             return $apiResponse->error($this->response, 'この操作は管理者のみ実行できます。', 403);
         }
 
-        // 権限を更新
-        $user->i_admin = (int)$isAdmin;
-        $user->dt_update = date('Y-m-d H:i:s');
-        $identity = $this->request->getAttribute('identity');
-        $user->c_update_user = $identity ? $identity->get('c_user_name') : '不明なユーザー';
-        if ($this->MUserInfo->save($user)) {
+        $identity  = $this->request->getAttribute('identity');
+        $updatedBy = $identity ? $identity->get('c_user_name') : '不明なユーザー';
+
+        if ($this->userPermissionService->updatePermission($user, (int)$isAdmin, $updatedBy)) {
             return $apiResponse->success($this->response, [], '管理者権限が正常に更新されました。');
-        } else {
-            return $apiResponse->error($this->response, '管理者権限の更新に失敗しました。', 500);
         }
+        return $apiResponse->error($this->response, '管理者権限の更新に失敗しました。', 500);
     }
 
     public function updateUserLevel()
@@ -703,10 +317,7 @@ class MUserInfoController extends AppController
             return $apiResponse->error($this->response, 'ユーザーIDまたは権限レベルが指定されていません。', 400);
         }
 
-        $user = $this->MUserInfo->find()
-            ->where(['i_id_user' => (int)$userId])
-            ->first();
-
+        $user = $this->MUserInfo->find()->where(['i_id_user' => (int)$userId])->first();
         if (!$user) {
             return $apiResponse->error($this->response, '対象ユーザーが見つかりません。', 404);
         }
@@ -717,22 +328,19 @@ class MUserInfoController extends AppController
             return $apiResponse->error($this->response, 'この操作は管理者のみ実行できます。', 403);
         }
 
-        $user->i_admin    = (int)$level;
-        $user->dt_update  = date('Y-m-d H:i:s');
-        $identity = $this->request->getAttribute('identity');
-        $user->c_update_user = $identity ? $identity->get('c_user_name') : '不明なユーザー';
+        $identity  = $this->request->getAttribute('identity');
+        $updatedBy = $identity ? $identity->get('c_user_name') : '不明なユーザー';
 
-        if ($this->MUserInfo->save($user)) {
+        if ($this->userPermissionService->updatePermission($user, (int)$level, $updatedBy)) {
             return $apiResponse->success($this->response, [], 'ブロック長権限が正常に更新されました。');
-        } else {
-            return $apiResponse->error($this->response, 'ブロック長権限の更新に失敗しました。', 500);
         }
+        return $apiResponse->error($this->response, 'ブロック長権限の更新に失敗しました。', 500);
     }
 
     public function view($id = null)
     {
         $mUserInfo = $this->MUserInfo->get($id, [
-            'contain' => ['MUserGroup' => ['MRoomInfo']]
+            'contain' => ['MUserGroup' => ['MRoomInfo']],
         ]);
         try {
             $this->Authorization->authorize($mUserInfo, 'view');
@@ -765,23 +373,10 @@ class MUserInfoController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        $mUserInfo->i_del_flag = 1;
-        $mUserInfo->i_enable = 1; // i_enableを1(無効)に設定
-        $mUserInfo->dt_update = date('Y-m-d H:i:s');
-        $user = $this->request->getAttribute('identity');
-        $mUserInfo->c_update_user = $user ? $user->get('c_user_name') : '不明なユーザー';
-        //MUserGroupに登録されている部屋所属情報のactive_flagを0から1に変更
-        $userGroups = $this->MUserGroup->find()
-            ->where(['i_id_user' => $id, 'active_flag' => 0])
-            ->all();
-        foreach ($userGroups as $userGroup) {
-            $userGroup->active_flag = 1;
-            $userGroup->dt_update = date('Y-m-d H:i:s');
-            $userGroup->c_update_user = $user ? $user->get('c_user_name') : '不明なユーザー';
-            $this->MUserGroup->save($userGroup);
-        }
+        $user      = $this->request->getAttribute('identity');
+        $updatedBy = $user ? $user->get('c_user_name') : '不明なユーザー';
 
-        if ($this->MUserInfo->save($mUserInfo)) {
+        if ($this->userDeletionService->softDelete($mUserInfo, $updatedBy)) {
             $this->Flash->success(__('ユーザー情報が削除されました。'));
         } else {
             $this->Flash->error(__('ユーザー情報を削除できませんでした。'));
@@ -801,11 +396,10 @@ class MUserInfoController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        $user = $this->request->getAttribute('identity');
+        $user       = $this->request->getAttribute('identity');
         $createUser = $user ? $user->get('c_user_name') : '不明なユーザー';
 
         if ($this->request->is('post')) {
-
             $roomId = $this->request->getData('i_id_room');
             if ($this->MUserInfo->saveUserRoom($userId, $roomId, $createUser)) {
                 $this->Flash->success(__('ユーザーに部屋が追加されました。'));
@@ -842,22 +436,17 @@ class MUserInfoController extends AppController
         $result = $this->Authentication->getResult();
 
         if ($result && $result->isValid()) {
-            // ログインユーザーが削除済みかチェック
-            $user = $result->getData(); // ログイン成功後のユーザーデータを取得
+            $user = $result->getData();
 
             if ($user->i_del_flag === 1 || $user->i_enable === 1) {
-                // ユーザーが削除済みの場合はログインを拒否
-                $this->Authentication->logout(); // ログイン状態を解除
+                $this->Authentication->logout();
                 $this->Flash->error(__('このアカウントは無効化されています。'));
-
-                return $this->redirect(['action' => 'login']); // ログイン画面にリダイレクト
+                return $this->redirect(['action' => 'login']);
             }
 
-            // 削除されていない場合は通常のリダイレクト処理
             if ((int)$user->i_admin === 1) {
                 $defaultRedirect = ['controller' => 'TReservationInfo', 'action' => 'index'];
             } elseif ((int)$user->i_user_level === 1) {
-                // 子供(児童)は予約画面へ
                 $defaultRedirect = ['controller' => 'TReservationInfo', 'action' => 'index'];
             } else {
                 $defaultRedirect = ['controller' => 'Pages', 'action' => 'display', 'home'];
@@ -867,12 +456,8 @@ class MUserInfoController extends AppController
         }
 
         if ($this->request->is('post') && !$result->isValid()) {
-            // デバッグのため値を取得
             $status = $result ? $result->getStatus() : 'Result is null';
-
-            // デバッグログに文字列変換して出力
             $this->log(print_r($status, true), 'debug');
-
             $this->Flash->error(__('ユーザー名またはパスワードが正しくありません。'));
         }
     }
@@ -899,19 +484,17 @@ class MUserInfoController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        // すべてのユーザーを取得（リスト表示用）
         $users = $this->fetchTable('MUserInfo')->find('list', [
-            'keyField' => 'i_id_user',
-            'valueField' => 'c_user_name'
+            'keyField'   => 'i_id_user',
+            'valueField' => 'c_user_name',
         ])->where(['i_del_flag' => 0])->toArray();
 
         $selectedUser = null;
 
         if ($this->request->is(['post', 'put'])) {
-            $data = $this->request->getData();
-
-            $userId = $data['user_id'] ?? null;
-            $newPassword = $data['new_password'] ?? '';
+            $data            = $this->request->getData();
+            $userId          = $data['user_id'] ?? null;
+            $newPassword     = $data['new_password'] ?? '';
             $confirmPassword = $data['confirm_password'] ?? '';
 
             if (!$userId || !isset($users[$userId])) {
@@ -921,7 +504,6 @@ class MUserInfoController extends AppController
 
             $selectedUser = $this->fetchTable('MUserInfo')->get($userId);
 
-            // パスワードバリデーション
             if ($newPassword !== $confirmPassword) {
                 $this->Flash->error(__('新しいパスワードが一致しません。'));
                 return $this->redirect(['action' => 'adminChangePassword']);
@@ -932,9 +514,6 @@ class MUserInfoController extends AppController
                 return $this->redirect(['action' => 'adminChangePassword']);
             }
 
-            // モデルでbeforeSaveハッシュ化する前提の場合は平文をセット
-            // もし beforeSave が無い場合は以下の1行を使用してください:
-            // $selectedUser->c_login_passwd = (new DefaultPasswordHasher())->hash($newPassword);
             $selectedUser->c_login_passwd = $newPassword;
 
             if ($this->fetchTable('MUserInfo')->save($selectedUser)) {
@@ -948,7 +527,6 @@ class MUserInfoController extends AppController
         $this->set(compact('users', 'selectedUser'));
     }
 
-
     public function generalPasswordReset(): ?\Cake\Http\Response
     {
         $this->request->allowMethod(['get', 'post', 'put', 'patch']);
@@ -959,9 +537,9 @@ class MUserInfoController extends AppController
         }
 
         $userId = $identity->getIdentifier() ?? $identity->get('i_id_user');
+        $Users  = $this->fetchTable('MUserInfo');
+        $user   = $Users->get($userId);
 
-        $Users = $this->fetchTable('MUserInfo');
-        $user  = $Users->get($userId);
         try {
             $this->Authorization->authorize($user, 'generalPasswordReset');
         } catch (ForbiddenException $e) {
@@ -970,12 +548,10 @@ class MUserInfoController extends AppController
         }
 
         if ($this->request->is(['post', 'put', 'patch'])) {
-            $data = (array)$this->request->getData();
-
+            $data            = (array)$this->request->getData();
             $newPassword     = (string)($data['new_password'] ?? '');
             $confirmPassword = (string)($data['confirm_password'] ?? '');
 
-            // 入力チェック（4文字以上 & 一致のみ）
             if ($newPassword !== $confirmPassword) {
                 $this->Flash->error('新しいパスワードが一致しません。');
                 return $this->redirect($this->request->getRequestTarget());
@@ -985,13 +561,12 @@ class MUserInfoController extends AppController
                 return $this->redirect($this->request->getRequestTarget());
             }
 
-            // ★ beforeSave でハッシュ化される前提：平文を代入
             $user->c_login_passwd = $newPassword;
 
             if ($Users->save($user)) {
-                $this->request->getSession()->renew(); // セッション再生成
+                $this->request->getSession()->renew();
                 $this->Flash->success('パスワードを変更しました。');
-                return $this->redirect(['controller'=>'TReservationInfo','action' => 'index']);
+                return $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
             }
 
             $this->Flash->error('パスワードの変更に失敗しました。');
@@ -1004,72 +579,49 @@ class MUserInfoController extends AppController
     /**
      * ユーザーの所属部屋登録API
      * POST: i_id_user, room_names[]
-     * 既存所属はactive_flag=1に更新し、新規所属をactive_flag=0で登録
-     * 最大2部屋まで
+     * 既存所属はactive_flag=1に更新し、新規所属をactive_flag=0で登録（最大2部屋）
      */
     public function addUserRooms()
     {
         $this->request->allowMethod(['post']);
         $this->viewBuilder()->setClassName('Json');
-        $userId = $this->request->getData('i_id_user');
+
+        $userId    = $this->request->getData('i_id_user');
         $roomNames = $this->request->getData('room_names');
+
         if (!is_numeric($userId) || empty($roomNames) || !is_array($roomNames)) {
-            $this->set(['ok' => false, 'message' => 'i_id_userとroom_names[]が必要です', '_serialize' => ['ok','message']]);
+            $this->set(['ok' => false, 'message' => 'i_id_userとroom_names[]が必要です', '_serialize' => ['ok', 'message']]);
             return;
         }
+
         $userId = (int)$userId;
-        $roomNames = array_slice($roomNames, 0, 2); // 最大2部屋
-        $user = $this->MUserInfo->find()->where(['i_id_user' => $userId, 'i_del_flag' => 0])->first();
+        $user   = $this->MUserInfo->find()->where(['i_id_user' => $userId, 'i_del_flag' => 0])->first();
+
         if (!$user) {
-            $this->set(['ok' => false, 'message' => 'ユーザーが見つかりません', '_serialize' => ['ok','message']]);
+            $this->set(['ok' => false, 'message' => 'ユーザーが見つかりません', '_serialize' => ['ok', 'message']]);
             return;
         }
+
         try {
             $this->Authorization->authorize($user, 'addUserRooms');
         } catch (ForbiddenException $e) {
             $this->set(['ok' => false, 'message' => '権限がありません', '_serialize' => ['ok', 'message']]);
             return;
         }
-        $conn = $this->MUserInfo->getConnection();
-        $conn->begin();
-        $errors = [];
+
         $identity = $this->request->getAttribute('identity');
-        $actor = $identity ? $identity->get('c_user_name') : 'API';
+        $actor    = $identity ? $identity->get('c_user_name') : 'API';
+
         try {
-            // 既存所属（active_flag=0）をactive_flag=1に更新
-            $oldGroups = $this->MUserGroup->find()->where(['i_id_user' => $userId, 'active_flag' => 0])->all();
-            foreach ($oldGroups as $group) {
-                $group->active_flag = 1;
-                $group->dt_update = date('Y-m-d H:i:s');
-                $group->c_update_user = $actor;
-                $this->MUserGroup->save($group);
-            }
-            // 新規所属登録
-            $created = 0;
-            foreach ($roomNames as $roomName) {
-                $room = $this->MRoomInfo->find()->where(['c_room_name' => $roomName])->first();
-                if ($room) {
-                    $newGroup = $this->MUserGroup->newEntity([
-                        'i_id_user' => $userId,
-                        'i_id_room' => $room->i_id_room,
-                        'active_flag' => 0,
-                        'dt_create' => date('Y-m-d H:i:s'),
-                        'c_create_user' => $actor,
-                    ]);
-                    if ($this->MUserGroup->save($newGroup)) {
-                        $created++;
-                    } else {
-                        $errors[] = "部屋 '{$roomName}' の登録に失敗";
-                    }
-                } else {
-                    $errors[] = "部屋名 '{$roomName}' が見つかりません";
-                }
-            }
-            $conn->commit();
-            $this->set(['ok' => true, 'created' => $created, 'errors' => $errors, '_serialize' => ['ok','created','errors']]);
+            $result = $this->userRoomAssignmentService->assign($userId, $roomNames, $actor);
+            $this->set([
+                'ok'      => true,
+                'created' => $result['created'],
+                'errors'  => $result['errors'],
+                '_serialize' => ['ok', 'created', 'errors'],
+            ]);
         } catch (\Throwable $e) {
-            $conn->rollback();
-            $this->set(['ok' => false, 'message' => $e->getMessage(), '_serialize' => ['ok','message']]);
+            $this->set(['ok' => false, 'message' => $e->getMessage(), '_serialize' => ['ok', 'message']]);
         }
     }
 
@@ -1079,7 +631,7 @@ class MUserInfoController extends AppController
     public function restore($id = null)
     {
         $this->request->allowMethod(['post', 'put']);
-        $user = $this->MUserInfo->get($id);
+        $user     = $this->MUserInfo->get($id);
         $identity = $this->request->getAttribute('identity');
 
         try {
@@ -1088,50 +640,21 @@ class MUserInfoController extends AppController
             $this->Flash->error(__('この機能は管理者のみ利用できます。'));
             return $this->redirect(['action' => 'index']);
         }
-        
+
         if ($user->i_del_flag !== 1) {
             $this->Flash->error(__('このユーザーは削除されていません。'));
             return $this->redirect(['action' => 'index', '?' => ['show_deleted' => '1']]);
         }
 
-        $conn = $this->MUserInfo->getConnection();
-        $conn->begin();
+        $updatedBy = $identity->get('c_user_name') ?? 'admin';
 
         try {
-            // ユーザーの削除フラグを解除
-            $user->i_del_flag = 0;
-            $user->dt_update = date('Y-m-d H:i:s');
-            $user->c_update_user = $identity->get('c_user_name') ?? 'admin';
-
-            if (!$this->MUserInfo->save($user)) {
-                throw new \Exception('ユーザー情報の更新に失敗しました。');
-            }
-
-            // MUserGroupのactive_flagを0（有効）に変更
-            $userGroups = $this->MUserGroup->find()
-                ->where(['i_id_user' => $id])
-                ->all();
-
-            foreach ($userGroups as $group) {
-                $group->active_flag = 0;
-                $group->dt_update = date('Y-m-d H:i:s');
-                $group->c_update_user = $identity->get('c_user_name') ?? 'admin';
-                
-                if (!$this->MUserGroup->save($group)) {
-                    throw new \Exception('グループ情報の更新に失敗しました。');
-                }
-            }
-
-            $conn->commit();
+            $this->userRestoreService->restore($user, $updatedBy);
             $this->Flash->success(__('ユーザー「{0}」を復元しました。', $user->c_user_name));
             return $this->redirect(['action' => 'index']);
-
         } catch (\Exception $e) {
-            $conn->rollback();
             $this->Flash->error(__('ユーザーの復元に失敗しました: {0}', $e->getMessage()));
             return $this->redirect(['action' => 'index', '?' => ['show_deleted' => '1']]);
         }
     }
-
-
 }

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -25,6 +25,7 @@ use App\Exception\OptimisticLockConflictException;
 use App\Service\ReservationChangeEditService;
 use App\Service\ReservationAddService;
 use App\Service\ApiResponseService;
+use App\Service\MealReportingService;
 use Cake\Routing\Router;
 
 /**
@@ -62,6 +63,7 @@ class TReservationInfoController extends AppController
     private ReservationCopyService $copyService;
     private ReservationDatePolicy $datePolicy;
     protected ApiResponseService $apiResponseService;
+    protected MealReportingService $mealReportingService;
     /**
      * initialize メソッド
      *
@@ -97,6 +99,7 @@ class TReservationInfoController extends AppController
         );
         $this->copyService = new ReservationCopyService();
         $this->apiResponseService = new ApiResponseService();
+        $this->mealReportingService = new MealReportingService();
         $this->loadComponent('Flash');
 
         // ★ これがあると全アクションが“勝手に JSON 化”されやすいので外す
@@ -172,21 +175,7 @@ class TReservationInfoController extends AppController
             (int)$userId
         );
         $myReservationDates = $this->calendarService->buildMyReservationDates($myReservationDetails);
-        //職員情報を取得する
-        $staff_user = $this->MUserGroup->find()
-            ->enableAutoFields(false)
-            ->select([
-                'user_name' => 'MUserInfo.c_user_name',
-                'staff_id' => 'MUserInfo.i_id_staff',
-                'is_admin' => 'MUserInfo.i_admin',
-            ])
-            ->innerJoin(
-                ['MUserInfo' => 'm_user_info'],
-                ['MUserInfo.i_id_user = MUserGroup.i_id_user']
-            )
-            ->where(['MUserGroup.i_id_user' => $userId])
-            ->enableHydration(false)
-            ->toArray();
+        $staff_user = $this->calendarService->getStaffUserInfo($this->MUserGroup, (int)$userId);
 
         /* ========== ビューへ ========== */
         $this->set(compact(
@@ -1617,7 +1606,6 @@ class TReservationInfoController extends AppController
 
         $authUser = $this->Authentication->getIdentity();
         $actor = (string)($authUser?->get('c_user_name') ?? 'system');
-        $now = \Cake\I18n\DateTime::now('Asia/Tokyo');
 
         foreach ($keys as $key) {
             $targetUid = (int)($key['user_id'] ?? 0);
@@ -1635,22 +1623,8 @@ class TReservationInfoController extends AppController
             }
         }
 
-        $affectedTotal = 0;
-        foreach ($keys as $key) {
-            $affectedTotal += $this->TIndividualReservationInfo->updateAll(
-                [
-                    'i_approval_status' => 0,
-                    'dt_update' => $now,
-                    'c_update_user' => $actor,
-                ],
-                [
-                    'i_id_user' => (int)$key['user_id'],
-                    'i_id_room' => (int)$key['room_id'],
-                    'd_reservation_date' => (string)$key['date'],
-                    'i_reservation_type' => (int)$key['meal_type'],
-                ]
-            );
-        }
+        $service       = new \App\Service\ActualMealManagementService();
+        $affectedTotal = $service->requestApproval($this->TIndividualReservationInfo, $keys, $actor);
 
         return $this->apiResponseService->success(
             $this->response,

--- a/src_web/kamaho-shokusu/src/Controller/Traits/ReservationReportActionsTrait.php
+++ b/src_web/kamaho-shokusu/src/Controller/Traits/ReservationReportActionsTrait.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace App\Controller\Traits;
 
 use Cake\Http\Exception\NotFoundException;
-use Cake\I18n\Date;
-use Cake\I18n\DateTime;
 use Cake\Log\Log;
 
 trait ReservationReportActionsTrait
@@ -119,59 +117,25 @@ trait ReservationReportActionsTrait
         $this->request->allowMethod(['post']);
 
         $loginUser = $this->request->getAttribute('identity');
-        $userId = (int)($loginUser?->get('i_id_user') ?? 0);
-        $userName = (string)($loginUser?->get('c_user_name') ?? $userId);
+        $userId    = (int)($loginUser?->get('i_id_user') ?? 0);
+        $userName  = (string)($loginUser?->get('c_user_name') ?? $userId);
+
         if ($userId <= 0) {
             return $this->apiResponseService->error($this->response, 'Unauthorized', 401);
         }
 
-        $today = Date::today('Asia/Tokyo')->format('Y-m-d');
-        $roomRow = $this->MUserGroup->find()
-            ->enableAutoFields(false)
-            ->select(['i_id_room'])
-            ->where(['i_id_user' => $userId, 'active_flag' => 0])
-            ->orderAsc('i_id_room')
-            ->first();
-        if (!$roomRow) {
-            return $this->apiResponseService->error($this->response, '所属部屋が設定されていません。管理者にお問い合わせください。', 400);
-        }
-        $roomId = (int)$roomRow->i_id_room;
+        $result = $this->mealReportingService->reportNoMeal(
+            $this->TIndividualReservationInfo,
+            $this->MUserGroup,
+            $userId,
+            $userName
+        );
 
-        $mealTypes = [1, 2, 3, 4];
-        foreach ($mealTypes as $mealType) {
-            $affected = $this->TIndividualReservationInfo->updateAll(
-                [
-                    'eat_flag' => 0,
-                    'i_change_flag' => 0,
-                    'c_update_user' => $userName,
-                    'dt_update' => DateTime::now('Asia/Tokyo'),
-                ],
-                [
-                    'i_id_user' => $userId,
-                    'd_reservation_date' => $today,
-                    'i_reservation_type' => $mealType,
-                    'i_id_room' => $roomId,
-                ]
-            );
-            if ($affected === 0) {
-                $entity = $this->TIndividualReservationInfo->newEmptyEntity();
-                $entity->i_id_user = $userId;
-                $entity->d_reservation_date = $today;
-                $entity->i_reservation_type = $mealType;
-                $entity->i_id_room = $roomId;
-                $entity->eat_flag = 0;
-                $entity->i_change_flag = 0;
-                $entity->c_create_user = $userName;
-                $entity->dt_create = DateTime::now('Asia/Tokyo');
-                if (!$this->TIndividualReservationInfo->save($entity)) {
-                    return $this->apiResponseService->error($this->response, '報告の保存に失敗しました。', 500);
-                }
-            }
+        if (!$result['ok']) {
+            return $this->apiResponseService->error($this->response, $result['message'], 400);
         }
 
-        $this->invalidateReportCaches($userId, $roomId, $today);
-
-        return $this->apiResponseService->success($this->response, [], '食べないで報告しました。');
+        return $this->apiResponseService->success($this->response, [], $result['message']);
     }
 
     protected function runReportEat()
@@ -179,61 +143,25 @@ trait ReservationReportActionsTrait
         $this->request->allowMethod(['post']);
 
         $loginUser = $this->request->getAttribute('identity');
-        $userId = (int)($loginUser?->get('i_id_user') ?? 0);
-        $userName = (string)($loginUser?->get('c_user_name') ?? $userId);
+        $userId    = (int)($loginUser?->get('i_id_user') ?? 0);
+        $userName  = (string)($loginUser?->get('c_user_name') ?? $userId);
+
         if ($userId <= 0) {
             return $this->apiResponseService->error($this->response, 'Unauthorized', 401);
         }
 
-        $today = Date::today('Asia/Tokyo')->format('Y-m-d');
-        $roomRow = $this->MUserGroup->find()
-            ->enableAutoFields(false)
-            ->select(['i_id_room'])
-            ->where(['i_id_user' => $userId, 'active_flag' => 0])
-            ->orderAsc('i_id_room')
-            ->first();
-        if (!$roomRow) {
-            return $this->apiResponseService->error($this->response, '所属部屋が設定されていません。管理者にお問い合わせください。', 400);
-        }
-        $roomId = (int)$roomRow->i_id_room;
+        $result = $this->mealReportingService->reportEat(
+            $this->TIndividualReservationInfo,
+            $this->MUserGroup,
+            $userId,
+            $userName
+        );
 
-        $mealTypes = [1, 2, 3, 4];
-        foreach ($mealTypes as $mealType) {
-            $affected = $this->TIndividualReservationInfo->updateAll(
-                [
-                    'eat_flag' => 1,
-                    'i_change_flag' => 1,
-                    'c_update_user' => $userName,
-                    'dt_update' => DateTime::now('Asia/Tokyo'),
-                ],
-                [
-                    'i_id_user' => $userId,
-                    'd_reservation_date' => $today,
-                    'i_reservation_type' => $mealType,
-                    'i_id_room' => $roomId,
-                ]
-            );
-            if ($affected === 0) {
-                $entity = $this->TIndividualReservationInfo->newEmptyEntity();
-                $entity->i_id_user = $userId;
-                $entity->d_reservation_date = $today;
-                $entity->i_reservation_type = $mealType;
-                $entity->i_id_room = $roomId;
-                $entity->eat_flag = 1;
-                $entity->i_change_flag = 1;
-                $entity->c_create_user = $userName;
-                $entity->dt_create = DateTime::now('Asia/Tokyo');
-                if (!$this->TIndividualReservationInfo->save($entity)) {
-                    return $this->apiResponseService->error($this->response, '報告の保存に失敗しました。', 500);
-                }
-            }
+        if (!$result['ok']) {
+            return $this->apiResponseService->error($this->response, $result['message'], 400);
         }
 
-        $this->invalidateReportCaches($userId, $roomId, $today);
-        // 食べる報告後は「報告済み」として即時キャッシュに書き込む
-        \Cake\Cache\Cache::write(sprintf('today_report:%d:%s', $userId, $today), 1, 'default');
-
-        return $this->apiResponseService->success($this->response, [], '食べるで報告しました。');
+        return $this->apiResponseService->success($this->response, [], $result['message']);
     }
 
     protected function runGetAllRoomsMealCounts()
@@ -261,17 +189,6 @@ trait ReservationReportActionsTrait
         } catch (\Exception $e) {
             return $this->apiResponseService->error($this->response, 'データ取得に失敗しました。', 500);
         }
-    }
-
-    /**
-     * 食数報告後に関連キャッシュをまとめて削除する共通処理。
-     * runReportNoMeal / runReportEat の両メソッドから呼ばれる。
-     */
-    private function invalidateReportCaches(int $userId, int $roomId, string $today): void
-    {
-        \Cake\Cache\Cache::delete(sprintf('today_report:%d:%s', $userId, $today), 'default');
-        \Cake\Cache\Cache::delete('meal_counts:' . $today, 'default');
-        \Cake\Cache\Cache::delete(sprintf('users_by_room_edit:%d:%s', $roomId, $today), 'default');
     }
 
     protected function runGetRoomMealCounts($roomId = null)

--- a/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
+++ b/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
@@ -284,6 +284,38 @@ class ActualMealManagementService
     }
 
     /**
+     * 実食確認の承認申請をまとめて行う（i_approval_status を 0 にリセット）。
+     *
+     * @param Table  $reservationTable TIndividualReservationInfo テーブル
+     * @param array  $keys             申請対象キーの配列（user_id, room_id, date, meal_type を含む）
+     * @param string $actor            操作者ユーザー名
+     * @return int 更新件数合計
+     */
+    public function requestApproval(Table $reservationTable, array $keys, string $actor): int
+    {
+        $now          = \Cake\I18n\DateTime::now('Asia/Tokyo');
+        $affectedTotal = 0;
+
+        foreach ($keys as $key) {
+            $affectedTotal += $reservationTable->updateAll(
+                [
+                    'i_approval_status' => 0,
+                    'dt_update'         => $now,
+                    'c_update_user'     => $actor,
+                ],
+                [
+                    'i_id_user'          => (int)$key['user_id'],
+                    'i_id_room'          => (int)$key['room_id'],
+                    'd_reservation_date' => (string)$key['date'],
+                    'i_reservation_type' => (int)$key['meal_type'],
+                ]
+            );
+        }
+
+        return $affectedTotal;
+    }
+
+    /**
      * 管理者が選択可能な最も古い週の月曜日を返す（過去2ヶ月）。
      *
      * @return \DateTimeImmutable

--- a/src_web/kamaho-shokusu/src/Service/MealReportingService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealReportingService.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\Cache\Cache;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use Cake\ORM\Table;
+
+/**
+ * 食事報告サービス
+ *
+ * 「食べない」「食べる」の当日報告処理を担う。
+ * ORM の updateAll / 新規エンティティ保存・キャッシュ無効化を集約する。
+ */
+class MealReportingService
+{
+    private const MEAL_TYPES = [1, 2, 3, 4];
+
+    /**
+     * 「食べない」で報告する（全食種を eat_flag=0, i_change_flag=0 に設定）。
+     *
+     * @param Table  $reservationTable TIndividualReservationInfo テーブル
+     * @param Table  $userGroupTable   MUserGroup テーブル
+     * @param int    $userId           ログインユーザーID
+     * @param string $userName         ログインユーザー名
+     * @return array{ok: bool, message: string}
+     */
+    public function reportNoMeal(Table $reservationTable, Table $userGroupTable, int $userId, string $userName): array
+    {
+        $roomId = $this->getPrimaryRoomId($userGroupTable, $userId);
+        if ($roomId === null) {
+            return ['ok' => false, 'message' => '所属部屋が設定されていません。管理者にお問い合わせください。'];
+        }
+
+        $today = Date::today('Asia/Tokyo')->format('Y-m-d');
+
+        foreach (self::MEAL_TYPES as $mealType) {
+            $affected = $reservationTable->updateAll(
+                [
+                    'eat_flag'      => 0,
+                    'i_change_flag' => 0,
+                    'c_update_user' => $userName,
+                    'dt_update'     => DateTime::now('Asia/Tokyo'),
+                ],
+                [
+                    'i_id_user'          => $userId,
+                    'd_reservation_date' => $today,
+                    'i_reservation_type' => $mealType,
+                    'i_id_room'          => $roomId,
+                ]
+            );
+
+            if ($affected === 0) {
+                $entity = $reservationTable->newEmptyEntity();
+                $entity->i_id_user          = $userId;
+                $entity->d_reservation_date = $today;
+                $entity->i_reservation_type = $mealType;
+                $entity->i_id_room          = $roomId;
+                $entity->eat_flag           = 0;
+                $entity->i_change_flag      = 0;
+                $entity->c_create_user      = $userName;
+                $entity->dt_create          = DateTime::now('Asia/Tokyo');
+
+                if (!$reservationTable->save($entity)) {
+                    return ['ok' => false, 'message' => '報告の保存に失敗しました。'];
+                }
+            }
+        }
+
+        $this->invalidateCaches($userId, $roomId, $today);
+
+        return ['ok' => true, 'message' => '食べないで報告しました。'];
+    }
+
+    /**
+     * 「食べる」で報告する（全食種を eat_flag=1, i_change_flag=1 に設定）。
+     *
+     * @param Table  $reservationTable TIndividualReservationInfo テーブル
+     * @param Table  $userGroupTable   MUserGroup テーブル
+     * @param int    $userId           ログインユーザーID
+     * @param string $userName         ログインユーザー名
+     * @return array{ok: bool, message: string}
+     */
+    public function reportEat(Table $reservationTable, Table $userGroupTable, int $userId, string $userName): array
+    {
+        $roomId = $this->getPrimaryRoomId($userGroupTable, $userId);
+        if ($roomId === null) {
+            return ['ok' => false, 'message' => '所属部屋が設定されていません。管理者にお問い合わせください。'];
+        }
+
+        $today = Date::today('Asia/Tokyo')->format('Y-m-d');
+
+        foreach (self::MEAL_TYPES as $mealType) {
+            $affected = $reservationTable->updateAll(
+                [
+                    'eat_flag'      => 1,
+                    'i_change_flag' => 1,
+                    'c_update_user' => $userName,
+                    'dt_update'     => DateTime::now('Asia/Tokyo'),
+                ],
+                [
+                    'i_id_user'          => $userId,
+                    'd_reservation_date' => $today,
+                    'i_reservation_type' => $mealType,
+                    'i_id_room'          => $roomId,
+                ]
+            );
+
+            if ($affected === 0) {
+                $entity = $reservationTable->newEmptyEntity();
+                $entity->i_id_user          = $userId;
+                $entity->d_reservation_date = $today;
+                $entity->i_reservation_type = $mealType;
+                $entity->i_id_room          = $roomId;
+                $entity->eat_flag           = 1;
+                $entity->i_change_flag      = 1;
+                $entity->c_create_user      = $userName;
+                $entity->dt_create          = DateTime::now('Asia/Tokyo');
+
+                if (!$reservationTable->save($entity)) {
+                    return ['ok' => false, 'message' => '報告の保存に失敗しました。'];
+                }
+            }
+        }
+
+        $this->invalidateCaches($userId, $roomId, $today);
+        Cache::write(sprintf('today_report:%d:%s', $userId, $today), 1, 'default');
+
+        return ['ok' => true, 'message' => '食べるで報告しました。'];
+    }
+
+    private function getPrimaryRoomId(Table $userGroupTable, int $userId): ?int
+    {
+        $row = $userGroupTable->find()
+            ->enableAutoFields(false)
+            ->select(['i_id_room'])
+            ->where(['i_id_user' => $userId, 'active_flag' => 0])
+            ->orderAsc('i_id_room')
+            ->first();
+
+        return $row ? (int)$row->i_id_room : null;
+    }
+
+    private function invalidateCaches(int $userId, int $roomId, string $today): void
+    {
+        Cache::delete(sprintf('today_report:%d:%s', $userId, $today), 'default');
+        Cache::delete('meal_counts:' . $today, 'default');
+        Cache::delete(sprintf('users_by_room_edit:%d:%s', $roomId, $today), 'default');
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/MealSummaryExportService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealSummaryExportService.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 食事集計エクスポートサービス
+ *
+ * 指定年度・月の職員別食事回数と料金を集計する。
+ */
+class MealSummaryExportService
+{
+    private const RESERVATION_TYPE_MORNING = 1;
+    private const RESERVATION_TYPE_LUNCH   = 2;
+    private const RESERVATION_TYPE_DINNER  = 3;
+    private const RESERVATION_TYPE_BENTO   = 4;
+    private const APPROVAL_STATUS_APPROVED = 2;
+
+    /**
+     * 指定年度・月の職員別食事集計データを返す。
+     *
+     * @param int $year  年度
+     * @param int $month 月（1〜12）
+     * @return array{name: string, staff_id: mixed, meal_counts: array, total_price: int}[]
+     */
+    public function aggregate(int $year, int $month): array
+    {
+        $mealPrices = $this->fetchMealPrices($year);
+        $users      = $this->fetchStaffUsers();
+
+        $monthlyData = [];
+        foreach ($users as $user) {
+            $mealCounts    = $this->countMeals($user->i_id_user, $year, $month);
+            $mealTotalPrice = $this->calcTotalPrice($mealCounts, $mealPrices);
+
+            $monthlyData[] = [
+                'name'        => $user->c_user_name,
+                'staff_id'    => $user->i_id_staff,
+                'meal_counts' => $mealCounts,
+                'total_price' => $mealTotalPrice,
+            ];
+        }
+
+        return $monthlyData;
+    }
+
+    /**
+     * @return array{morning: int, lunch: int, dinner: int, bento: int}
+     */
+    private function fetchMealPrices(int $year): array
+    {
+        $table = TableRegistry::getTableLocator()->get('MMealPriceInfo');
+        $row   = $table->find()
+            ->select(['i_morning_price', 'i_lunch_price', 'i_dinner_price', 'i_bento_price'])
+            ->where(['i_fiscal_year' => $year])
+            ->first();
+
+        return [
+            'morning' => $row->i_morning_price ?? 0,
+            'lunch'   => $row->i_lunch_price   ?? 0,
+            'dinner'  => $row->i_dinner_price  ?? 0,
+            'bento'   => $row->i_bento_price   ?? 0,
+        ];
+    }
+
+    private function fetchStaffUsers(): array
+    {
+        $table = TableRegistry::getTableLocator()->get('MUserInfo');
+        return $table->find()
+            ->select(['i_id_user', 'c_user_name', 'i_id_staff'])
+            ->where(['i_id_staff IS NOT' => null, 'i_del_flag' => 0])
+            ->all()
+            ->toArray();
+    }
+
+    /**
+     * @return array{morning: int, lunch: int, dinner: int, bento: int}
+     */
+    private function countMeals(int $userId, int $year, int $month): array
+    {
+        $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $rows  = $table->find()
+            ->select(['i_reservation_type', 'eat_flag', 'i_change_flag', 'i_approval_status'])
+            ->where([
+                'i_id_user'              => $userId,
+                'YEAR(d_reservation_date)'  => $year,
+                'MONTH(d_reservation_date)' => $month,
+                'i_approval_status'      => self::APPROVAL_STATUS_APPROVED,
+            ])
+            ->toArray();
+
+        $counts = ['bento' => 0, 'morning' => 0, 'lunch' => 0, 'dinner' => 0];
+
+        foreach ($rows as $row) {
+            $effectiveFlag = $row->i_change_flag !== null
+                ? (int)$row->i_change_flag
+                : (int)($row->eat_flag ?? 0);
+
+            if ($effectiveFlag !== 1) {
+                continue;
+            }
+
+            match ((int)$row->i_reservation_type) {
+                self::RESERVATION_TYPE_BENTO   => $counts['bento']++,
+                self::RESERVATION_TYPE_MORNING => $counts['morning']++,
+                self::RESERVATION_TYPE_LUNCH   => $counts['lunch']++,
+                self::RESERVATION_TYPE_DINNER  => $counts['dinner']++,
+                default                        => null,
+            };
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array{morning: int, lunch: int, dinner: int, bento: int} $counts
+     * @param array{morning: int, lunch: int, dinner: int, bento: int} $prices
+     */
+    private function calcTotalPrice(array $counts, array $prices): int
+    {
+        return (
+            $counts['bento']   * $prices['bento'] +
+            $counts['morning'] * $prices['morning'] +
+            $counts['lunch']   * $prices['lunch'] +
+            $counts['dinner']  * $prices['dinner']
+        );
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
@@ -333,4 +333,29 @@ class ReservationCalendarService
 
         return $events;
     }
+
+    /**
+     * ログインユーザーの職員情報（名前・職員ID・管理者フラグ）を返す。
+     *
+     * @param Table $userGroupTable MUserGroup テーブル
+     * @param int   $userId         ログインユーザーID
+     * @return array
+     */
+    public function getStaffUserInfo(Table $userGroupTable, int $userId): array
+    {
+        return $userGroupTable->find()
+            ->enableAutoFields(false)
+            ->select([
+                'user_name' => 'MUserInfo.c_user_name',
+                'staff_id'  => 'MUserInfo.i_id_staff',
+                'is_admin'  => 'MUserInfo.i_admin',
+            ])
+            ->innerJoin(
+                ['MUserInfo' => 'm_user_info'],
+                ['MUserInfo.i_id_user = MUserGroup.i_id_user']
+            )
+            ->where(['MUserGroup.i_id_user' => $userId])
+            ->enableHydration(false)
+            ->toArray();
+    }
 }

--- a/src_web/kamaho-shokusu/src/Service/RoomService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomService.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\I18n\DateTime;
+use Cake\ORM\TableRegistry;
+
+/**
+ * 部屋管理サービス
+ *
+ * 部屋の表示用データ集約・採番・ソフトデリートを担う。
+ */
+class RoomService
+{
+    /**
+     * 部屋に紐づくユーザー一覧を返す。
+     *
+     * @param \App\Model\Entity\MRoomInfo $roomInfo MUserGroup を contain 済みのエンティティ
+     * @return array
+     */
+    public function getUsersForRoom(mixed $roomInfo): array
+    {
+        $userGroups = $roomInfo->m_user_group ?: [];
+
+        $userIds = array_map(
+            fn($group) => $group->i_id_user,
+            $userGroups
+        );
+
+        if (empty($userIds)) {
+            return [];
+        }
+
+        $table = TableRegistry::getTableLocator()->get('MUserInfo');
+        return $table->find('all', [
+            'conditions' => ['MUserInfo.i_id_user IN' => $userIds],
+        ])->toArray();
+    }
+
+    /**
+     * 次の表示番号（MAX + 1）を返す。
+     */
+    public function nextDisplayNo(): int
+    {
+        $table   = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $maxDispNo = (int)($table->find()
+            ->select(['max_disp_no' => 'MAX(i_disp_no)'])
+            ->first()
+            ?->max_disp_no ?? 0);
+
+        return $maxDispNo + 1;
+    }
+
+    /**
+     * 部屋をソフトデリートする（i_del_flg = 1）。
+     *
+     * @param \App\Model\Entity\MRoomInfo $roomInfo
+     * @param string|null                 $updatedBy 更新者名
+     * @return bool
+     */
+    public function softDelete(mixed $roomInfo, ?string $updatedBy): bool
+    {
+        $table = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $roomInfo->i_del_flg    = 1;
+        $roomInfo->c_update_user = $updatedBy;
+        $roomInfo->dt_update    = DateTime::now('Asia/Tokyo');
+
+        return (bool)$table->save($roomInfo);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserBulkImportService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserBulkImportService.php
@@ -1,0 +1,278 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー一括インポートサービス
+ *
+ * importJson エンドポイント向けに、JSONレコード配列を受け取り
+ * バリデーション・正規化・保存を一括処理する。
+ */
+class UserBulkImportService
+{
+    /**
+     * @param array  $records     クライアントから送られてきたレコード配列
+     * @param string $createUser  作成者ユーザー名
+     * @return array{processed: int, created: int, skipped: int, failed: int, errors: array}
+     */
+    public function import(array $records, string $createUser): array
+    {
+        $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $roomInfoTable  = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $maxDispNoRow = $userInfoTable->find()
+            ->select(['max_no' => $userInfoTable->find()->func()->max('i_disp_no')])
+            ->first();
+        $nextDispNo = ($maxDispNoRow && $maxDispNoRow->max_no !== null)
+            ? ((int)$maxDispNoRow->max_no + 1)
+            : 1;
+
+        $results = [
+            'processed' => 0,
+            'created'   => 0,
+            'skipped'   => 0,
+            'failed'    => 0,
+            'errors'    => [],
+        ];
+
+        $conn = $userInfoTable->getConnection();
+        $conn->begin();
+
+        try {
+            foreach ($records as $rec) {
+                $rowNo         = (int)($rec['_row'] ?? 0);
+                $loginId       = trim((string)($rec['login_id'] ?? ''));
+                $name          = trim((string)($rec['name'] ?? ''));
+                $roleRaw       = (string)($rec['role'] ?? '');
+                $passRaw       = (string)($rec['password'] ?? '');
+                $staffId       = trim((string)($rec['staff_id'] ?? ''));
+                $ageRaw        = (string)($rec['age'] ?? '');
+                $genderInput   = (string)($rec['i_user_gender'] ?? ($rec['gender'] ?? ''));
+                $ageGroupInput = (string)($rec['age_group'] ?? '');
+                $roomName1     = trim((string)($rec['room_name1'] ?? ''));
+                $roomName2     = trim((string)($rec['room_name2'] ?? ''));
+
+                if ($loginId === '' || $name === '' || $roleRaw === '') {
+                    $results['failed']++;
+                    $results['processed']++;
+                    $results['errors'][$rowNo][] = '必須項目（login_id, name, role）のいずれかが空です。';
+                    continue;
+                }
+
+                if ($userInfoTable->exists(['c_login_account' => $loginId])) {
+                    $results['skipped']++;
+                    $results['processed']++;
+                    $results['errors'][$rowNo][] = 'c_login_account が既に存在します。';
+                    continue;
+                }
+
+                $level = $this->normalizeRole($roleRaw);
+                if ($level === null) {
+                    $results['failed']++;
+                    $results['processed']++;
+                    $results['errors'][$rowNo][] = 'role の値が不正です（職員/児童/その他 または 0/1/3 を指定してください）。';
+                    continue;
+                }
+
+                if ($level === 0 && $staffId === '') {
+                    $results['failed']++;
+                    $results['processed']++;
+                    $results['errors'][$rowNo][] = 'role=職員 のため staff_id が必須です。';
+                    continue;
+                }
+
+                if ($passRaw === '') {
+                    $passRaw = bin2hex(random_bytes(6));
+                }
+
+                $ageVal = null;
+                if ($ageRaw !== '') {
+                    $ageInt = (int)$ageRaw;
+                    if ($ageInt > 0) {
+                        $ageVal = $ageInt;
+                    }
+                }
+
+                $genderVal = null;
+                if ($genderInput !== '') {
+                    $g = mb_strtolower(trim($genderInput), 'UTF-8');
+                    if (is_numeric($g)) {
+                        $gi = (int)$g;
+                        if (in_array($gi, [1, 2], true)) {
+                            $genderVal = $gi;
+                        }
+                    } else {
+                        if (in_array($g, ['1', '男', '男性', 'male', 'm'], true)) {
+                            $genderVal = 1;
+                        }
+                        if (in_array($g, ['2', '女', '女性', 'female', 'f'], true)) {
+                            $genderVal = 2;
+                        }
+                    }
+                }
+
+                $ageGroupCode = $ageGroupInput !== '' ? $this->normalizeAgeGroup($ageGroupInput) : null;
+
+                $newData = [
+                    'c_login_account' => $loginId,
+                    'c_user_name'     => $name,
+                    'i_user_level'    => $level,
+                    'c_login_passwd'  => $passRaw,
+                    'i_del_flag'      => 0,
+                    'i_enable'        => 0,
+                    'i_disp_no'       => $nextDispNo++,
+                    'dt_create'       => date('Y-m-d H:i:s'),
+                    'c_create_user'   => $createUser,
+                ];
+                if ($ageVal !== null) {
+                    $newData['i_user_age'] = $ageVal;
+                }
+                if ($genderVal !== null) {
+                    $newData['i_user_gender'] = $genderVal;
+                }
+                if ($ageGroupCode !== null) {
+                    $newData['i_user_rank'] = $ageGroupCode;
+                }
+                if ($level === 0) {
+                    $newData['i_id_staff'] = $staffId;
+                }
+
+                $entity = $userInfoTable->newEntity($newData);
+
+                if ($entity->getErrors()) {
+                    $results['failed']++;
+                    foreach ($entity->getErrors() as $field => $msgs) {
+                        foreach ($msgs as $msg) {
+                            $results['errors'][$rowNo][] = "{$field}: {$msg}";
+                        }
+                    }
+                    $results['processed']++;
+                    continue;
+                }
+
+                if ($userInfoTable->save($entity)) {
+                    $results['created']++;
+                    $userId    = $entity->i_id_user;
+                    $roomNames = array_filter([$roomName1, $roomName2], fn($n) => $n !== '');
+
+                    foreach ($roomNames as $roomName) {
+                        $room = $roomInfoTable->find()->where(['c_room_name' => $roomName])->first();
+                        if ($room && $userId) {
+                            $userGroup = $userGroupTable->newEntity([
+                                'i_id_user'     => $userId,
+                                'i_id_room'     => $room->i_id_room,
+                                'active_flag'   => 0,
+                                'dt_create'     => date('Y-m-d H:i:s'),
+                                'c_create_user' => $createUser,
+                            ]);
+                            $userGroupTable->save($userGroup);
+                        } else {
+                            $results['errors'][$rowNo][] = "部屋名 '{$roomName}' が見つかりません";
+                        }
+                    }
+                } else {
+                    $results['failed']++;
+                    $results['errors'][$rowNo][] = '保存に失敗しました。';
+                }
+
+                $results['processed']++;
+            }
+
+            $conn->commit();
+        } catch (\Throwable $e) {
+            $conn->rollback();
+            throw $e;
+        }
+
+        return $results;
+    }
+
+    /**
+     * 役割名 → i_user_level（0:職員, 1:児童, 3:その他）へ正規化
+     */
+    private function normalizeRole(string $raw): ?int
+    {
+        $v = trim($raw);
+        if ($v === '') {
+            return null;
+        }
+        if (function_exists('mb_convert_kana')) {
+            $v = mb_convert_kana($v, 'nas', 'UTF-8');
+        }
+        $vLower = mb_strtolower($v, 'UTF-8');
+
+        if (is_numeric($vLower)) {
+            $n = (int)$vLower;
+            return in_array($n, [0, 1, 3], true) ? $n : null;
+        }
+
+        $exactMap = [
+            'staff' => 0, '職員' => 0, 'スタッフ' => 0, '教職員' => 0,
+            'child' => 1, 'user' => 1, '利用者' => 1, '児童' => 1,
+            'こども' => 1, '子ども' => 1, '子供' => 1, '生徒' => 1, 'ユーザー' => 1,
+            'other' => 3, 'その他' => 3, '外部' => 3, 'ゲスト' => 3, '臨時' => 3, 'ボランティア' => 3,
+        ];
+        if (array_key_exists($vLower, $exactMap)) {
+            return $exactMap[$vLower];
+        }
+
+        $containsAny = function (string $haystack, array $needles): bool {
+            foreach ($needles as $needle) {
+                if ($needle !== '' && mb_strpos($haystack, $needle, 0, 'UTF-8') !== false) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if ($containsAny($vLower, ['職員', 'スタッフ', '教職員', 'staff'])) return 0;
+        if ($containsAny($vLower, ['児童', '子ども', '子供', 'こども', '生徒', '利用者', 'ユーザー', 'child', 'user'])) return 1;
+        if ($containsAny($vLower, ['その他', '外部', 'ゲスト', '臨時', 'other'])) return 3;
+
+        return null;
+    }
+
+    /**
+     * 年代（age_group）表記 → コード（1..7）へ正規化
+     * 1:3~5才, 2:低学年, 3:中学年, 4:高学年, 5:中学生, 6:高校生, 7:大人
+     */
+    private function normalizeAgeGroup(string $raw): ?int
+    {
+        $v = trim($raw);
+        if ($v === '') {
+            return null;
+        }
+
+        if (is_numeric($v)) {
+            $n = (int)$v;
+            return ($n >= 1 && $n <= 7) ? $n : null;
+        }
+
+        if (function_exists('mb_convert_kana')) {
+            $v = mb_convert_kana($v, 'as', 'UTF-8');
+        }
+        $v      = str_replace(['歳', '才', '　'], ['', '', ''], $v);
+        $vLower = mb_strtolower($v, 'UTF-8');
+
+        $pairs = [
+            ['3~5', 1], ['3-5', 1], ['3〜5', 1], ['3～5', 1],
+            ['低学年', 2],
+            ['中学年', 3],
+            ['高学年', 4],
+            ['中学生', 5],
+            ['高校生', 6],
+            ['大人',   7], ['成人', 7],
+        ];
+        foreach ($pairs as [$key, $code]) {
+            if (mb_strpos($vLower, $key, 0, 'UTF-8') !== false) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserCreateService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserCreateService.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー新規作成サービス
+ *
+ * 表示番号採番・ログインID重複チェック・ユーザー+グループ保存を担う。
+ */
+class UserCreateService
+{
+    /**
+     * 次の表示番号（MAX + 1）を返す。
+     */
+    public function nextDisplayNo(): int
+    {
+        $table       = TableRegistry::getTableLocator()->get('MUserInfo');
+        $maxDispNoRow = $table->find()
+            ->select(['max_no' => $table->find()->func()->max('i_disp_no')])
+            ->first();
+
+        return $maxDispNoRow && $maxDispNoRow->max_no !== null
+            ? ((int)$maxDispNoRow->max_no + 1)
+            : 1;
+    }
+
+    /**
+     * ログインIDが既に存在するか確認する。
+     */
+    public function loginAccountExists(string $loginId): bool
+    {
+        $table = TableRegistry::getTableLocator()->get('MUserInfo');
+        return (bool)$table->find()->where(['c_login_account' => $loginId])->first();
+    }
+
+    /**
+     * ユーザー情報と部屋所属情報をまとめて保存する。
+     *
+     * @param mixed  $entity     MUserInfo エンティティ（patchEntity 済み）
+     * @param array  $groupData  MUserGroup の入力データ配列（'i_id_room' を含む）
+     * @param string $createdBy  作成者ユーザー名
+     * @return bool
+     */
+    public function saveWithRooms(mixed $entity, array $groupData, string $createdBy): bool
+    {
+        $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        if (!$userInfoTable->save($entity)) {
+            return false;
+        }
+
+        $userId     = $entity->i_id_user;
+        $userGroups = [];
+
+        foreach ($groupData as $group) {
+            if (!empty($group['i_id_room'])) {
+                $userGroups[] = $userGroupTable->newEntity([
+                    'i_id_user'     => (int)$userId,
+                    'i_id_room'     => (int)$group['i_id_room'],
+                    'active_flag'   => 0,
+                    'dt_create'     => date('Y-m-d H:i:s'),
+                    'c_create_user' => $createdBy,
+                ]);
+            }
+        }
+
+        if (!empty($userGroups)) {
+            $userGroupTable->saveMany($userGroups);
+        }
+
+        return true;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザーソフトデリートサービス
+ *
+ * i_del_flag を立てて無効化し、MUserGroup の active_flag も無効化する。
+ */
+class UserDeletionService
+{
+    /**
+     * @param mixed  $user      MUserInfo エンティティ
+     * @param string $updatedBy 操作者ユーザー名
+     * @return bool
+     */
+    public function softDelete(mixed $user, string $updatedBy): bool
+    {
+        $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $user->i_del_flag    = 1;
+        $user->i_enable      = 1;
+        $user->dt_update     = date('Y-m-d H:i:s');
+        $user->c_update_user = $updatedBy;
+
+        $userGroups = $userGroupTable->find()
+            ->where(['i_id_user' => $user->i_id_user, 'active_flag' => 0])
+            ->all();
+
+        foreach ($userGroups as $group) {
+            $group->active_flag   = 1;
+            $group->dt_update     = date('Y-m-d H:i:s');
+            $group->c_update_user = $updatedBy;
+            $userGroupTable->save($group);
+        }
+
+        return (bool)$userInfoTable->save($user);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserEditService.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー編集サービス
+ *
+ * トランザクションを管理しながら、ユーザー情報と部屋所属情報を差し替え保存する。
+ */
+class UserEditService
+{
+    /**
+     * @param mixed  $entity    MUserInfo エンティティ（contain MUserGroup 済み）
+     * @param array  $data      リクエストデータ
+     * @param int[]  $roomIds   新しく所属させる部屋IDの配列
+     * @param string $updatedBy 操作者ユーザー名
+     * @return bool
+     * @throws \Exception
+     */
+    public function updateWithRooms(mixed $entity, array $data, array $roomIds, string $updatedBy): bool
+    {
+        $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $userId = $entity->i_id_user;
+
+        $newUserGroups = [];
+        foreach ($roomIds as $roomId) {
+            $newUserGroups[] = $userInfoTable->MUserGroup->newEntity([
+                'i_id_user'     => $userId,
+                'i_id_room'     => (int)$roomId,
+                'active_flag'   => 0,
+                'dt_create'     => date('Y-m-d H:i:s'),
+                'dt_update'     => date('Y-m-d H:i:s'),
+                'c_update_user' => $updatedBy,
+            ]);
+        }
+
+        $conn = $userInfoTable->getConnection();
+        $conn->begin();
+
+        try {
+            $userGroupTable->deleteAll(['i_id_user' => $userId]);
+
+            $entity = $userInfoTable->patchEntity($entity, $data, ['associated' => ['MUserGroup']]);
+            $entity->m_user_group = $newUserGroups;
+
+            if (!$userInfoTable->save($entity, ['associated' => ['MUserGroup']])) {
+                $conn->rollback();
+                return false;
+            }
+
+            $conn->commit();
+            return true;
+        } catch (\Exception $e) {
+            $conn->rollback();
+            throw $e;
+        }
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserPermissionService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserPermissionService.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー権限更新サービス
+ *
+ * i_admin フィールドの更新を担う（管理者フラグ・ブロック長フラグ共通）。
+ */
+class UserPermissionService
+{
+    /**
+     * @param mixed  $user      MUserInfo エンティティ（取得・認可済み）
+     * @param int    $value     新しい権限値
+     * @param string $updatedBy 操作者ユーザー名
+     * @return bool
+     */
+    public function updatePermission(mixed $user, int $value, string $updatedBy): bool
+    {
+        $table = TableRegistry::getTableLocator()->get('MUserInfo');
+
+        $user->i_admin       = $value;
+        $user->dt_update     = date('Y-m-d H:i:s');
+        $user->c_update_user = $updatedBy;
+
+        return (bool)$table->save($user);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserRestoreService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserRestoreService.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー復元サービス
+ *
+ * ソフトデリートされたユーザーを復元し、MUserGroup の active_flag も再有効化する。
+ * 処理はトランザクション内で実行される。
+ *
+ * @throws \Exception 保存失敗時
+ */
+class UserRestoreService
+{
+    /**
+     * @param mixed  $user      MUserInfo エンティティ（i_del_flag === 1 であること）
+     * @param string $updatedBy 操作者ユーザー名
+     * @return bool
+     * @throws \Exception
+     */
+    public function restore(mixed $user, string $updatedBy): bool
+    {
+        $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $conn = $userInfoTable->getConnection();
+        $conn->begin();
+
+        try {
+            $user->i_del_flag    = 0;
+            $user->dt_update     = date('Y-m-d H:i:s');
+            $user->c_update_user = $updatedBy;
+
+            if (!$userInfoTable->save($user)) {
+                throw new \Exception('ユーザー情報の更新に失敗しました。');
+            }
+
+            $userGroups = $userGroupTable->find()
+                ->where(['i_id_user' => $user->i_id_user])
+                ->all();
+
+            foreach ($userGroups as $group) {
+                $group->active_flag   = 0;
+                $group->dt_update     = date('Y-m-d H:i:s');
+                $group->c_update_user = $updatedBy;
+
+                if (!$userGroupTable->save($group)) {
+                    throw new \Exception('グループ情報の更新に失敗しました。');
+                }
+            }
+
+            $conn->commit();
+            return true;
+        } catch (\Exception $e) {
+            $conn->rollback();
+            throw $e;
+        }
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/UserRoomAssignmentService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserRoomAssignmentService.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * ユーザー部屋割り当てサービス
+ *
+ * 既存の所属（active_flag=0）を無効化し、指定部屋名で新規所属を登録する。
+ * 処理はトランザクション内で実行される。最大2部屋まで。
+ */
+class UserRoomAssignmentService
+{
+    /**
+     * @param int      $userId    対象ユーザーID
+     * @param string[] $roomNames 部屋名の配列（最大2件）
+     * @param string   $actor     操作者ユーザー名
+     * @return array{created: int, errors: string[]}
+     * @throws \Throwable
+     */
+    public function assign(int $userId, array $roomNames, string $actor): array
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $roomInfoTable  = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $roomNames = array_slice($roomNames, 0, 2);
+        $errors    = [];
+        $created   = 0;
+
+        $conn = $userGroupTable->getConnection();
+        $conn->begin();
+
+        try {
+            $oldGroups = $userGroupTable->find()
+                ->where(['i_id_user' => $userId, 'active_flag' => 0])
+                ->all();
+
+            foreach ($oldGroups as $group) {
+                $group->active_flag   = 1;
+                $group->dt_update     = date('Y-m-d H:i:s');
+                $group->c_update_user = $actor;
+                $userGroupTable->save($group);
+            }
+
+            foreach ($roomNames as $roomName) {
+                $room = $roomInfoTable->find()->where(['c_room_name' => $roomName])->first();
+                if ($room) {
+                    $newGroup = $userGroupTable->newEntity([
+                        'i_id_user'     => $userId,
+                        'i_id_room'     => $room->i_id_room,
+                        'active_flag'   => 0,
+                        'dt_create'     => date('Y-m-d H:i:s'),
+                        'c_create_user' => $actor,
+                    ]);
+                    if ($userGroupTable->save($newGroup)) {
+                        $created++;
+                    } else {
+                        $errors[] = "部屋 '{$roomName}' の登録に失敗";
+                    }
+                } else {
+                    $errors[] = "部屋名 '{$roomName}' が見つかりません";
+                }
+            }
+
+            $conn->commit();
+        } catch (\Throwable $e) {
+            $conn->rollback();
+            throw $e;
+        }
+
+        return ['created' => $created, 'errors' => $errors];
+    }
+}


### PR DESCRIPTION
## 概要

Issue #191 に対応し、Fat Controller を解消しました。
コントローラーからビジネスロジック・ORM直接操作を分離し、Service層へ移動しました。

## 変更内容

### Phase 1: MMealPriceInfoController・MRoomInfoController

| 新規Service | 分離したロジック |
|------------|----------------|
| `MealSummaryExportService` | 食事単価取得・職員ユーザー集計・料金計算 |
| `RoomService` | ユーザー集約・表示番号採番・ソフトデリート |

- `exportMealSummary()`: 90行 → 10行

### Phase 2: MUserInfoController（1,137行 → 660行、42%削減）

| 新規Service | 分離したロジック |
|------------|----------------|
| `UserBulkImportService` | importJson の正規化・トランザクション・ループ |
| `UserCreateService` | 採番・ログインID重複チェック・ユーザー+グループ保存 |
| `UserDeletionService` | ソフトデリート + MUserGroup 無効化 |
| `UserEditService` | トランザクション付き編集・グループ差し替え |
| `UserPermissionService` | i_admin フィールド更新（管理者・ブロック長共通） |
| `UserRestoreService` | 復元トランザクション + グループ再有効化 |
| `UserRoomAssignmentService` | 旧グループ無効化 → 部屋名で新規グループ登録 |

### Phase 3: TReservationInfoController・ReservationReportActionsTrait

| 変更 | 内容 |
|------|------|
| `MealReportingService` 新規作成 | reportNoMeal/reportEat のORM操作・キャッシュ無効化を分離 |
| `ReservationCalendarService` に `getStaffUserInfo()` 追加 | index() のORM直接クエリを分離 |
| `ActualMealManagementService` に `requestApproval()` 追加 | actualMealRequestApproval の updateAll ループを分離 |
| `ReservationReportActionsTrait` | runReportNoMeal/runReportEat を MealReportingService へ委譲（130行削減） |

## 受け入れ条件の確認

- [x] Controller のメソッドが薄くなっている（ORM直接記述・条件分岐ロジックなし）
- [x] 移動したロジックは独立したServiceクラスに存在し、単体テストが書ける状態