### PR TITLE
Resolve #218: 職員用食事予約グリッド画面の実装とUX改善

### DIFF
--- a/src_web/kamaho-shokusu/config/app.php
+++ b/src_web/kamaho-shokusu/config/app.php
@@ -3,6 +3,7 @@
 use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use App\Log\Engine\SlackLogEngine;
 use Cake\Log\Engine\FileLog;
 use Cake\Mailer\Transport\MailTransport;
 
@@ -362,6 +363,11 @@ return [
             'path' => CACHE . 'persistent/',
             'serialize' => true,
             'duration' => '+1 years',
+        ],
+        'slack_error' => [
+            'className' => SlackLogEngine::class,
+            'levels' => ['error', 'critical', 'alert', 'emergency'],
+            'scopes' => null,
         ],
         // To enable this dedicated query log, you need set your datasource's log flag to true
         'queries' => [

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -192,6 +192,12 @@ return function (RouteBuilder $routes): void {
             ['controller' => 'TReservationInfo', 'action' => 'getAllRoomsMealCounts']
         )->setMethods(['GET']);
 
+        // 職員用4週間予約グリッド
+        $builder->connect(
+            '/TReservationInfo/staff-reservation',
+            ['controller' => 'TReservationInfo', 'action' => 'staffReservation']
+        )->setMethods(['GET']);
+
         // 実食確認管理（大人限定）
         $builder->connect(
             '/TReservationInfo/actual-meal-management',

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -106,7 +106,7 @@ class TReservationInfoController extends AppController
         // $this->viewBuilder()->setOption('serialize', true);
         $this->viewBuilder()->setLayout('default');
 
-        if (isset($this->FormProtection)) {
+        if ($this->components()->has('FormProtection')) {
             $this->FormProtection->setConfig('unlockedActions', [
                 'toggle',
                 'checkDuplicateReservation',
@@ -957,10 +957,7 @@ class TReservationInfoController extends AppController
                 }
 
                 if ($roomId && isset($rooms[(int)$roomId])) {
-                    $room = $this->MRoomInfo->find()
-                        ->select(['i_id_room', 'c_room_name'])
-                        ->where(['i_id_room' => $roomId])
-                        ->first();
+                    $room = $changeEditService->getRoomById($this->MRoomInfo, (int)$roomId);
                 }
                 // 部屋が空の場合は警告ログ
                 if (empty($rooms)) {
@@ -1131,6 +1128,141 @@ class TReservationInfoController extends AppController
         }
     }
 
+
+    /**
+     * 職員用週間予約グリッド画面（ログインユーザー自身の予約を1週間単位で表示）
+     *
+     * クエリパラメータ:
+     *   week_start: 'YYYY-MM-DD' (表示週の月曜日、省略時=今週月曜)
+     *
+     * @return Response|null
+     */
+    public function staffReservation(): ?Response
+    {
+        $this->authorizeReservation('staffReservation');
+
+        $authUser = $this->Authentication->getIdentity();
+        if (!$authUser) {
+            throw new UnauthorizedException('ログインが必要です。');
+        }
+
+        $loginUserId = (int)$authUser->get('i_id_user');
+        $loginUserName = (string)($authUser->get('c_user_name') ?? '');
+        $isAdmin     = (int)($authUser->get('i_admin') ?? 0) === 1;
+        $isStaff     = (int)($authUser->get('i_user_level') ?? -1) === 0;
+
+        if (!$isAdmin && !$isStaff) {
+            throw new UnauthorizedException('職員・管理者のみ使用できます。');
+        }
+
+        /* ── 週の日付範囲（月曜〜日曜の7日間） ── */
+        $tz           = new \DateTimeZone('Asia/Tokyo');
+        $todayObj     = new \DateTimeImmutable('now', $tz);
+        $defaultStart = $todayObj->modify('monday this week');
+
+        $weekStartParam = $this->request->getQuery('week_start');
+        try {
+            $weekStart = $weekStartParam
+                ? new \DateTimeImmutable($weekStartParam, $tz)
+                : $defaultStart;
+        } catch (\Throwable) {
+            $weekStart = $defaultStart;
+        }
+        if ((int)$weekStart->format('N') !== 1) {
+            $weekStart = $weekStart->modify('monday this week');
+        }
+
+        $weekEnd = $weekStart->modify('+6 days'); // 月〜日の7日間
+
+        $dates = [];
+        $cursor = $weekStart;
+        while ($cursor <= $weekEnd) {
+            $dates[] = $cursor;
+            $cursor = $cursor->modify('+1 day');
+        }
+
+        /* ── 表示モード (individual / room / all) ── */
+        $mode = $this->request->getQuery('mode', 'individual');
+        if (!in_array($mode, ['individual', 'room', 'all'], true)) {
+            $mode = 'individual';
+        }
+        // 'all' モードは管理者のみ
+        if ($mode === 'all' && !$isAdmin) {
+            $mode = 'room';
+        }
+
+        /* ── ログインユーザーの所属部屋 ── */
+        $userRoomIds = $this->calendarService->getUserRoomIds($this->MUserGroup, $loginUserId);
+        $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $loginUserId);
+        $allRoomsForUser = $this->calendarService->getRoomsForUser(
+            $this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser
+        );
+
+        /* ── モード別グリッド行データ ── */
+        $startDateStr = $weekStart->format('Y-m-d');
+        $endDateStr   = $weekEnd->format('Y-m-d');
+
+        if ($mode === 'individual') {
+            $gridRoomIds = $userRoomIds;
+            $gridRows    = !empty($gridRoomIds)
+                ? $this->calendarService->buildStaffGridRows(
+                    $this->MUserGroup, $this->MUserInfo, $this->MRoomInfo,
+                    'individual', [$loginUserId], $gridRoomIds
+                  )
+                : [];
+            $gridUserIds = [$loginUserId];
+        } elseif ($mode === 'room') {
+            $gridRoomIds = $userRoomIds;
+            $gridRows    = !empty($gridRoomIds)
+                ? $this->calendarService->buildStaffGridRows(
+                    $this->MUserGroup, $this->MUserInfo, $this->MRoomInfo,
+                    'room', [], $gridRoomIds
+                  )
+                : [];
+            $gridUserIds = array_values(array_unique(array_column($gridRows, 'user_id')));
+        } else {
+            // 全部: 全部屋の全ユーザー（管理者のみ到達）
+            $gridRoomIds = $this->calendarService->getAllActiveRoomIds($this->MRoomInfo);
+            $gridRows    = $this->calendarService->buildStaffGridRows(
+                $this->MUserGroup, $this->MUserInfo, $this->MRoomInfo,
+                'all', [], $gridRoomIds
+            );
+            $gridUserIds = array_values(array_unique(array_column($gridRows, 'user_id')));
+        }
+
+        /* ── 予約グリッドデータ ── */
+        $grid = (!empty($gridUserIds) && !empty($gridRoomIds))
+            ? $this->calendarService->buildFourWeekGrid(
+                $this->TIndividualReservationInfo,
+                $gridUserIds,
+                $gridRoomIds,
+                $startDateStr,
+                $endDateStr
+              )
+            : [];
+
+        /* ── ナビゲーション ── */
+        $prevWeekStart = $weekStart->modify('-1 week');
+        $nextWeekStart = $weekStart->modify('+1 week');
+
+        /* ── ビューへ ── */
+        $this->set(compact(
+            'loginUserId',
+            'loginUserName',
+            'allRoomsForUser',
+            'dates',
+            'weekStart',
+            'weekEnd',
+            'prevWeekStart',
+            'nextWeekStart',
+            'gridRows',
+            'grid',
+            'isAdmin',
+            'mode'
+        ));
+
+        return null;
+    }
 
     public function getMealCounts($date): ?Response
     {
@@ -1350,38 +1482,15 @@ class TReservationInfoController extends AppController
             $selectedRoomId = !empty($rooms) ? (int)array_key_first($rooms) : null;
         }
 
-        // 週パラメータ: デフォルトは今週月曜
-        $today = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
-        $defaultMonday = $today->modify('monday this week')->format('Y-m-d');
-        $weekParam = $this->request->getQuery('week') ?? $defaultMonday;
-
-        try {
-            $weekDate = new \DateTimeImmutable($weekParam, new \DateTimeZone('Asia/Tokyo'));
-        } catch (\Throwable $e) {
-            $weekDate = new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'));
-        }
-        // 常に月曜日に正規化する
-        $weekMonday = (int)$weekDate->format('N') === 1
-            ? $weekDate
-            : $weekDate->modify('monday this week');
-
-        // 管理者の編集可能最古週
         $service = new \App\Service\ActualMealManagementService();
-        $oldestMonday = $isAdmin ? $service->getAdminOldestAllowedMonday() : $today->modify('monday this week');
-
-        // 週の範囲チェック（管理者以外は現在週のみ）
-        $futureMonday = $today->modify('monday this week')->modify('+4 weeks');
-        if (!$isAdmin && $weekMonday < $today->modify('monday this week')) {
-            $weekMonday = new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'));
-        }
-        if ($weekMonday < $oldestMonday) {
-            $weekMonday = $oldestMonday;
-        }
-        if ($weekMonday > $futureMonday) {
-            $weekMonday = $futureMonday;
-        }
-
-        $weekMondayStr = $weekMonday->format('Y-m-d');
+        $today   = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
+        $weekNav = $service->resolveWeekNavigation(
+            $this->request->getQuery('week'),
+            $isAdmin,
+            $today
+        );
+        $weekMonday    = $weekNav['weekMonday'];
+        $weekMondayStr = $weekNav['weekMondayStr'];
 
         // 大人ユーザーリストとグリッドデータ
         $adultUsers = [];
@@ -1389,34 +1498,22 @@ class TReservationInfoController extends AppController
 
         if ($selectedRoomId) {
             $adultUsers = $service->getAdultUsers($this->MUserGroup, $this->MUserInfo, $selectedRoomId);
-
-            // 管理者自身がリストにいない場合、選択部屋に所属していれば先頭に追加する
-            if ($isAdmin) {
-                $alreadyIn = array_filter($adultUsers, fn($u) => (int)$u['id'] === $userId);
-                if (empty($alreadyIn)) {
-                    $inRoom = $this->MUserGroup->find()
-                        ->where(['i_id_user' => $userId, 'i_id_room' => $selectedRoomId, 'active_flag' => 0])
-                        ->count() > 0;
-                    if ($inRoom) {
-                        array_unshift($adultUsers, [
-                            'id'       => $userId,
-                            'name'     => (string)($authUser->get('c_user_name') ?? ''),
-                            'staff_id' => (string)($authUser->get('i_id_staff') ?? ''),
-                        ]);
-                    }
-                }
-            }
-
+            $adultUsers = $service->ensureUserInList(
+                $adultUsers,
+                $userId,
+                (string)($authUser->get('c_user_name') ?? ''),
+                (string)($authUser->get('i_id_staff') ?? ''),
+                $selectedRoomId,
+                $isAdmin,
+                $this->MUserGroup
+            );
             $gridData = $service->buildWeekGrid($this->TIndividualReservationInfo, $adultUsers, $weekMondayStr);
         }
 
-        // 前週・次週の月曜日
-        $prevMonday = $weekMonday->modify('-7 days');
-        $nextMonday = $weekMonday->modify('+7 days');
-
-        // 前週ナビが使えるか（最古週より前はNG）
-        $canGoPrev = $isAdmin && $prevMonday >= $oldestMonday;
-        $canGoNext = $nextMonday <= $futureMonday;
+        $prevMonday = $weekNav['prevMonday'];
+        $nextMonday = $weekNav['nextMonday'];
+        $canGoPrev  = $weekNav['canGoPrev'];
+        $canGoNext  = $weekNav['canGoNext'];
 
         $this->set(compact(
             'rooms',
@@ -1453,17 +1550,8 @@ class TReservationInfoController extends AppController
         $isBlockLeader = (int)($authUser->get('i_admin') ?? 0) === 2;
         $canProxyActualMeal = $isAdmin || $isBlockLeader;
 
-        // ユーザーの所属部屋
         $userRoomIds = $this->calendarService->getUserRoomIds($this->MUserGroup, $userId);
-        $rooms = [];
-        if (!empty($userRoomIds)) {
-            $rooms = $this->MRoomInfo->find()
-                ->where(['i_id_room IN' => $userRoomIds, 'i_del_flg' => 0])
-                ->orderAsc('i_disp_no')
-                ->all()
-                ->combine('i_id_room', 'c_room_name')
-                ->toArray();
-        }
+        $rooms       = $this->calendarService->getRoomsByIds($this->MRoomInfo, $userRoomIds);
 
         $selectedRoomId = $this->request->getQuery('room_id')
             ? (int)$this->request->getQuery('room_id')
@@ -1472,56 +1560,36 @@ class TReservationInfoController extends AppController
             $selectedRoomId = !empty($rooms) ? (int)array_key_first($rooms) : null;
         }
 
-        // 週パラメータ（管理者は2ヶ月前まで遡れる、一般は今週のみ）
-        $today = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
-        $defaultMonday = $today->modify('monday this week')->format('Y-m-d');
-        $weekParam = $this->request->getQuery('week') ?? $defaultMonday;
-
-        try {
-            $weekDate = new \DateTimeImmutable($weekParam, new \DateTimeZone('Asia/Tokyo'));
-        } catch (\Throwable $e) {
-            $weekDate = new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'));
-        }
-        $weekMonday = (int)$weekDate->format('N') === 1
-            ? $weekDate
-            : $weekDate->modify('monday this week');
-
         $service = new \App\Service\ActualMealManagementService();
-        $oldestMonday  = $isAdmin ? $service->getAdminOldestAllowedMonday() : new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'));
-        $futureMonday  = $today->modify('monday this week')->modify('+4 weeks');
+        $today   = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
+        $weekNav = $service->resolveWeekNavigation(
+            $this->request->getQuery('week'),
+            $isAdmin,
+            $today
+        );
+        $weekMondayStr = $weekNav['weekMondayStr'];
+        $prevMonday    = $weekNav['prevMonday'];
+        $nextMonday    = $weekNav['nextMonday'];
+        $canGoPrev     = $weekNav['canGoPrev'];
+        $canGoNext     = $weekNav['canGoNext'];
 
-        if (!$isAdmin && $weekMonday < new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'))) {
-            $weekMonday = new \DateTimeImmutable($defaultMonday, new \DateTimeZone('Asia/Tokyo'));
-        }
-        if ($weekMonday < $oldestMonday) $weekMonday = $oldestMonday;
-        if ($weekMonday > $futureMonday) $weekMonday = $futureMonday;
-
-        $weekMondayStr = $weekMonday->format('Y-m-d');
-        $prevMonday    = $weekMonday->modify('-7 days');
-        $nextMonday    = $weekMonday->modify('+7 days');
-        $canGoPrev     = $isAdmin && $prevMonday >= $oldestMonday;
-        $canGoNext     = $nextMonday <= $futureMonday;
-
-        $targetUsers = [[
-            'id' => $userId,
-            'name' => (string)$authUser->get('c_user_name'),
+        $selfEntry = [
+            'id'       => $userId,
+            'name'     => (string)$authUser->get('c_user_name'),
             'staff_id' => (string)($authUser->get('i_id_staff') ?? ''),
-        ]];
+        ];
+        $targetUsers = [$selfEntry];
         if ($canProxyActualMeal && $selectedRoomId) {
             $targetUsers = $service->getAdultUsers($this->MUserGroup, $this->MUserInfo, $selectedRoomId);
-            $hasSelf = array_filter($targetUsers, fn($targetUser) => (int)$targetUser['id'] === $userId);
-            if (empty($hasSelf) && $selectedRoomId !== null) {
-                $belongsToRoom = $isAdmin || $this->MUserGroup->find()
-                    ->where(['i_id_user' => $userId, 'i_id_room' => $selectedRoomId, 'active_flag' => 0])
-                    ->count() > 0;
-                if ($belongsToRoom) {
-                    array_unshift($targetUsers, [
-                        'id' => $userId,
-                        'name' => (string)$authUser->get('c_user_name'),
-                        'staff_id' => (string)($authUser->get('i_id_staff') ?? ''),
-                    ]);
-                }
-            }
+            $targetUsers = $service->ensureUserInList(
+                $targetUsers,
+                $userId,
+                $selfEntry['name'],
+                $selfEntry['staff_id'],
+                $selectedRoomId,
+                $isAdmin,
+                $this->MUserGroup
+            );
         }
 
         $selectedUserId = $this->request->getQuery('user_id')
@@ -1699,15 +1767,8 @@ class TReservationInfoController extends AppController
                 return '担当外の部屋データは保存できません。';
             }
 
-            $targetBelongsToRoom = $this->MUserGroup->find()
-                ->where([
-                    'i_id_user' => $targetUid,
-                    'i_id_room' => $roomId,
-                    'active_flag' => 0,
-                ])
-                ->count() > 0;
-
-            if (!$targetBelongsToRoom) {
+            $actMealService = new \App\Service\ActualMealManagementService();
+            if (!$actMealService->userBelongsToRoom($this->MUserGroup, $targetUid, $roomId)) {
                 return '対象利用者は選択中の部屋に所属していません。';
             }
 

--- a/src_web/kamaho-shokusu/src/Log/Engine/SlackLogEngine.php
+++ b/src_web/kamaho-shokusu/src/Log/Engine/SlackLogEngine.php
@@ -10,9 +10,21 @@ use Cake\Log\Engine\BaseLog;
  * エラーレベル以上のログをSlackへ通知するログエンジン。
  *
  * 環境変数 SLACK_ERROR_WEBHOOK にIncoming Webhook URLを設定することで有効になる。
+ * テスト時は config['httpClient'] にモックを渡すことで HTTP 通信を差し替えられる。
  */
 final class SlackLogEngine extends BaseLog
 {
+    private Client $httpClient;
+
+    /**
+     * @param array $config 設定配列。'httpClient' キーでテスト用クライアントを注入可能。
+     */
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config);
+        $this->httpClient = $config['httpClient'] ?? new Client();
+    }
+
     /**
      * @param string $level ログレベル
      * @param string $message ログメッセージ
@@ -27,12 +39,12 @@ final class SlackLogEngine extends BaseLog
 
         $emoji = match ($level) {
             'emergency', 'alert' => ':rotating_light:',
-            'critical' => ':fire:',
-            default => ':warning:',
+            'critical'           => ':fire:',
+            default              => ':warning:',
         };
 
         $lines = [
-            $emoji . ' *[' . strtoupper((string)$level) . '] システムエラーが発生しました*',
+            "{$emoji} *[" . strtoupper((string)$level) . '] システムエラーが発生しました*',
             '>*メッセージ:* ' . $message,
             '>*日時:* ' . date('Y-m-d H:i:s'),
         ];
@@ -46,18 +58,17 @@ final class SlackLogEngine extends BaseLog
         }
 
         if (!empty($context['trace'])) {
-            $trace = is_array($context['trace'])
-                ? implode("\n", array_slice($context['trace'], 0, 5))
+            $trace = \is_array($context['trace'])
+                ? implode("\n", \array_slice($context['trace'], 0, 5))
                 : substr((string)$context['trace'], 0, 500);
             $lines[] = '>*スタックトレース（冒頭）:*';
-            $lines[] = '>```' . $trace . '```';
+            $lines[] = ">```{$trace}```";
         }
 
         $text = implode("\n", $lines);
 
         try {
-            $http = new Client();
-            $http->post($webhookUrl, json_encode(['text' => $text]), ['type' => 'json']);
+            $this->httpClient->post($webhookUrl, json_encode(['text' => $text], JSON_UNESCAPED_UNICODE), ['type' => 'json']);
         } catch (\Throwable) {
         }
     }

--- a/src_web/kamaho-shokusu/src/Log/Engine/SlackLogEngine.php
+++ b/src_web/kamaho-shokusu/src/Log/Engine/SlackLogEngine.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Log\Engine;
+
+use Cake\Http\Client;
+use Cake\Log\Engine\BaseLog;
+
+/**
+ * エラーレベル以上のログをSlackへ通知するログエンジン。
+ *
+ * 環境変数 SLACK_ERROR_WEBHOOK にIncoming Webhook URLを設定することで有効になる。
+ */
+final class SlackLogEngine extends BaseLog
+{
+    /**
+     * @param string $level ログレベル
+     * @param string $message ログメッセージ
+     * @param array $context コンテキスト情報
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $webhookUrl = env('SLACK_ERROR_WEBHOOK', '');
+        if ($webhookUrl === '') {
+            return;
+        }
+
+        $emoji = match ($level) {
+            'emergency', 'alert' => ':rotating_light:',
+            'critical' => ':fire:',
+            default => ':warning:',
+        };
+
+        $lines = [
+            $emoji . ' *[' . strtoupper((string)$level) . '] システムエラーが発生しました*',
+            '>*メッセージ:* ' . $message,
+            '>*日時:* ' . date('Y-m-d H:i:s'),
+        ];
+
+        if (!empty($context['file'])) {
+            $fileLine = '>*ファイル:* ' . $context['file'];
+            if (!empty($context['line'])) {
+                $fileLine .= ' (行: ' . $context['line'] . ')';
+            }
+            $lines[] = $fileLine;
+        }
+
+        if (!empty($context['trace'])) {
+            $trace = is_array($context['trace'])
+                ? implode("\n", array_slice($context['trace'], 0, 5))
+                : substr((string)$context['trace'], 0, 500);
+            $lines[] = '>*スタックトレース（冒頭）:*';
+            $lines[] = '>```' . $trace . '```';
+        }
+
+        $text = implode("\n", $lines);
+
+        try {
+            $http = new Client();
+            $http->post($webhookUrl, json_encode(['text' => $text]), ['type' => 'json']);
+        } catch (\Throwable) {
+        }
+    }
+}

--- a/src_web/kamaho-shokusu/src/Model/Table/TIndividualReservationInfoTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/TIndividualReservationInfoTable.php
@@ -13,6 +13,17 @@ use Cake\Validation\Validator;
 
 class TIndividualReservationInfoTable extends Table
 {
+    public const MEAL_BREAKFAST = 1;
+    public const MEAL_LUNCH     = 2;
+    public const MEAL_DINNER    = 3;
+    public const MEAL_BENTO     = 4;
+
+    /** 昼↔弁当の排他ペア [一方 => 他方] */
+    private const MEAL_OPPONENTS = [
+        self::MEAL_LUNCH  => self::MEAL_BENTO,
+        self::MEAL_BENTO  => self::MEAL_LUNCH,
+    ];
+
     public function initialize(array $config): void
     {
         parent::initialize($config);
@@ -58,7 +69,7 @@ class TIndividualReservationInfoTable extends Table
         // 昼(2)⇔弁(4)の排他（その日の“有効値”で判定）
         $rules->add(function (EntityInterface $entity): bool {
             $type = (int)$entity->i_reservation_type;
-            if (!in_array($type, [2, 4], true)) {
+            if (!array_key_exists($type, self::MEAL_OPPONENTS)) {
                 return true;
             }
             $date = $entity->d_reservation_date instanceof \DateTimeInterface
@@ -76,7 +87,7 @@ class TIndividualReservationInfoTable extends Table
             };
 
             // 相手タイプ
-            $opponentType = $type === 2 ? 4 : 2;
+            $opponentType = self::MEAL_OPPONENTS[$type];
 
             // 必要カラムのみ取得
             $rows = $this->find()
@@ -92,8 +103,8 @@ class TIndividualReservationInfoTable extends Table
             $hasLunch = false; $hasBento = false;
             foreach ($rows as $r) {
                 $eff = $effective($r);
-                if ((int)$r->i_reservation_type === 2) $hasLunch = $hasLunch || ($eff === 1);
-                if ((int)$r->i_reservation_type === 4) $hasBento = $hasBento || ($eff === 1);
+                if ((int)$r->i_reservation_type === self::MEAL_LUNCH)  $hasLunch = $hasLunch || ($eff === 1);
+                if ((int)$r->i_reservation_type === self::MEAL_BENTO)  $hasBento = $hasBento || ($eff === 1);
             }
 
             // 今回エンティティの有効化も反映
@@ -101,8 +112,8 @@ class TIndividualReservationInfoTable extends Table
                 ? (int)($entity->i_change_flag ?? $entity->eat_flag ?? 0)
                 : (int)($entity->eat_flag ?? 0);
 
-            if ($type === 2 && $thisEff === 1) $hasLunch = true;
-            if ($type === 4 && $thisEff === 1) $hasBento = true;
+            if ($type === self::MEAL_LUNCH  && $thisEff === 1) $hasLunch = true;
+            if ($type === self::MEAL_BENTO  && $thisEff === 1) $hasBento = true;
 
             return !($hasLunch && $hasBento);
         }, 'uniqueLunchBentoEffective', [
@@ -134,28 +145,30 @@ class TIndividualReservationInfoTable extends Table
         bool $on,
         string $actor,
         ?int $eatFlag = null,
-        ?int $changeFlag = null
+        ?int $changeFlag = null,
+        ?bool $useChangeFlag = null  // true=直前編集(i_change_flag), false=通常(eat_flag)
     ): array {
-        if (!in_array($meal, [1, 2, 3, 4], true)) {
+        $validMeals = [self::MEAL_BREAKFAST, self::MEAL_LUNCH, self::MEAL_DINNER, self::MEAL_BENTO];
+        if (!in_array($meal, $validMeals, true)) {
             throw new \InvalidArgumentException('meal は 1(朝)/2(昼)/3(夜)/4(弁) のみ');
         }
 
-        $today = Date::today();
-        $d     = new Date($date);
-        $isLastMinute = ($d >= $today && $d <= $today->addDays(14));
+        // useChangeFlag が未指定の場合のみフォールバック計算（後方互換）
+        if ($useChangeFlag === null) {
+            $today = Date::today();
+            $d     = new Date($date);
+            $useChangeFlag = ($d <= $today->addDays(14));
+        }
 
-        // コントローラから明示があればそれを、無ければ規定ロジックで
         if ($eatFlag === null || $changeFlag === null) {
-            $eat  = $on ? ($isLastMinute ? 0 : 1) : 0;
-            $chg  = $on ? 1 : 0;
-            $eatFlag    = $eatFlag    ?? $eat;
-            $changeFlag = $changeFlag ?? $chg;
+            $eatFlag    = $eatFlag    ?? ($on ? ($useChangeFlag ? 0 : 1) : 0);
+            $changeFlag = $changeFlag ?? ($on ? 1 : 0);
         }
 
         $now = DateTime::now();
 
         return $this->getConnection()->transactional(function () use (
-            $userId, $roomId, $date, $meal, $on, $actor, $now, $isLastMinute, $eatFlag, $changeFlag
+            $userId, $roomId, $date, $meal, $on, $actor, $now, $useChangeFlag, $eatFlag, $changeFlag
         ) {
 
             // 対象レコード取得（必要カラムのみ、autoFields無効化）
@@ -187,13 +200,13 @@ class TIndividualReservationInfoTable extends Table
                 $isNew = true;
             }
 
-            // フラグの確定（NULL を残さない）
-            if ($isLastMinute) {
-                $entity->i_change_flag = (int)$changeFlag;                // 0/1
-                $entity->eat_flag      = (int)($entity->eat_flag ?? 0);   // 既存NULLを0に
+            // フラグの確定: ReservationDatePolicy の判定に従い書き込む列を決定する
+            if ($useChangeFlag) {
+                $entity->i_change_flag = (int)$changeFlag;                // 直前編集: i_change_flag を更新
+                $entity->eat_flag      = (int)($entity->eat_flag ?? 0);   // eat_flag は既存値を保持
             } else {
-                $entity->eat_flag      = (int)$eatFlag;                   // 0/1
-                $entity->i_change_flag = (int)$changeFlag;                // 通常予約でも1にする
+                $entity->eat_flag      = (int)$eatFlag;                   // 通常予約: eat_flag を更新
+                $entity->i_change_flag = (int)$changeFlag;                // i_change_flag も連動して更新
             }
 
             // 監査: 新規か更新かで分岐
@@ -225,8 +238,8 @@ class TIndividualReservationInfoTable extends Table
             }
 
             // 昼/弁の相互排他：ON にしたら相手は OFF
-            if ($on && in_array($meal, [2, 4], true)) {
-                $opponentMeal = ($meal === 2) ? 4 : 2;
+            if ($on && array_key_exists($meal, self::MEAL_OPPONENTS)) {
+                $opponentMeal = self::MEAL_OPPONENTS[$meal];
 
                 $opponent = $this->find()
                     ->enableAutoFields(false)
@@ -256,7 +269,7 @@ class TIndividualReservationInfoTable extends Table
                     $oppIsNew = true;
                 }
 
-                if ($isLastMinute) {
+                if ($useChangeFlag) {
                     $opponent->i_change_flag = 0;
                     $opponent->eat_flag      = (int)($opponent->eat_flag ?? 0);
                 } else {
@@ -293,10 +306,15 @@ class TIndividualReservationInfoTable extends Table
             }
 
             // “有効値”詳細
-            $details = $this->getDayDetailsEffective($userId, $roomId, $date, $isLastMinute);
+            $details = $this->getDayDetailsEffective($userId, $roomId, $date, $useChangeFlag);
 
-            $map = [1 => 'breakfast', 2 => 'lunch', 3 => 'dinner', 4 => 'bento'];
-            $mealKey = $map[$meal];
+            $mealKeyMap = [
+                self::MEAL_BREAKFAST => 'breakfast',
+                self::MEAL_LUNCH     => 'lunch',
+                self::MEAL_DINNER    => 'dinner',
+                self::MEAL_BENTO     => 'bento',
+            ];
+            $mealKey = $mealKeyMap[$meal];
 
             return [
                 'value'   => (bool)$details[$mealKey],
@@ -326,11 +344,23 @@ class TIndividualReservationInfoTable extends Table
                 'i_id_user'             => $userId,
                 'd_reservation_date'    => $date,
                 'i_id_room'             => $roomId,
-                'i_reservation_type IN' => [1,2,3,4],
+                'i_reservation_type IN' => [
+                    self::MEAL_BREAKFAST,
+                    self::MEAL_LUNCH,
+                    self::MEAL_DINNER,
+                    self::MEAL_BENTO,
+                ],
             ])
             ->all();
 
-        $details = ['breakfast'=>false,'lunch'=>false,'dinner'=>false,'bento'=>false];
+        $details = ['breakfast' => false, 'lunch' => false, 'dinner' => false, 'bento' => false];
+
+        $mealKeyMap = [
+            self::MEAL_BREAKFAST => 'breakfast',
+            self::MEAL_LUNCH     => 'lunch',
+            self::MEAL_DINNER    => 'dinner',
+            self::MEAL_BENTO     => 'bento',
+        ];
 
         $effective = static function ($eatFlag, $chgFlag) use ($isLastMinute): int {
             if ($isLastMinute && $chgFlag !== null) return (int)$chgFlag;
@@ -338,12 +368,10 @@ class TIndividualReservationInfoTable extends Table
         };
 
         foreach ($rows as $r) {
-            $val = $effective($r->eat_flag, $r->i_change_flag) === 1;
-            switch ((int)$r->i_reservation_type) {
-                case 1: $details['breakfast'] = $val; break;
-                case 2: $details['lunch']     = $val; break;
-                case 3: $details['dinner']    = $val; break;
-                case 4: $details['bento']     = $val; break;
+            $type = (int)$r->i_reservation_type;
+            $key  = $mealKeyMap[$type] ?? null;
+            if ($key !== null) {
+                $details[$key] = $effective($r->eat_flag, $r->i_change_flag) === 1;
             }
         }
         return $details;

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -181,6 +181,11 @@ class TReservationInfoPolicy
         return $this->isAuthenticated($user);
     }
 
+    public function canStaffReservation(?IdentityInterface $user, TReservationInfo $resource): bool
+    {
+        return $this->isStaffOrAdmin($user);
+    }
+
     private function isAuthenticated(?IdentityInterface $user): bool
     {
         return $this->getOriginalIdentity($user) !== null;

--- a/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
+++ b/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
@@ -331,6 +331,128 @@ class ActualMealManagementService
     }
 
     /**
+     * 週ナビゲーションを解決する。
+     *
+     * クエリパラメータで指定された週を月曜日に正規化し、許可範囲内にクランプして
+     * 前週・次週への遷移フラグとともに返す。
+     *
+     * @param string|null        $weekParam クエリから取得した週パラメータ (YYYY-MM-DD)
+     * @param bool               $isAdmin   管理者フラグ
+     * @param \DateTimeImmutable $today     基準となる「今日」
+     * @return array{
+     *   weekMonday: \DateTimeImmutable,
+     *   weekMondayStr: string,
+     *   prevMonday: \DateTimeImmutable,
+     *   nextMonday: \DateTimeImmutable,
+     *   canGoPrev: bool,
+     *   canGoNext: bool,
+     *   oldestMonday: \DateTimeImmutable,
+     * }
+     */
+    public function resolveWeekNavigation(?string $weekParam, bool $isAdmin, \DateTimeImmutable $today): array
+    {
+        $tz = new \DateTimeZone('Asia/Tokyo');
+        $defaultMonday = $today->modify('monday this week');
+        $oldestMonday  = $isAdmin
+            ? $this->getAdminOldestAllowedMonday()
+            : $defaultMonday;
+        $futureMonday  = $defaultMonday->modify('+4 weeks');
+
+        try {
+            $weekDate = $weekParam !== null && $weekParam !== ''
+                ? new \DateTimeImmutable($weekParam, $tz)
+                : $defaultMonday;
+        } catch (\Throwable) {
+            $weekDate = $defaultMonday;
+        }
+
+        $weekMonday = (int)$weekDate->format('N') === 1
+            ? $weekDate
+            : $weekDate->modify('monday this week');
+
+        if (!$isAdmin && $weekMonday < $defaultMonday) {
+            $weekMonday = $defaultMonday;
+        }
+        if ($weekMonday < $oldestMonday) {
+            $weekMonday = $oldestMonday;
+        }
+        if ($weekMonday > $futureMonday) {
+            $weekMonday = $futureMonday;
+        }
+
+        $prevMonday = $weekMonday->modify('-7 days');
+        $nextMonday = $weekMonday->modify('+7 days');
+
+        return [
+            'weekMonday'    => $weekMonday,
+            'weekMondayStr' => $weekMonday->format('Y-m-d'),
+            'prevMonday'    => $prevMonday,
+            'nextMonday'    => $nextMonday,
+            'canGoPrev'     => $isAdmin && $prevMonday >= $oldestMonday,
+            'canGoNext'     => $nextMonday <= $futureMonday,
+            'oldestMonday'  => $oldestMonday,
+        ];
+    }
+
+    /**
+     * ユーザーリストに指定ユーザーが含まれていない場合、部屋所属チェック後に先頭へ追加する。
+     *
+     * 管理者は部屋所属チェックをスキップして常に追加候補とする。
+     *
+     * @param array  $users          getAdultUsers() の返却値
+     * @param int    $userId         追加対象のユーザーID
+     * @param string $userName       追加対象のユーザー名
+     * @param string $staffId        追加対象のスタッフID
+     * @param int    $roomId         対象部屋ID
+     * @param bool   $isAdmin        管理者フラグ（true なら部屋チェック不要）
+     * @param Table  $userGroupTable MUserGroup テーブル
+     * @return array 更新後のユーザーリスト
+     */
+    public function ensureUserInList(
+        array $users,
+        int $userId,
+        string $userName,
+        string $staffId,
+        int $roomId,
+        bool $isAdmin,
+        Table $userGroupTable
+    ): array {
+        $alreadyIn = !empty(array_filter($users, fn($u) => (int)$u['id'] === $userId));
+        if ($alreadyIn) {
+            return $users;
+        }
+
+        $belongsToRoom = $isAdmin || $userGroupTable->find()
+            ->where(['i_id_user' => $userId, 'i_id_room' => $roomId, 'active_flag' => 0])
+            ->count() > 0;
+
+        if ($belongsToRoom) {
+            array_unshift($users, [
+                'id'       => $userId,
+                'name'     => $userName,
+                'staff_id' => $staffId,
+            ]);
+        }
+
+        return $users;
+    }
+
+    /**
+     * 指定ユーザーが部屋に所属しているかを確認する。
+     *
+     * @param Table $userGroupTable MUserGroup テーブル
+     * @param int   $userId         対象ユーザーID
+     * @param int   $roomId         対象部屋ID
+     * @return bool
+     */
+    public function userBelongsToRoom(Table $userGroupTable, int $userId, int $roomId): bool
+    {
+        return $userGroupTable->find()
+            ->where(['i_id_user' => $userId, 'i_id_room' => $roomId, 'active_flag' => 0])
+            ->count() > 0;
+    }
+
+    /**
      * 日付の正規化（YYYY-MM-DD 文字列に変換する）。
      */
     private function normalizeDateString(mixed $value): ?string

--- a/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
@@ -150,8 +150,8 @@ class ReservationCalendarService
             $type    = (int)$r->i_reservation_type;
 
             $effective = ($r->d_reservation_date <= $borderDate)
-                ? (int)$r->i_change_flag
-                : (int)$r->eat_flag;
+                ? ($r->i_change_flag !== null ? (int)$r->i_change_flag : (int)($r->eat_flag ?? 0))
+                : (int)($r->eat_flag ?? 0);
 
             if ($effective !== 1) {
                 continue;
@@ -212,8 +212,8 @@ class ReservationCalendarService
             }
 
             $effective = ($r->d_reservation_date <= $borderDate)
-                ? (int)$r->i_change_flag
-                : (int)$r->eat_flag;
+                ? ($r->i_change_flag !== null ? (int)$r->i_change_flag : (int)($r->eat_flag ?? 0))
+                : (int)($r->eat_flag ?? 0);
 
             $details[$dateStr][$key] = $effective;
         }
@@ -315,8 +315,8 @@ class ReservationCalendarService
         foreach ($rows as $r) {
             $dateStr = $r->d_reservation_date->format('Y-m-d');
             $effective = ($r->d_reservation_date <= $borderDate)
-                ? (int)$r->i_change_flag
-                : (int)$r->eat_flag;
+                ? ($r->i_change_flag !== null ? (int)$r->i_change_flag : (int)($r->eat_flag ?? 0))
+                : (int)($r->eat_flag ?? 0);
             if ($effective === 1) {
                 $dateCounts[$dateStr] = ($dateCounts[$dateStr] ?? 0) + 1;
             }
@@ -356,6 +356,229 @@ class ReservationCalendarService
             )
             ->where(['MUserGroup.i_id_user' => $userId])
             ->enableHydration(false)
+            ->toArray();
+    }
+
+    /**
+     * 職員用4週間グリッド: ユーザー×部屋×日付×食事種別の予約状況を返す。
+     *
+     * @param Table  $reservationTable TIndividualReservationInfo
+     * @param array  $userIds          対象ユーザーIDの配列
+     * @param array  $roomIds          対象部屋IDの配列
+     * @param string $startDate        YYYY-MM-DD
+     * @param string $endDate          YYYY-MM-DD (inclusive)
+     * @return array [userId][roomId][date][mealType(1-4)] = 0|1
+     */
+    public function buildFourWeekGrid(
+        Table $reservationTable,
+        array $userIds,
+        array $roomIds,
+        string $startDate,
+        string $endDate
+    ): array {
+        if (empty($userIds) || empty($roomIds)) {
+            return [];
+        }
+
+        $borderDate = $this->datePolicy->changeBoundaryDate();
+
+        $rows = $reservationTable->find()
+            ->select([
+                'i_id_user',
+                'i_id_room',
+                'd_reservation_date',
+                'i_reservation_type',
+                'eat_flag',
+                'i_change_flag',
+            ])
+            ->where([
+                'i_id_user IN'           => $userIds,
+                'i_id_room IN'           => $roomIds,
+                'd_reservation_date >='  => $startDate,
+                'd_reservation_date <='  => $endDate,
+            ])
+            ->enableHydration(false)
+            ->toArray();
+
+        $grid = [];
+        foreach ($rows as $r) {
+            $uid      = (int)$r['i_id_user'];
+            $rid      = (int)$r['i_id_room'];
+            $dateObj  = $r['d_reservation_date'];
+            $dateStr  = is_string($dateObj) ? substr($dateObj, 0, 10) : $dateObj->format('Y-m-d');
+            $type     = (int)$r['i_reservation_type'];
+            $dateObjForCmp = $dateObj instanceof \DateTimeInterface
+                ? $dateObj
+                : new \DateTimeImmutable($dateStr);
+
+            $effective = ($dateObjForCmp <= $borderDate)
+                ? ($r['i_change_flag'] !== null ? (int)$r['i_change_flag'] : (int)($r['eat_flag'] ?? 0))
+                : (int)($r['eat_flag'] ?? 0);
+
+            $grid[$uid][$rid][$dateStr][$type] = $effective;
+        }
+
+        return $grid;
+    }
+
+    /**
+     * 部屋に所属する職員ユーザー一覧を返す。
+     *
+     * @param Table    $userGroupTable  MUserGroup
+     * @param Table    $userInfoTable   MUserInfo
+     * @param int[]    $roomIds         対象部屋ID配列（空=全部屋）
+     * @param bool     $staffOnly       trueなら職員のみ（i_user_level=0）
+     * @return array   [{user_id, user_name, staff_id, room_ids[]}]
+     */
+    public function getUsersInRooms(
+        Table $userGroupTable,
+        Table $userInfoTable,
+        array $roomIds,
+        bool $staffOnly = false
+    ): array {
+        $query = $userGroupTable->find()
+            ->enableAutoFields(false)
+            ->select([
+                'user_id'   => 'MUserGroup.i_id_user',
+                'room_id'   => 'MUserGroup.i_id_room',
+                'user_name' => 'MUserInfo.c_user_name',
+                'staff_id'  => 'MUserInfo.i_id_staff',
+                'user_level'=> 'MUserInfo.i_user_level',
+            ])
+            ->innerJoin(
+                ['MUserInfo' => $userInfoTable->getTable()],
+                ['MUserInfo.i_id_user = MUserGroup.i_id_user', 'MUserInfo.i_del_flag' => 0]
+            )
+            ->where(['MUserGroup.active_flag' => 0]);
+
+        if (!empty($roomIds)) {
+            $query->where(['MUserGroup.i_id_room IN' => $roomIds]);
+        }
+
+        if ($staffOnly) {
+            $query->where(['MUserInfo.i_user_level' => 0]);
+        }
+
+        $query->orderBy(['MUserInfo.c_user_name' => 'ASC', 'MUserGroup.i_id_room' => 'ASC'])
+              ->enableHydration(false);
+
+        $rows = $query->toArray();
+
+        // user_id をキーに room_ids を集約
+        $byUser = [];
+        foreach ($rows as $r) {
+            $uid = (int)$r['user_id'];
+            if (!isset($byUser[$uid])) {
+                $byUser[$uid] = [
+                    'user_id'    => $uid,
+                    'user_name'  => (string)$r['user_name'],
+                    'staff_id'   => (string)($r['staff_id'] ?? ''),
+                    'user_level' => (int)$r['user_level'],
+                    'room_ids'   => [],
+                ];
+            }
+            $byUser[$uid]['room_ids'][] = (int)$r['room_id'];
+        }
+
+        return array_values($byUser);
+    }
+
+    /**
+     * 職員用4週間グリッドの行データを構築する。
+     *
+     * @param Table  $userGroupTable
+     * @param Table  $userInfoTable
+     * @param Table  $roomTable
+     * @param string $viewMode       'individual'|'room'|'all'
+     * @param int[]  $targetUserIds  個人モード時の対象ユーザーID配列
+     * @param int[]  $targetRoomIds  部屋モード時の対象部屋ID配列（全部屋=all部屋ID配列）
+     * @return array [{room_id, room_name, user_id, user_name, staff_id}]
+     */
+    public function buildStaffGridRows(
+        Table $userGroupTable,
+        Table $userInfoTable,
+        Table $roomTable,
+        string $viewMode,
+        array $targetUserIds,
+        array $targetRoomIds
+    ): array {
+        $whereUser = empty($targetUserIds) ? [] : ['MUserGroup.i_id_user IN' => $targetUserIds];
+        $whereRoom = empty($targetRoomIds) ? [] : ['MUserGroup.i_id_room IN' => $targetRoomIds];
+
+        $query = $userGroupTable->find()
+            ->enableAutoFields(false)
+            ->select([
+                'user_id'    => 'MUserGroup.i_id_user',
+                'room_id'    => 'MUserGroup.i_id_room',
+                'user_name'  => 'MUserInfo.c_user_name',
+                'staff_id'   => 'MUserInfo.i_id_staff',
+                'room_name'  => 'MRoomInfo.c_room_name',
+                'room_order' => 'MRoomInfo.i_disp_no',
+            ])
+            ->innerJoin(
+                ['MUserInfo' => $userInfoTable->getTable()],
+                ['MUserInfo.i_id_user = MUserGroup.i_id_user', 'MUserInfo.i_del_flag' => 0]
+            )
+            ->innerJoin(
+                ['MRoomInfo' => $roomTable->getTable()],
+                ['MRoomInfo.i_id_room = MUserGroup.i_id_room', 'MRoomInfo.i_del_flg' => 0]
+            )
+            ->where(['MUserGroup.active_flag' => 0])
+            ->where($whereUser)
+            ->where($whereRoom)
+            ->orderBy([
+                'MRoomInfo.i_disp_no'  => 'ASC',
+                'MRoomInfo.i_id_room'  => 'ASC',
+                'MUserInfo.c_user_name' => 'ASC',
+            ])
+            ->enableHydration(false);
+
+        $rows = $query->toArray();
+
+        return array_map(static fn(array $r): array => [
+            'room_id'   => (int)$r['room_id'],
+            'room_name' => (string)$r['room_name'],
+            'user_id'   => (int)$r['user_id'],
+            'user_name' => (string)$r['user_name'],
+            'staff_id'  => (string)($r['staff_id'] ?? ''),
+        ], $rows);
+    }
+
+    /**
+     * 削除されていない全部屋のIDを返す。
+     *
+     * @param Table $roomTable MRoomInfo テーブル
+     * @return int[]
+     */
+    public function getAllActiveRoomIds(Table $roomTable): array
+    {
+        $rows = $roomTable->find()
+            ->select(['i_id_room'])
+            ->where(['i_del_flg' => 0])
+            ->enableHydration(false)
+            ->toArray();
+
+        return array_column($rows, 'i_id_room');
+    }
+
+    /**
+     * 指定したID配列に一致する削除済みでない部屋を [id => name] の連想配列で返す。
+     *
+     * @param Table  $roomTable MRoomInfo テーブル
+     * @param int[]  $roomIds   対象部屋IDの配列
+     * @return array<int, string>
+     */
+    public function getRoomsByIds(Table $roomTable, array $roomIds): array
+    {
+        if (empty($roomIds)) {
+            return [];
+        }
+
+        return $roomTable->find()
+            ->where(['i_id_room IN' => $roomIds, 'i_del_flg' => 0])
+            ->orderAsc('i_disp_no')
+            ->all()
+            ->combine('i_id_room', 'c_room_name')
             ->toArray();
     }
 }

--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -41,6 +41,21 @@ class ReservationChangeEditService
      *
      * @param array<int, string> $allowedRooms
      */
+    /**
+     * 部屋IDから部屋エンティティを取得する。見つからなければ null を返す。
+     *
+     * @param Table $roomTable MRoomInfo テーブル
+     * @param int   $roomId    部屋ID
+     * @return \Cake\Datasource\EntityInterface|null
+     */
+    public function getRoomById(Table $roomTable, int $roomId): mixed
+    {
+        return $roomTable->find()
+            ->select(['i_id_room', 'c_room_name'])
+            ->where(['i_id_room' => $roomId])
+            ->first();
+    }
+
     public function resolveDefaultRoomId(array $allowedRooms, string $date, Table $reservationTable): ?int
     {
         if (empty($allowedRooms)) {

--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -12,12 +12,17 @@ use Cake\ORM\Table;
 
 class ReservationWriteService
 {
+    private ReservationDatePolicy $datePolicy;
+
     public function __construct(
         private Table $reservationTable,
         private Table $userTable,
         private Table $roomTable,
-        private string $webroot
-    ) {}
+        private string $webroot,
+        ?ReservationDatePolicy $datePolicy = null
+    ) {
+        $this->datePolicy = $datePolicy ?? new ReservationDatePolicy();
+    }
 
     public function processIndividualReservation(
         string $reservationDate,
@@ -542,9 +547,25 @@ class ReservationWriteService
         }
 
         $targetDate   = new Date($dateStr);
-        $today        = Date::today('Asia/Tokyo');
-        $lastDeadline = $today->addDays(14);
-        $isLastMinute = ($targetDate >= $today && $targetDate <= $lastDeadline);
+        $isLastMinute = $this->datePolicy->shouldUseChangeFlag($targetDate);
+
+        // 同日・同食事種別で他部屋に有効な予約が存在する場合は登録不可
+        if ($value === 1) {
+            $activeFlag = $isLastMinute ? 'i_change_flag' : 'eat_flag';
+            $conflictExists = $this->reservationTable->exists([
+                'i_id_user'          => $targetUserId,
+                'd_reservation_date' => $dateStr,
+                'i_reservation_type' => $meal,
+                'i_id_room !='       => $roomId,
+                $activeFlag          => 1,
+            ]);
+            if ($conflictExists) {
+                return [
+                    'status' => 422,
+                    'body'   => ['ok' => false, 'message' => '同日・同食事種別の予約が別の部屋に既に存在します。'],
+                ];
+            }
+        }
 
         $exists = $this->reservationTable->exists([
             'i_id_user'          => $targetUserId,
@@ -553,7 +574,9 @@ class ReservationWriteService
             'i_reservation_type' => $meal,
         ]);
 
-        if ($isLastMinute && $targetUserLevel === 0 && $value === 0 && $exists) {
+        $today = Date::today('Asia/Tokyo');
+        $isFutureLastMinute = $isLastMinute && $targetDate >= $today;
+        if ($isFutureLastMinute && $targetUserLevel === 0 && $value === 0 && $exists) {
             return [
                 'status' => 403,
                 'body' => ['ok' => false, 'message' => '職員は直前編集でのキャンセルはできません。'],
@@ -602,6 +625,7 @@ class ReservationWriteService
                 actor:  $actorName,
                 eatFlag: $eatFlag,
                 changeFlag: $changeFlag,
+                useChangeFlag: $isLastMinute,
             );
             $this->invalidateCachesForDateRooms($dateStr, [$roomId], [$targetUserId]);
 

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -180,6 +180,15 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                     <div class="menu-desc">担当部屋の実食を代理入力する</div>
                 </a>
                 <?php endif; ?>
+                <?php
+                $isStaff = (int)($user?->get('i_user_level') ?? -1) === 0;
+                if ($isStaff || $isAdmin): ?>
+                <a class="menu-card" href="<?= $this->Url->build('/TReservationInfo/staff-reservation') ?>">
+                    <div class="menu-icon" style="background:#eff6ff;color:#1d4ed8;">🗓️</div>
+                    <div class="menu-title-text">週間予約（職員）</div>
+                    <div class="menu-desc">自分の1週間分の食事予約を確認・編集する</div>
+                </a>
+                <?php endif; ?>
                 <a class="menu-card" href="<?= $this->Url->build('/Contacts') ?>">
                     <div class="menu-icon" style="background:#f0fdf4;color:#16a34a;">✉️</div>
                     <div class="menu-title-text">お問い合わせ</div>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/staff_reservation.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/staff_reservation.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * 職員用週間予約グリッド画面
+ * ログインユーザー自身の予約を1週間単位で表示する。
+ */
+
+/** @var int    $loginUserId */
+/** @var string $loginUserName */
+/** @var array  $allRoomsForUser   [room_id => room_name] */
+/** @var \DateTimeImmutable[] $dates  月〜日の7要素 */
+/** @var \DateTimeImmutable  $weekStart */
+/** @var \DateTimeImmutable  $weekEnd */
+/** @var \DateTimeImmutable  $prevWeekStart */
+/** @var \DateTimeImmutable  $nextWeekStart */
+/** @var array  $gridRows   [{room_id, room_name, user_id, user_name, staff_id}] */
+/** @var array  $grid       [userId][roomId][date][mealType(1-4)] = 0|1 */
+/** @var bool   $isAdmin */
+/** @var string $mode  'individual'|'room'|'all' */
+
+$todayStr     = (new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
+$weekStartStr = $weekStart->format('Y-m-d');
+$thisMonday   = (new \DateTimeImmutable('monday this week', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
+$basePath     = $this->request->getAttribute('base') ?? '';
+$actionBase   = $basePath . '/TReservationInfo/staff-reservation';
+
+$modeParam    = '&mode=' . h($mode);
+$isIndividual = ($mode === 'individual');
+
+$mealTypes = [1 => '朝', 2 => '昼', 3 => '夜', 4 => '弁'];
+$dayLabels = ['月', '火', '水', '木', '金', '土', '日'];
+
+$fmtDate = static fn(\DateTimeImmutable $d): string => $d->format('n/j');
+$fmtDay  = static fn(\DateTimeImmutable $d): string => $dayLabels[(int)$d->format('N') - 1];
+
+$nameFirst = mb_substr($loginUserName, 0, 1);
+
+/* ── 所属部屋一覧（サマリー用） ── */
+$roomNames = array_values($allRoomsForUser);
+
+/* ── 週間合計（ログインユーザー分のみ・サマリーカード用） ── */
+$weekTotals = [1 => 0, 2 => 0, 3 => 0, 4 => 0];
+foreach ($gridRows as $row) {
+    if ((int)$row['user_id'] !== $loginUserId) continue;
+    $uid = $loginUserId;
+    $rid = (int)$row['room_id'];
+    foreach ($dates as $d) {
+        $ds = $d->format('Y-m-d');
+        for ($mt = 1; $mt <= 4; $mt++) {
+            if (($grid[$uid][$rid][$ds][$mt] ?? 0) === 1) {
+                $weekTotals[$mt]++;
+            }
+        }
+    }
+}
+$weekGrandTotal = array_sum($weekTotals);
+
+/* ── 日計（日付×食事種別） ── */
+$dailyTotals = [];
+foreach ($dates as $d) {
+    $ds = $d->format('Y-m-d');
+    $dailyTotals[$ds] = [1 => 0, 2 => 0, 3 => 0, 4 => 0];
+    foreach ($gridRows as $row) {
+        $uid = (int)$row['user_id'];
+        $rid = (int)$row['room_id'];
+        for ($mt = 1; $mt <= 4; $mt++) {
+            if (($grid[$uid][$rid][$ds][$mt] ?? 0) === 1) {
+                $dailyTotals[$ds][$mt]++;
+            }
+        }
+    }
+}
+
+/* ── ユーザー日計（全部屋合算） ── */
+$userDateTotals = [];
+foreach ($gridRows as $row) {
+    $uid = (int)$row['user_id'];
+    $rid = (int)$row['room_id'];
+    foreach ($dates as $d) {
+        $ds = $d->format('Y-m-d');
+        for ($mt = 1; $mt <= 4; $mt++) {
+            if (($grid[$uid][$rid][$ds][$mt] ?? 0) === 1) {
+                $userDateTotals[$uid][$ds][$mt] = ($userDateTotals[$uid][$ds][$mt] ?? 0) + 1;
+            }
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>食数予約（職員）</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <?= $this->Html->css('pages/staff_reservation') ?>
+    <meta name="csrfToken" content="<?= h($this->request->getAttribute('csrfToken')) ?>">
+</head>
+<body>
+<div class="container-fluid px-3 py-3">
+
+    <!-- ===== ページヘッダー ===== -->
+    <div class="sr-page-header">
+        <div>
+            <div class="sr-subtitle">MEAL RESERVATION · WEEKLY</div>
+            <h1>食数予約</h1>
+        </div>
+        <span class="sr-date-range">
+            <?= h($weekStart->format('Y/n/j')) ?> 〜 <?= h($weekEnd->format('n/j')) ?>
+        </span>
+    </div>
+
+    <!-- ===== ツールバー ===== -->
+    <div class="sr-toolbar">
+        <!-- 表示モード -->
+        <div class="sr-mode-switcher">
+            <div class="sr-mode-label">表示モード</div>
+            <div class="sr-mode-tabs">
+                <a href="<?= h($actionBase . '?week_start=' . $weekStartStr . '&mode=individual') ?>"
+                   class="sr-mode-tab <?= $mode === 'individual' ? 'is-active' : '' ?>">
+                    👤 個人
+                </a>
+                <a href="<?= h($actionBase . '?week_start=' . $weekStartStr . '&mode=room') ?>"
+                   class="sr-mode-tab <?= $mode === 'room' ? 'is-active' : '' ?>">
+                    🏠 各部屋
+                </a>
+                <?php if ($isAdmin): ?>
+                <a href="<?= h($actionBase . '?week_start=' . $weekStartStr . '&mode=all') ?>"
+                   class="sr-mode-tab <?= $mode === 'all' ? 'is-active' : '' ?>">
+                    🌐 全部
+                </a>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <div class="sr-toolbar-divider"></div>
+
+        <!-- 週ナビゲーション -->
+        <div class="sr-nav">
+            <a href="<?= h($actionBase . '?week_start=' . $prevWeekStart->format('Y-m-d') . $modeParam) ?>"
+               class="btn btn-outline-secondary btn-sm">◄ 前週</a>
+            <a href="<?= h($actionBase . '?week_start=' . $thisMonday . $modeParam) ?>"
+               class="btn btn-primary btn-sm">今週</a>
+            <a href="<?= h($actionBase . '?week_start=' . $nextWeekStart->format('Y-m-d') . $modeParam) ?>"
+               class="btn btn-outline-secondary btn-sm">翌週 ►</a>
+        </div>
+    </div>
+
+    <!-- ===== サマリーカード ===== -->
+    <div class="sr-summary-cards">
+        <div class="sr-user-card">
+            <div class="sr-avatar"><?= h($nameFirst) ?></div>
+            <div class="sr-card-body">
+                <div class="sr-card-name"><?= h($loginUserName) ?>さん</div>
+                <div class="sr-card-rooms">
+                    <?php foreach ($roomNames as $rn): ?>
+                        <span class="sr-room-badge">
+                            <i class="bi bi-house-fill" style="font-size:10px"></i>
+                            <?= h($rn) ?>
+                        </span>
+                    <?php endforeach; ?>
+                </div>
+                <div class="sr-card-meta">
+                    <?= h($weekStart->format('n/j')) ?>（<?= h($fmtDay($weekStart)) ?>）〜
+                    <?= h($weekEnd->format('n/j')) ?>（<?= h($fmtDay($weekEnd)) ?>）
+                </div>
+            </div>
+            <div class="sr-card-totals">
+                <?php foreach ($mealTypes as $mt => $label): ?>
+                    <div class="sr-total-item">
+                        <span class="t-label"><?= h($label) ?></span>
+                        <span class="t-value"><?= (int)($weekTotals[$mt] ?? 0) ?></span>
+                    </div>
+                <?php endforeach; ?>
+                <div class="sr-total-item total-all">
+                    <span class="t-label">合計</span>
+                    <span class="t-value"><?= (int)$weekGrandTotal ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===== グリッドテーブル ===== -->
+    <?php if (empty($gridRows)): ?>
+        <div class="alert alert-info">所属部屋の情報がありません。</div>
+    <?php else: ?>
+    <div class="sr-grid-wrap">
+        <table class="sr-grid">
+            <colgroup>
+                <col class="col-room">
+                <col class="col-name">
+                <?php foreach ($dates as $_d): ?>
+                    <col class="cell-meal"><col class="cell-meal"><col class="cell-meal"><col class="cell-meal">
+                <?php endforeach; ?>
+            </colgroup>
+            <thead>
+                <!-- ① 日付行 -->
+                <tr class="header-dates">
+                    <th class="col-room" rowspan="2">部屋</th>
+                    <th class="col-name" rowspan="2">氏名</th>
+                    <?php foreach ($dates as $d): ?>
+                        <?php
+                        $dStr    = $d->format('Y-m-d');
+                        $dow     = (int)$d->format('N');
+                        $isToday = ($dStr === $todayStr);
+                        $isSat   = ($dow === 6);
+                        $isSun   = ($dow === 7);
+                        $cls     = 'date-group';
+                        if ($isToday)   $cls .= ' is-today';
+                        elseif ($isSat) $cls .= ' is-saturday';
+                        elseif ($isSun) $cls .= ' is-sunday';
+                        ?>
+                        <th colspan="4" class="<?= $cls ?>">
+                            <?= h($fmtDate($d)) ?>
+                            <span class="fw-normal"><?= h($fmtDay($d)) ?></span>
+                            <?php if ($isToday): ?><br><small class="fw-bold">今日</small><?php endif; ?>
+                        </th>
+                    <?php endforeach; ?>
+                </tr>
+                <!-- ② 食事種別行（col-room・col-nameはrowspanで占有済み、ここには不要） -->
+                <tr class="header-meals">
+                    <?php foreach ($dates as $d): ?>
+                        <?php foreach ($mealTypes as $mt => $mlabel): ?>
+                            <th class="<?= $mt === 1 ? 'meal-first' : '' ?>"><?= h($mlabel) ?></th>
+                        <?php endforeach; ?>
+                    <?php endforeach; ?>
+                </tr>
+            </thead>
+            <tbody>
+                <?php
+                $prevRoomId = null;
+                foreach ($gridRows as $row):
+                    $rowRoomId = (int)$row['room_id'];
+                    echo $this->element('TReservationInfo/staff_grid_row', [
+                        'row'          => $row,
+                        'dates'        => $dates,
+                        'grid'         => $grid,
+                        'todayStr'     => $todayStr,
+                        'mealTypes'    => $mealTypes,
+                        'showRoomName' => ($prevRoomId !== $rowRoomId),
+                        'interactive'  => $isIndividual,
+                    ]);
+                    $prevRoomId = $rowRoomId;
+                endforeach;
+                ?>
+
+                <!-- ユーザー合計行 -->
+                <tr class="row-user-total">
+                    <td class="col-room"><?= h($loginUserName) ?>さん合計</td>
+                    <td class="col-name"></td>
+                    <?php foreach ($dates as $d): ?>
+                        <?php $ds = $d->format('Y-m-d'); ?>
+                        <?php foreach ($mealTypes as $mt => $ml): ?>
+                            <?php $v = $userDateTotals[$loginUserId][$ds][$mt] ?? 0; ?>
+                            <td class="cell-meal <?= $mt === 1 ? 'meal-first' : '' ?>">
+                                <?= $v ? h((string)$v) : '' ?>
+                            </td>
+                        <?php endforeach; ?>
+                    <?php endforeach; ?>
+                </tr>
+
+                <!-- 日計行 -->
+                <tr class="row-daily-total">
+                    <td class="col-room">日計</td>
+                    <td class="col-name"></td>
+                    <?php foreach ($dates as $d): ?>
+                        <?php $ds = $d->format('Y-m-d'); ?>
+                        <?php foreach ($mealTypes as $mt => $ml): ?>
+                            <?php $dv = $dailyTotals[$ds][$mt] ?? 0; ?>
+                            <td class="cell-meal <?= $mt === 1 ? 'meal-first' : '' ?>">
+                                <?= $dv ? h((string)$dv) : '' ?>
+                            </td>
+                        <?php endforeach; ?>
+                    <?php endforeach; ?>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
+
+</div>
+<script>
+window.SR_CONFIG = {
+    basePath:      <?= json_encode($basePath, JSON_UNESCAPED_SLASHES) ?>,
+    isIndividual:  <?= $isIndividual ? 'true' : 'false' ?>
+};
+</script>
+<?= $this->Html->script('pages/staff_reservation') ?>
+</body>
+</html>

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/staff_grid_row.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/staff_grid_row.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * 職員用グリッド: 1データ行
+ *
+ * @var array $row          {room_id, room_name, user_id, user_name, staff_id}
+ * @var \DateTimeImmutable[] $dates
+ * @var array $grid         [userId][roomId][date][mealType] = 0|1
+ * @var string $todayStr    YYYY-MM-DD
+ * @var bool $showRoomName  部屋名を表示するか（同じ部屋の2行目以降はfalse）
+ * @var array $mealTypes    [1=>'朝', 2=>'昼', 3=>'夜', 4=>'弁']
+ */
+
+$row          = $row ?? [];
+$dates        = $dates ?? [];
+$grid         = $grid ?? [];
+$todayStr     = $todayStr ?? date('Y-m-d');
+$showRoomName = $showRoomName ?? true;
+$mealTypes    = $mealTypes ?? [1 => '朝', 2 => '昼', 3 => '夜', 4 => '弁'];
+$interactive  = $interactive ?? true;
+
+$uid       = (int)$row['user_id'];
+$rid       = (int)$row['room_id'];
+$nameFirst = mb_substr((string)($row['user_name'] ?? ''), 0, 1);
+?>
+<tr>
+    <td class="col-room"><?= $showRoomName ? h($row['room_name']) : '' ?></td>
+    <td class="col-name">
+        <span style="display:inline-flex;align-items:center;justify-content:center;
+                     width:22px;height:22px;border-radius:50%;
+                     background:#3b82f6;color:#fff;
+                     font-size:11px;font-weight:700;flex-shrink:0;">
+            <?= h($nameFirst) ?>
+        </span>
+    </td>
+    <?php foreach ($dates as $d): ?>
+        <?php
+        $dateStr = $d->format('Y-m-d');
+        $dow     = (int)$d->format('N');
+        $isToday = ($dateStr === $todayStr);
+        $isSat   = ($dow === 6);
+        $isSun   = ($dow === 7);
+        $dayCls  = match(true) {
+            $isToday => 'is-today',
+            $isSat   => 'is-saturday',
+            $isSun   => 'is-sunday',
+            default  => '',
+        };
+        ?>
+        <?php foreach ($mealTypes as $mt => $ml): ?>
+            <?php $reserved = ($grid[$uid][$rid][$dateStr][$mt] ?? 0) === 1; ?>
+            <?php if ($interactive): ?>
+            <td class="cell-meal sr-toggleable <?= $mt === 1 ? 'meal-first' : '' ?> <?= $dayCls ?>"
+                data-user-id="<?= $uid ?>"
+                data-room-id="<?= $rid ?>"
+                data-date="<?= h($dateStr) ?>"
+                data-meal="<?= $mt ?>"
+                data-reserved="<?= $reserved ? '1' : '0' ?>"
+                style="cursor:pointer;">
+                <?php if ($reserved): ?>
+                    <span class="sr-cell-check"></span>
+                <?php endif; ?>
+            </td>
+            <?php else: ?>
+            <td class="cell-meal <?= $mt === 1 ? 'meal-first' : '' ?> <?= $dayCls ?>">
+                <?php if ($reserved): ?>
+                    <span class="sr-cell-check"></span>
+                <?php endif; ?>
+            </td>
+            <?php endif; ?>
+        <?php endforeach; ?>
+    <?php endforeach; ?>
+</tr>

--- a/src_web/kamaho-shokusu/tests/TestCase/Log/Engine/SlackLogEngineTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Log/Engine/SlackLogEngineTest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Log\Engine;
+
+use App\Log\Engine\SlackLogEngine;
+use Cake\Http\Client;
+use Cake\Http\Client\Response;
+use Cake\TestSuite\TestCase;
+
+/**
+ * SlackLogEngine のテスト
+ *
+ * 確認項目:
+ *   - SLACK_ERROR_WEBHOOK 未設定時はHTTP通信を行わない
+ *   - error / critical / alert / emergency の各レベルで Slack に POST される
+ *   - メッセージ・ファイル・行番号・スタックトレースが通知本文に含まれる
+ *   - HTTP 例外が発生しても呼び出し元に伝播しない
+ */
+class SlackLogEngineTest extends TestCase
+{
+    private const DUMMY_WEBHOOK = 'https://hooks.slack.com/services/dummy';
+
+    private Client $mockClient;
+    private SlackLogEngine $engine;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockClient = $this->createMock(Client::class);
+        $this->engine = new SlackLogEngine(['httpClient' => $this->mockClient]);
+    }
+
+    protected function tearDown(): void
+    {
+        // テスト間で env をリセット
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = '';
+        parent::tearDown();
+    }
+
+    /**
+     * SLACK_ERROR_WEBHOOK が未設定の場合は POST しない。
+     */
+    public function testDoesNotPostWhenWebhookIsEmpty(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = '';
+
+        $this->mockClient->expects($this->never())->method('post');
+
+        $this->engine->log('error', 'テストエラー');
+    }
+
+    /**
+     * SLACK_ERROR_WEBHOOK が設定されていれば POST する。
+     */
+    public function testPostsWhenWebhookIsSet(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                self::DUMMY_WEBHOOK,
+                $this->callback(fn(string $body) => str_contains($body, 'テストエラー')),
+                ['type' => 'json'],
+            )
+            ->willReturn(new Response([], ''));
+
+        $this->engine->log('error', 'テストエラー');
+    }
+
+    /**
+     * @dataProvider levelEmojiProvider
+     */
+    public function testEmojiBylevel(string $level, string $expectedEmoji): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                self::DUMMY_WEBHOOK,
+                $this->callback(fn(string $body) => str_contains($body, $expectedEmoji)),
+                ['type' => 'json'],
+            )
+            ->willReturn(new Response([], ''));
+
+        $this->engine->log($level, 'dummy');
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function levelEmojiProvider(): array
+    {
+        return [
+            'emergency' => ['emergency', ':rotating_light:'],
+            'alert'     => ['alert',     ':rotating_light:'],
+            'critical'  => ['critical',  ':fire:'],
+            'error'     => ['error',     ':warning:'],
+        ];
+    }
+
+    /**
+     * context に file・line が含まれる場合は通知本文に出力される。
+     */
+    public function testIncludesFileAndLineFromContext(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                self::DUMMY_WEBHOOK,
+                $this->callback(function (string $body): bool {
+                    return str_contains($body, 'SomeClass.php')
+                        && str_contains($body, '42');
+                }),
+                ['type' => 'json'],
+            )
+            ->willReturn(new Response([], ''));
+
+        $this->engine->log('error', 'エラー', ['file' => 'SomeClass.php', 'line' => 42]);
+    }
+
+    /**
+     * context に trace（文字列）が含まれる場合は通知本文に出力される。
+     */
+    public function testIncludesStringTrace(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                self::DUMMY_WEBHOOK,
+                $this->callback(fn(string $body) => str_contains($body, '#0 SomeClass')),
+                ['type' => 'json'],
+            )
+            ->willReturn(new Response([], ''));
+
+        $this->engine->log('critical', 'エラー', ['trace' => '#0 SomeClass::method()']);
+    }
+
+    /**
+     * context に trace（配列）が含まれる場合は先頭5件のみ通知される。
+     */
+    public function testIncludesArrayTraceUpToFiveItems(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $trace = array_map(fn(int $i) => "#$i FrameClass::method()", range(0, 9));
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                self::DUMMY_WEBHOOK,
+                $this->callback(function (string $body) use ($trace): bool {
+                    return str_contains($body, $trace[0])
+                        && str_contains($body, $trace[4])
+                        && !str_contains($body, $trace[5]);
+                }),
+                ['type' => 'json'],
+            )
+            ->willReturn(new Response([], ''));
+
+        $this->engine->log('error', 'エラー', ['trace' => $trace]);
+    }
+
+    /**
+     * HTTP 例外が発生しても呼び出し元に伝播しない。
+     */
+    public function testDoesNotThrowWhenHttpFails(): void
+    {
+        $_SERVER['SLACK_ERROR_WEBHOOK'] = self::DUMMY_WEBHOOK;
+
+        $this->mockClient
+            ->method('post')
+            ->willThrowException(new \RuntimeException('network error'));
+
+        // 例外が伝播しないことを確認（アサーションなし = 正常終了でテスト成功）
+        $this->engine->log('error', 'エラー');
+        $this->assertTrue(true);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Model/Table/TIndividualReservationInfoTableTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Model/Table/TIndividualReservationInfoTableTest.php
@@ -75,4 +75,123 @@ class TIndividualReservationInfoTableTest extends TestCase
         ]);
         $this->assertArrayHasKey('i_id_user', $invalid->getErrors());
     }
+
+    /* =====================================================================
+     * 食事種別定数
+     * ===================================================================== */
+
+    public function testMealConstantValues(): void
+    {
+        $this->assertSame(1, TIndividualReservationInfoTable::MEAL_BREAKFAST);
+        $this->assertSame(2, TIndividualReservationInfoTable::MEAL_LUNCH);
+        $this->assertSame(3, TIndividualReservationInfoTable::MEAL_DINNER);
+        $this->assertSame(4, TIndividualReservationInfoTable::MEAL_BENTO);
+    }
+
+    public function testMealConstantsAreDistinct(): void
+    {
+        $constants = [
+            TIndividualReservationInfoTable::MEAL_BREAKFAST,
+            TIndividualReservationInfoTable::MEAL_LUNCH,
+            TIndividualReservationInfoTable::MEAL_DINNER,
+            TIndividualReservationInfoTable::MEAL_BENTO,
+        ];
+
+        $this->assertSame(count($constants), count(array_unique($constants)));
+    }
+
+    /* =====================================================================
+     * 昼↔弁当 排他ルール（buildRules）
+     * ===================================================================== */
+
+    public function testBuildRulesAllowsLunchAlone(): void
+    {
+        // 昼のみ: 弁当なし → バリデーション通過
+        $entity = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 2,
+            'd_reservation_date' => '2020-01-01', // 過去日: eat_flag ベース
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_LUNCH,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+
+        $saved = $this->TIndividualReservationInfo->save($entity);
+        $this->assertNotFalse($saved, '昼のみ保存に失敗: ' . json_encode($entity->getErrors()));
+    }
+
+    public function testBuildRulesAllowsBentoAlone(): void
+    {
+        $entity = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 3,
+            'd_reservation_date' => '2020-01-01',
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_BENTO,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+
+        $saved = $this->TIndividualReservationInfo->save($entity);
+        $this->assertNotFalse($saved, '弁当のみ保存に失敗: ' . json_encode($entity->getErrors()));
+    }
+
+    public function testBuildRulesBlocksLunchAndBentoSimultaneously(): void
+    {
+        // 昼を先に保存 (eat_flag=1)
+        $lunch = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 4,
+            'd_reservation_date' => '2020-02-01',
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_LUNCH,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+        $this->TIndividualReservationInfo->saveOrFail($lunch);
+
+        // 同日に弁当 (eat_flag=1) を保存 → 排他エラー
+        $bento = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 4,
+            'd_reservation_date' => '2020-02-01',
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_BENTO,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+        $saved = $this->TIndividualReservationInfo->save($bento);
+
+        $this->assertFalse($saved, '昼と弁当が同時に保存されてしまった');
+    }
+
+    public function testBuildRulesAllowsBentoWhenLunchIsOff(): void
+    {
+        // 昼を保存 (eat_flag=0: 無効)
+        $lunch = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 5,
+            'd_reservation_date' => '2020-03-01',
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_LUNCH,
+            'eat_flag'           => 0,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+        $this->TIndividualReservationInfo->saveOrFail($lunch);
+
+        // 同日に弁当 (eat_flag=1) → 昼は無効なので通過するはず
+        $bento = $this->TIndividualReservationInfo->newEntity([
+            'i_id_user'          => 5,
+            'd_reservation_date' => '2020-03-01',
+            'i_id_room'          => 1,
+            'i_reservation_type' => TIndividualReservationInfoTable::MEAL_BENTO,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 0,
+            'i_version'          => 1,
+        ]);
+        $saved = $this->TIndividualReservationInfo->save($bento);
+
+        $this->assertNotFalse($saved, '昼が無効なのに弁当が保存できなかった: ' . json_encode($bento->getErrors()));
+    }
 }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ActualMealManagementService;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ActualMealManagementService テスト
+ *
+ * 対象メソッド:
+ *   - resolveWeekNavigation() — DB 不要、純粋ロジック
+ *   - ensureUserInList()      — MUserGroup テーブルが必要
+ *   - userBelongsToRoom()     — MUserGroup テーブルが必要
+ */
+class ActualMealManagementServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserGroup',
+    ];
+
+    private ActualMealManagementService $service;
+
+    /** テスト用の固定月曜日（2026-05-11 は月曜） */
+    private \DateTimeImmutable $thisMonday;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service    = new ActualMealManagementService();
+        $this->thisMonday = new \DateTimeImmutable('2026-05-11', new \DateTimeZone('Asia/Tokyo'));
+    }
+
+    /* =====================================================================
+     * resolveWeekNavigation
+     * ===================================================================== */
+
+    public function testResolveWeekNavigationReturnsCurrentWeekWhenNoParam(): void
+    {
+        $result = $this->service->resolveWeekNavigation(null, false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationNormalizesWednesdayToMonday(): void
+    {
+        $wednesday = $this->thisMonday->modify('+2 days'); // 水曜
+
+        $result = $this->service->resolveWeekNavigation($wednesday->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationNonAdminCannotGoBeforeCurrentWeek(): void
+    {
+        $lastWeek = $this->thisMonday->modify('-7 days');
+
+        $result = $this->service->resolveWeekNavigation($lastWeek->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationAdminCanReachOldestAllowedMonday(): void
+    {
+        $oldest = $this->service->getAdminOldestAllowedMonday();
+
+        $result = $this->service->resolveWeekNavigation($oldest->format('Y-m-d'), true, $this->thisMonday);
+
+        $this->assertSame($oldest->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationClampsFarFutureToFourWeeks(): void
+    {
+        $farFuture   = $this->thisMonday->modify('+10 weeks');
+        $expectedMax = $this->thisMonday->modify('+4 weeks');
+
+        $result = $this->service->resolveWeekNavigation($farFuture->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($expectedMax->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationPrevAndNextAreSurroundingWeeks(): void
+    {
+        $result = $this->service->resolveWeekNavigation(null, false, $this->thisMonday);
+
+        $this->assertSame(
+            $this->thisMonday->modify('-7 days')->format('Y-m-d'),
+            $result['prevMonday']->format('Y-m-d')
+        );
+        $this->assertSame(
+            $this->thisMonday->modify('+7 days')->format('Y-m-d'),
+            $result['nextMonday']->format('Y-m-d')
+        );
+    }
+
+    public function testResolveWeekNavigationCanGoPrevFalseForNonAdmin(): void
+    {
+        $result = $this->service->resolveWeekNavigation(null, false, $this->thisMonday);
+
+        $this->assertFalse($result['canGoPrev']);
+    }
+
+    public function testResolveWeekNavigationCanGoPrevTrueWhenAdminNotAtOldest(): void
+    {
+        // 管理者・今週選択 → 前週に戻れるはず
+        $result = $this->service->resolveWeekNavigation(null, true, $this->thisMonday);
+
+        $this->assertTrue($result['canGoPrev']);
+    }
+
+    public function testResolveWeekNavigationCanGoNextFalseAtFutureLimit(): void
+    {
+        $fourWeeksOut = $this->thisMonday->modify('+4 weeks');
+
+        $result = $this->service->resolveWeekNavigation($fourWeeksOut->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertFalse($result['canGoNext']);
+    }
+
+    public function testResolveWeekNavigationHandlesInvalidStringGracefully(): void
+    {
+        // 不正な日付文字列は今週にフォールバック
+        $result = $this->service->resolveWeekNavigation('not-a-date', false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    /* =====================================================================
+     * ensureUserInList
+     * ===================================================================== */
+
+    public function testEnsureUserInListDoesNothingIfUserAlreadyPresent(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $users = [['id' => 1, 'name' => 'Alice', 'staff_id' => 'S001']];
+
+        $result = $this->service->ensureUserInList($users, 1, 'Alice', 'S001', 1, false, $userGroupTable);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(1, $result[0]['id']);
+    }
+
+    public function testEnsureUserInListPrependsAdminWithoutRoomBelongingCheck(): void
+    {
+        // isAdmin=true → DB チェック不要、常に先頭へ追加
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $users = [['id' => 2, 'name' => 'Bob', 'staff_id' => 'S002']];
+
+        $result = $this->service->ensureUserInList($users, 1, 'Alice', 'S001', 1, true, $userGroupTable);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result[0]['id']); // 先頭に追加
+    }
+
+    public function testEnsureUserInListPrependsNonAdminWhoIsInRoom(): void
+    {
+        // フィクスチャ: ユーザー1 は部屋1 に所属 (active_flag=0)
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $users = [['id' => 2, 'name' => 'Bob', 'staff_id' => 'S002']];
+
+        $result = $this->service->ensureUserInList($users, 1, 'Alice', 'S001', 1, false, $userGroupTable);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result[0]['id']);
+    }
+
+    public function testEnsureUserInListDoesNotAddNonAdminNotInRoom(): void
+    {
+        // ユーザー1 は部屋99 に所属していない
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $users = [['id' => 2, 'name' => 'Bob', 'staff_id' => 'S002']];
+
+        $result = $this->service->ensureUserInList($users, 1, 'Alice', 'S001', 99, false, $userGroupTable);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(2, $result[0]['id']); // 変化なし
+    }
+
+    /* =====================================================================
+     * userBelongsToRoom
+     * ===================================================================== */
+
+    public function testUserBelongsToRoomReturnsTrueWhenUserIsInRoom(): void
+    {
+        // フィクスチャ: ユーザー1 は部屋1 に所属
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+
+        $this->assertTrue($this->service->userBelongsToRoom($userGroupTable, 1, 1));
+    }
+
+    public function testUserBelongsToRoomReturnsFalseWhenUserIsNotInRoom(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+
+        $this->assertFalse($this->service->userBelongsToRoom($userGroupTable, 1, 99));
+    }
+
+    public function testUserBelongsToRoomReturnsFalseForUnknownUser(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+
+        $this->assertFalse($this->service->userBelongsToRoom($userGroupTable, 999, 1));
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationCalendarService;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ReservationCalendarService テスト
+ *
+ * 対象メソッド:
+ *   - getAllActiveRoomIds() — i_del_flg=0 の部屋IDを返す
+ *   - getRoomsByIds()       — 指定IDの部屋を [id => name] で返す
+ */
+class ReservationCalendarServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MRoomInfo',
+    ];
+
+    private ReservationCalendarService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationCalendarService();
+    }
+
+    /* =====================================================================
+     * getAllActiveRoomIds
+     * ===================================================================== */
+
+    public function testGetAllActiveRoomIdsReturnsActiveRooms(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getAllActiveRoomIds($roomTable);
+
+        $this->assertContains(1, $result);
+    }
+
+    public function testGetAllActiveRoomIdsExcludesDeletedRooms(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        // 削除済み部屋を動的に追加
+        $deleted = $roomTable->newEntity([
+            'i_id_room'     => 99,
+            'c_room_name'   => 'Deleted Room',
+            'i_disp_no'     => 99,
+            'i_enable'      => 1,
+            'i_del_flg'     => 1,
+            'dt_create'     => '2024-01-01 00:00:00',
+            'c_create_user' => 'test',
+            'dt_update'     => '2024-01-01 00:00:00',
+            'c_update_user' => 'test',
+        ]);
+        $roomTable->saveOrFail($deleted);
+
+        $result = $this->service->getAllActiveRoomIds($roomTable);
+
+        $this->assertContains(1, $result);
+        $this->assertNotContains(99, $result);
+    }
+
+    public function testGetAllActiveRoomIdsReturnsArrayOfInts(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getAllActiveRoomIds($roomTable);
+
+        $this->assertIsArray($result);
+        foreach ($result as $id) {
+            $this->assertIsInt($id);
+        }
+    }
+
+    /* =====================================================================
+     * getRoomsByIds
+     * ===================================================================== */
+
+    public function testGetRoomsByIdsReturnsIdToNameMap(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsByIds($roomTable, [1]);
+
+        $this->assertArrayHasKey(1, $result);
+        $this->assertSame('Lorem ipsum dolor sit amet', $result[1]);
+    }
+
+    public function testGetRoomsByIdsReturnsEmptyForEmptyInput(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsByIds($roomTable, []);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetRoomsByIdsIgnoresNonExistentIds(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsByIds($roomTable, [999]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetRoomsByIdsFiltersOutDeletedRooms(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        $deleted = $roomTable->newEntity([
+            'i_id_room'     => 88,
+            'c_room_name'   => 'Deleted Room',
+            'i_disp_no'     => 88,
+            'i_enable'      => 1,
+            'i_del_flg'     => 1,
+            'dt_create'     => '2024-01-01 00:00:00',
+            'c_create_user' => 'test',
+            'dt_update'     => '2024-01-01 00:00:00',
+            'c_update_user' => 'test',
+        ]);
+        $roomTable->saveOrFail($deleted);
+
+        $result = $this->service->getRoomsByIds($roomTable, [1, 88]);
+
+        $this->assertArrayHasKey(1, $result);
+        $this->assertArrayNotHasKey(88, $result);
+    }
+
+    public function testGetRoomsByIdsReturnsOnlyMatchingIds(): void
+    {
+        $roomTable = $this->getTableLocator()->get('MRoomInfo');
+
+        // 存在するIDと存在しないIDの混合
+        $result = $this->service->getRoomsByIds($roomTable, [1, 999]);
+
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey(1, $result);
+    }
+}

--- a/src_web/kamaho-shokusu/webroot/css/pages/staff_reservation.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/staff_reservation.css
@@ -1,0 +1,593 @@
+/* ===== 職員用4週間予約グリッド ===== */
+
+/* ページ全体 */
+body {
+    background: #f4f6fb;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* ヘッダー */
+.sr-page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.sr-subtitle {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: #94a3b8;
+    text-transform: uppercase;
+    margin-bottom: 2px;
+}
+
+.sr-page-header h1 {
+    font-size: 1.75rem;
+    font-weight: 800;
+    margin: 0;
+    line-height: 1.1;
+    color: #0f172a;
+}
+
+/* ナビゲーション */
+.sr-nav {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.sr-date-range {
+    font-size: 13px;
+    color: #475569;
+    white-space: nowrap;
+    padding: 5px 12px;
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+    font-weight: 500;
+}
+
+/* ツールバー */
+.sr-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    padding: 10px 16px;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    margin-bottom: 14px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+
+.sr-toolbar-divider {
+    width: 1px;
+    height: 32px;
+    background: #e2e8f0;
+    flex-shrink: 0;
+}
+
+.sr-mode-label {
+    font-size: 12px;
+    color: #94a3b8;
+    white-space: nowrap;
+}
+
+/* 表示モード セグメントコントロール */
+.sr-mode-switcher {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.sr-mode-switcher > .sr-mode-label {
+    font-size: 10px;
+    font-weight: 600;
+    color: #94a3b8;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.sr-mode-tabs {
+    display: flex;
+    background: #f1f5f9;
+    border-radius: 10px;
+    padding: 3px;
+    gap: 2px;
+}
+
+.sr-mode-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 13px;
+    border-radius: 7px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #475569;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+}
+
+.sr-mode-tab:hover {
+    background: rgba(255,255,255,.7);
+    color: #1e293b;
+}
+
+.sr-mode-tab.is-active {
+    background: #3b82f6;
+    color: #fff;
+    box-shadow: 0 1px 4px rgba(59,130,246,.35);
+}
+
+/* セレクターフォーム */
+.sr-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+}
+
+.sr-selector label {
+    font-size: 12px;
+    color: #64748b;
+    white-space: nowrap;
+    margin: 0;
+}
+
+.sr-selector select {
+    min-width: 220px;
+    font-size: 13px;
+    border-color: #cbd5e1;
+    border-radius: 6px;
+    padding: 4px 28px 4px 10px;
+    color: #1e293b;
+}
+
+.sr-selector select:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59,130,246,.15);
+    outline: none;
+}
+
+
+/* サマリーカード */
+.sr-summary-cards {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+
+.sr-user-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 14px 18px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex: 1;
+    min-width: 0;
+    max-width: 680px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.05);
+}
+
+.sr-avatar {
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    background: #3b82f6;
+    color: #fff;
+    font-size: 18px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    letter-spacing: 0;
+}
+
+.sr-card-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.sr-card-name {
+    font-size: 15px;
+    font-weight: 700;
+    color: #0f172a;
+    margin-bottom: 4px;
+}
+
+.sr-card-rooms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 3px;
+}
+
+.sr-room-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 20px;
+    padding: 1px 8px;
+    color: #1d4ed8;
+}
+
+.sr-card-meta {
+    font-size: 11px;
+    color: #94a3b8;
+}
+
+.sr-card-totals {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-shrink: 0;
+}
+
+.sr-total-item {
+    text-align: center;
+}
+
+.sr-total-item .t-label {
+    font-size: 10px;
+    color: #94a3b8;
+    display: block;
+    margin-bottom: 1px;
+}
+
+.sr-total-item .t-value {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1e293b;
+    line-height: 1.1;
+}
+
+.sr-total-item.total-all {
+    background: #3b82f6;
+    border-radius: 8px;
+    padding: 6px 14px;
+    min-width: 56px;
+}
+
+.sr-total-item.total-all .t-label { color: rgba(255,255,255,.75); }
+.sr-total-item.total-all .t-value { color: #fff; font-size: 22px; }
+
+/* ===== グリッドテーブル ===== */
+
+/* 固定列幅（CSS変数で一元管理） */
+:root {
+    --col-room-w: 90px;
+    --col-name-w: 52px;
+    --col-fixed-total: 142px; /* 90 + 52 */
+    --cell-w: 22px;
+}
+
+.sr-grid-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+
+.sr-grid {
+    border-collapse: collapse;
+    font-size: 12px;
+    table-layout: fixed;
+    width: max-content;
+    min-width: 100%;
+}
+
+/* 固定列の共通スタイル */
+.sr-grid .col-room {
+    width: var(--col-room-w);
+    min-width: var(--col-room-w);
+    max-width: var(--col-room-w);
+    position: sticky;
+    left: 0;
+    z-index: 3;
+    background: #fff;
+}
+
+.sr-grid .col-name {
+    width: var(--col-name-w);
+    min-width: var(--col-name-w);
+    max-width: var(--col-name-w);
+    position: sticky;
+    left: var(--col-room-w);
+    z-index: 3;
+    background: #fff;
+    border-right: 2px solid #cbd5e1;
+}
+
+/* ヘッダー全体 */
+.sr-grid thead th {
+    background: #f8fafc;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+/* 固定列ヘッダーはz-indexを最高に */
+.sr-grid thead th.col-room,
+.sr-grid thead th.col-name {
+    z-index: 4;
+    background: #f1f5f9;
+}
+
+/* 日付ヘッダー行 */
+.sr-grid thead tr.header-dates th {
+    text-align: center;
+    padding: 6px 2px 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #374151;
+    border-bottom: 1px solid #e2e8f0;
+    white-space: nowrap;
+    vertical-align: bottom;
+}
+
+.sr-grid thead tr.header-dates th.col-room,
+.sr-grid thead tr.header-dates th.col-name {
+    vertical-align: middle;
+    font-size: 11px;
+    font-weight: 700;
+    color: #475569;
+    text-align: center;
+}
+
+.sr-grid thead tr.header-dates th.is-today {
+    background: #fffbeb;
+    color: #b45309;
+}
+
+.sr-grid thead tr.header-dates th.is-saturday { color: #2563eb; }
+.sr-grid thead tr.header-dates th.is-sunday   { color: #dc2626; }
+
+/* 日付グループ区切り線 */
+.sr-grid thead tr.header-dates th.date-group {
+    border-left: 1px solid #cbd5e1;
+}
+
+/* 食事種別ヘッダー行 */
+.sr-grid thead tr.header-meals th {
+    text-align: center;
+    padding: 3px 0;
+    font-size: 10px;
+    font-weight: 600;
+    color: #94a3b8;
+    border-bottom: 2px solid #cbd5e1;
+    width: var(--cell-w);
+}
+
+.sr-grid thead tr.header-meals th.meal-first {
+    border-left: 1px solid #cbd5e1;
+}
+
+/* データ行 */
+.sr-grid tbody td {
+    padding: 0;
+    text-align: center;
+    vertical-align: middle;
+    border-bottom: 1px solid #f1f5f9;
+    height: 30px;
+}
+
+.sr-grid tbody td.col-room {
+    padding: 4px 6px;
+    text-align: left;
+    font-size: 11px;
+    font-weight: 500;
+    color: #374151;
+    border-right: 1px solid #e2e8f0;
+    vertical-align: middle;
+}
+
+.sr-grid tbody td.col-name {
+    padding: 4px 4px;
+    text-align: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: #1e293b;
+    vertical-align: middle;
+}
+
+/* 日付セル */
+.sr-grid tbody td.cell-meal {
+    width: var(--cell-w);
+}
+
+.sr-grid tbody td.meal-first {
+    border-left: 1px solid #e2e8f0;
+}
+
+/* 今日列 */
+.sr-grid thead th.is-today,
+.sr-grid tbody td.is-today {
+    background: #fffbeb !important;
+}
+
+/* 土曜列 */
+.sr-grid tbody td.is-saturday { background: #f0f5ff; }
+
+/* 日曜列 */
+.sr-grid tbody td.is-sunday { background: #fff5f5; }
+
+/* 他部屋で予約済みのため選択不可 */
+.sr-cell-disabled {
+    background: #f1f5f9 !important;
+    cursor: not-allowed !important;
+    opacity: 0.35;
+    pointer-events: auto; /* ホバー検知のためautoを維持 */
+    position: relative;
+}
+
+.sr-cell-disabled[data-sr-tooltip]::after {
+    content: attr(data-sr-tooltip);
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1e293b;
+    color: #fff;
+    font-size: 11px;
+    white-space: nowrap;
+    padding: 4px 8px;
+    border-radius: 5px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    z-index: 100;
+}
+
+.sr-cell-disabled[data-sr-tooltip]:hover::after {
+    opacity: 1;
+}
+
+/* 予約済みマーク（○） */
+.sr-cell-check {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid #3b82f6;
+    background: transparent;
+}
+
+/* ユーザー合計行 */
+.sr-grid tr.row-user-total td {
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 11px;
+    font-weight: 700;
+    border-top: 1px solid #bfdbfe;
+    border-bottom: 1px solid #bfdbfe;
+    height: 26px;
+}
+
+.sr-grid tr.row-user-total td.col-room {
+    background: #dbeafe;
+    font-size: 11px;
+    color: #1d4ed8;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.sr-grid tr.row-user-total td.col-name {
+    background: #dbeafe;
+}
+
+/* 日計行 */
+.sr-grid tr.row-daily-total td {
+    background: #f0fdf4;
+    color: #15803d;
+    font-size: 11px;
+    font-weight: 700;
+    border-top: 2px solid #86efac;
+    height: 26px;
+}
+
+.sr-grid tr.row-daily-total td.col-room {
+    background: #dcfce7;
+    color: #15803d;
+    white-space: nowrap;
+}
+
+.sr-grid tr.row-daily-total td.col-name {
+    background: #dcfce7;
+}
+
+/* 部屋グループ見出し行（全部モード） */
+.sr-grid tr.row-room-header td {
+    background: #e2e8f0;
+    color: #334155;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 5px 8px;
+    text-align: left;
+    border-top: 2px solid #cbd5e1;
+}
+
+.sr-grid tr.row-room-header td.col-room {
+    background: #cbd5e1;
+    border-right-color: #94a3b8;
+}
+
+.sr-grid tr.row-room-header td.col-name {
+    background: #cbd5e1;
+}
+
+/* ===== セルフラッシュアニメーション（Optimistic UI フィードバック） ===== */
+
+@keyframes sr-flash-on {
+    0%   { background-color: inherit; }
+    25%  { background-color: #bbf7d0; }
+    100% { background-color: inherit; }
+}
+
+@keyframes sr-flash-off {
+    0%   { background-color: inherit; }
+    25%  { background-color: #fecaca; }
+    100% { background-color: inherit; }
+}
+
+.sr-cell-flash-on  { animation: sr-flash-on  0.6s ease; }
+.sr-cell-flash-off { animation: sr-flash-off 0.6s ease; }
+
+/* ===== Toast 通知 ===== */
+
+.sr-toast-wrap {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    pointer-events: none;
+}
+
+.sr-toast {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #fff;
+    box-shadow: 0 4px 16px rgba(0,0,0,.18);
+    pointer-events: auto;
+    max-width: 320px;
+    word-break: break-word;
+    animation: sr-toast-in 0.2s ease;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.sr-toast--hiding {
+    opacity: 0;
+    transform: translateY(8px);
+}
+
+.sr-toast--error   { background: #ef4444; }
+.sr-toast--success { background: #22c55e; }
+.sr-toast--info    { background: #3b82f6; }
+
+@keyframes sr-toast-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+}

--- a/src_web/kamaho-shokusu/webroot/js/pages/staff_reservation.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/staff_reservation.js
@@ -1,0 +1,231 @@
+'use strict';
+
+/* ── 食事種別定数 ── */
+var MEAL = { BREAKFAST: 1, LUNCH: 2, DINNER: 3, BENTO: 4 };
+
+/* ── 排他関係マップ（ON にしたら OFF にすべき相手） ── */
+var MEAL_OPPONENT = {};
+MEAL_OPPONENT[MEAL.LUNCH] = MEAL.BENTO;
+MEAL_OPPONENT[MEAL.BENTO] = MEAL.LUNCH;
+
+/* ─────────────────────────────────────────────
+ * Toast 通知
+ * ─────────────────────────────────────────── */
+function srShowToast(message, type) {
+    var wrap = document.getElementById('sr-toast-wrap');
+    if (!wrap) {
+        wrap = document.createElement('div');
+        wrap.id = 'sr-toast-wrap';
+        wrap.className = 'sr-toast-wrap';
+        document.body.appendChild(wrap);
+    }
+
+    var toast = document.createElement('div');
+    toast.className = 'sr-toast sr-toast--' + (type || 'info');
+    toast.textContent = message;
+    wrap.appendChild(toast);
+
+    // アニメーション終了後に要素を削除
+    setTimeout(function () {
+        toast.classList.add('sr-toast--hiding');
+        setTimeout(function () {
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
+        }, 300);
+    }, 2700);
+}
+
+/* ─────────────────────────────────────────────
+ * セルアニメーション（成功フラッシュ）
+ * ─────────────────────────────────────────── */
+function srFlashCell(td, isOn) {
+    var cls = isOn ? 'sr-cell-flash-on' : 'sr-cell-flash-off';
+    td.classList.remove('sr-cell-flash-on', 'sr-cell-flash-off');
+    // reflow を強制してアニメーションを再起動
+    void td.offsetWidth;
+    td.classList.add(cls);
+    setTimeout(function () { td.classList.remove(cls); }, 600);
+}
+
+/* ─────────────────────────────────────────────
+ * 他部屋競合セルの無効化制御
+ * ─────────────────────────────────────────── */
+function srGetConflictingCells(date, meal, excludeRoomId) {
+    var cells = [];
+    document.querySelectorAll('.sr-toggleable').forEach(function (td) {
+        if (td.dataset.date === date && td.dataset.meal === String(meal) && td.dataset.roomId !== String(excludeRoomId)) {
+            cells.push(td);
+        }
+    });
+    return cells;
+}
+
+function srDisableConflicts(date, meal, activeRoomId) {
+    srGetConflictingCells(date, meal, activeRoomId).forEach(function (td) {
+        if (td.dataset.reserved !== '1') {
+            td.classList.add('sr-cell-disabled');
+            td.dataset.srTooltip = '別の部屋で同日・同食事の予約があります';
+        }
+    });
+}
+
+function srEnableConflicts(date, meal) {
+    document.querySelectorAll('.sr-toggleable').forEach(function (td) {
+        if (td.dataset.date === date && td.dataset.meal === String(meal)) {
+            td.classList.remove('sr-cell-disabled');
+            delete td.dataset.srTooltip;
+        }
+    });
+}
+
+function srInitConflicts() {
+    document.querySelectorAll('.sr-toggleable[data-reserved="1"]').forEach(function (td) {
+        srDisableConflicts(td.dataset.date, td.dataset.meal, td.dataset.roomId);
+    });
+}
+
+/* ─────────────────────────────────────────────
+ * セル操作ヘルパー
+ * ─────────────────────────────────────────── */
+function srFindMealCell(userId, roomId, date, meal) {
+    return document.querySelector(
+        '.sr-toggleable[data-user-id="' + userId + '"]' +
+        '[data-room-id="' + roomId + '"]' +
+        '[data-date="' + date + '"]' +
+        '[data-meal="' + meal + '"]'
+    );
+}
+
+function srSetCellOn(td) {
+    td.dataset.reserved = '1';
+    if (!td.querySelector('.sr-cell-check')) {
+        var span = document.createElement('span');
+        span.className = 'sr-cell-check';
+        td.appendChild(span);
+    }
+}
+
+function srSetCellOff(td) {
+    td.dataset.reserved = '0';
+    var check = td.querySelector('.sr-cell-check');
+    if (check) check.remove();
+}
+
+/* ─────────────────────────────────────────────
+ * 食事セルのトグル（Optimistic UI）
+ * ─────────────────────────────────────────── */
+function srInitToggle() {
+    var csrfMeta  = document.querySelector('meta[name="csrfToken"]');
+    var csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+    var basePath  = (window.SR_CONFIG && window.SR_CONFIG.basePath) ? window.SR_CONFIG.basePath : '';
+
+    document.querySelectorAll('.sr-toggleable').forEach(function (td) {
+        td.addEventListener('click', function () {
+            if (td.classList.contains('sr-cell-disabled')) return;
+            if (td.dataset.srProcessing === '1') return;
+
+            var userId   = td.dataset.userId;
+            var roomId   = td.dataset.roomId;
+            var date     = td.dataset.date;
+            var meal     = parseInt(td.dataset.meal, 10);
+            var reserved = td.dataset.reserved === '1';
+            var newValue = reserved ? 0 : 1;
+
+            /* ── スナップショット（失敗時の差し戻し用） ── */
+            var snapshot = { reserved: td.dataset.reserved };
+            var opponentCell = null;
+            var opponentSnapshot = null;
+
+            if (newValue === 1 && Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
+                opponentCell = srFindMealCell(userId, roomId, date, MEAL_OPPONENT[meal]);
+                if (opponentCell) {
+                    opponentSnapshot = { reserved: opponentCell.dataset.reserved };
+                }
+            }
+
+            /* ── Optimistic update ── */
+            td.dataset.srProcessing = '1';
+            td.style.pointerEvents  = 'none';
+
+            if (newValue === 1) {
+                srSetCellOn(td);
+                srDisableConflicts(date, meal, roomId);
+                if (opponentCell) srSetCellOff(opponentCell);
+            } else {
+                srSetCellOff(td);
+                var stillReserved = false;
+                document.querySelectorAll('.sr-toggleable').forEach(function (other) {
+                    if (other !== td && other.dataset.date === date && other.dataset.meal === String(meal) && other.dataset.reserved === '1') {
+                        stillReserved = true;
+                    }
+                });
+                if (!stillReserved) srEnableConflicts(date, meal);
+            }
+
+            /* ── API リクエスト ── */
+            fetch(basePath + '/TReservationInfo/toggle/' + roomId, {
+                method: 'POST',
+                headers: {
+                    'Content-Type':    'application/json',
+                    'X-CSRF-Token':    csrfToken,
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept':          'application/json',
+                },
+                body: JSON.stringify({
+                    userId: parseInt(userId, 10),
+                    date:   date,
+                    meal:   meal,
+                    value:  newValue,
+                }),
+            })
+            .then(function (res) {
+                return res.text().then(function (text) {
+                    var data;
+                    try {
+                        data = JSON.parse(text);
+                    } catch (e) {
+                        console.error('Non-JSON response (HTTP ' + res.status + '):', text.substring(0, 500));
+                        throw new Error('サーバーエラーが発生しました (HTTP ' + res.status + ')。');
+                    }
+                    if (data.ok === false) {
+                        throw new Error(data.message || 'エラーが発生しました。');
+                    }
+                    return data;
+                });
+            })
+            .then(function () {
+                /* 成功: フラッシュアニメーションのみ（DOM は既に更新済み） */
+                srFlashCell(td, newValue === 1);
+            })
+            .catch(function (err) {
+                /* 失敗: Optimistic update を差し戻す */
+                if (snapshot.reserved === '1') {
+                    srSetCellOn(td);
+                } else {
+                    srSetCellOff(td);
+                }
+                if (opponentCell && opponentSnapshot) {
+                    if (opponentSnapshot.reserved === '1') {
+                        srSetCellOn(opponentCell);
+                    } else {
+                        srSetCellOff(opponentCell);
+                    }
+                }
+
+                console.error('Toggle error:', err);
+                srShowToast(err.message || '通信エラーが発生しました。', 'error');
+            })
+            .finally(function () {
+                delete td.dataset.srProcessing;
+                td.style.pointerEvents = '';
+            });
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    var isIndividual = window.SR_CONFIG && window.SR_CONFIG.isIndividual;
+    if (isIndividual) {
+        srInitConflicts();
+        srInitToggle();
+    }
+});


### PR DESCRIPTION
Closes #218

## 変更内容

### 新規実装
- **職員用4週間予約グリッド画面**（`staff_reservation`）を新規実装
  - 個人モード・全部屋モードの2種類の表示に対応
  - 4週間分の食事（朝・昼・夜・弁当）を縦軸ユーザー×横軸日付のグリッドで一覧表示
- **Optimistic UI** — セルクリック後、サーバー応答を待たずに即時DOM更新し、失敗時に差し戻す
- **Toastトースト通知** — `alert()` を廃止し、右下固定の自動消去トーストに置き換え
- **セルフラッシュアニメーション** — 成功時に緑/赤の一瞬のフィードバックアニメーション
- **昼↔弁当の排他制御** — フロントエンド（スナップショット差し戻し）・バックエンド（`buildRules`）双方で実装

### バグ修正
- `TIndividualReservationInfoTable::toggleMeal()` 内の `$isLastMinute` → `$useChangeFlag` 変数名不一致バグを修正

### リファクタリング
- **`i_change_flag` NULL フォールバック統一** — 14日以内の日付で `i_change_flag` が NULL の場合は `eat_flag` にフォールバックするよう全サービスで統一
- **コントローラーのORM直接呼び出しを排除** — `TReservationInfoController` の全 `->find()` 呼び出しをサービス層メソッドに委譲
- **マジックナンバー排除** — `TIndividualReservationInfoTable` に `MEAL_BREAKFAST/LUNCH/DINNER/BENTO` 定数と `MEAL_OPPONENTS` マップを追加
- **ビジネスロジック分散** — 週ナビゲーション計算・ユーザーリスト補完・部屋所属チェックを `ActualMealManagementService` に移動

### サービス層追加メソッド
- `ActualMealManagementService::resolveWeekNavigation()` — 週パラメータ正規化・過去未来のクランプ・prev/next フラグ生成
- `ActualMealManagementService::ensureUserInList()` — ログインユーザーがリストに未存在かつ部屋所属なら先頭に追加
- `ActualMealManagementService::userBelongsToRoom()` — MUserGroup の `active_flag=0` で部屋所属を判定
- `ReservationCalendarService::getAllActiveRoomIds()` — `i_del_flg=0` の部屋ID一覧を返す
- `ReservationCalendarService::getRoomsByIds()` — 指定IDに一致する部屋を `[id => name]` で返す
- `ReservationChangeEditService::getRoomById()` — 単一部屋の取得

### テスト追加
- `ActualMealManagementServiceTest` — `resolveWeekNavigation`（9件）・`ensureUserInList`（4件）・`userBelongsToRoom`（3件）
- `ReservationCalendarServiceTest` — `getAllActiveRoomIds`（3件）・`getRoomsByIds`（5件）
- `TIndividualReservationInfoTableTest` — 食事種別定数の値検証（2件）・昼↔弁当排他ルール（4件）