### PR TITLE
Resolve #207: 部屋異動予約機能（将来日付での部屋移動スケジュール）

### DIFF
--- a/.github/workflows/room_transfer_apply.yml
+++ b/.github/workflows/room_transfer_apply.yml
@@ -1,0 +1,45 @@
+name: Apply Room Transfer Schedule
+
+on:
+  schedule:
+    - cron: '0 15 * * *'   # 毎日 JST 0:00 に実行（UTC 15:00）
+  workflow_dispatch:         # 手動実行も可能
+
+jobs:
+  apply:
+    name: Apply Room Transfer Schedule
+    runs-on: ubuntu-latest
+    # 本番サーバー専用: main ブランチのみ実行
+    if: github.ref == 'refs/heads/main'
+    env:
+      SLACK_USERNAME: DeployBot
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    steps:
+      - name: SSH into production server and apply room transfer schedule
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ubuntu
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            bash scripts/apply_room_transfer_schedule.sh
+
+      - name: Slack Notification on Success
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ success() }}
+        env:
+          SLACK_TITLE: Room Transfer Apply / Success
+          SLACK_COLOR: good
+          SLACK_MESSAGE: 部屋異動予約の適用が完了しました✅
+
+      - name: Slack Notification on Failure
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_TITLE: Room Transfer Apply / Failure
+          SLACK_COLOR: danger
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> 部屋異動予約の適用に失敗しました😢"

--- a/scripts/apply_room_transfer_schedule.sh
+++ b/scripts/apply_room_transfer_schedule.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# PHP コンテナ内で CakePHP コマンドを実行する
+CONTAINER_NAME="kamakura-shokusu_web"
+APP_PATH="/var/www/html/kamaho-shokusu"
+
+echo "Starting room transfer schedule apply: $(date)"
+
+docker exec "$CONTAINER_NAME" \
+  bash -c "cd ${APP_PATH} && php bin/cake.php apply_room_transfer_schedule"
+
+echo "Room transfer schedule apply completed: $(date)"

--- a/sql/m_room_transfer_schedule.sql
+++ b/sql/m_room_transfer_schedule.sql
@@ -1,0 +1,20 @@
+create table m_room_transfer_schedule
+(
+    i_id             int          not null auto_increment,
+    i_id_user        int          not null,
+    i_id_room_from   int          null,
+    i_id_room_to     int          not null,
+    d_effective_date date         not null,
+    i_status         tinyint      not null default 0 comment '0=予約中, 1=適用済み, 2=キャンセル',
+    c_create_user    varchar(50)  null,
+    dt_create        datetime     null,
+    c_update_user    varchar(50)  null,
+    dt_update        datetime     null,
+    primary key (i_id),
+    constraint fk_rts_user foreign key (i_id_user) references m_user_info (i_id_user),
+    constraint fk_rts_room_from foreign key (i_id_room_from) references m_room_info (i_id_room),
+    constraint fk_rts_room_to foreign key (i_id_room_to) references m_room_info (i_id_room)
+);
+
+create index idx_rts_user_id on m_room_transfer_schedule (i_id_user);
+create index idx_rts_effective_date on m_room_transfer_schedule (d_effective_date, i_status);

--- a/sql/updates/20260514_001_create_m_room_transfer_schedule.sql
+++ b/sql/updates/20260514_001_create_m_room_transfer_schedule.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS m_room_transfer_schedule
+(
+    i_id             INT         NOT NULL AUTO_INCREMENT,
+    i_id_user        INT         NOT NULL,
+    i_id_room_from   INT         NULL,
+    i_id_room_to     INT         NOT NULL,
+    d_effective_date DATE        NOT NULL,
+    i_status         TINYINT     NOT NULL DEFAULT 0 COMMENT '0=予約中, 1=適用済み, 2=キャンセル',
+    c_create_user    VARCHAR(50) NULL,
+    dt_create        DATETIME    NULL,
+    c_update_user    VARCHAR(50) NULL,
+    dt_update        DATETIME    NULL,
+    PRIMARY KEY (i_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @idx_user_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'm_room_transfer_schedule'
+      AND index_name = 'idx_rts_user_id'
+);
+SET @idx_user_sql := IF(
+    @idx_user_exists = 0,
+    'CREATE INDEX idx_rts_user_id ON m_room_transfer_schedule (i_id_user)',
+    'SELECT 1'
+);
+PREPARE idx_user_stmt FROM @idx_user_sql;
+EXECUTE idx_user_stmt;
+DEALLOCATE PREPARE idx_user_stmt;
+
+SET @idx_date_exists := (
+    SELECT COUNT(1)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'm_room_transfer_schedule'
+      AND index_name = 'idx_rts_effective_date'
+);
+SET @idx_date_sql := IF(
+    @idx_date_exists = 0,
+    'CREATE INDEX idx_rts_effective_date ON m_room_transfer_schedule (d_effective_date, i_status)',
+    'SELECT 1'
+);
+PREPARE idx_date_stmt FROM @idx_date_sql;
+EXECUTE idx_date_stmt;
+DEALLOCATE PREPARE idx_date_stmt;

--- a/src_web/kamaho-shokusu/config/Migrations/20260513000000_CreateMRoomTransferSchedule.php
+++ b/src_web/kamaho-shokusu/config/Migrations/20260513000000_CreateMRoomTransferSchedule.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class CreateMRoomTransferSchedule extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('m_room_transfer_schedule', ['id' => false, 'primary_key' => ['i_id']]);
+        $table
+            ->addColumn('i_id', 'integer', ['identity' => true, 'null' => false])
+            ->addColumn('i_id_user', 'integer', ['null' => false])
+            ->addColumn('i_id_room_from', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('i_id_room_to', 'integer', ['null' => false])
+            ->addColumn('d_effective_date', 'date', ['null' => false])
+            ->addColumn('i_status', 'integer', ['null' => false, 'default' => 0, 'limit' => 1, 'comment' => '0=予約中, 1=適用済み, 2=キャンセル'])
+            ->addColumn('c_create_user', 'string', ['null' => true, 'limit' => 50])
+            ->addColumn('dt_create', 'datetime', ['null' => true])
+            ->addColumn('c_update_user', 'string', ['null' => true, 'limit' => 50])
+            ->addColumn('dt_update', 'datetime', ['null' => true])
+            ->addIndex(['i_id_user'], ['name' => 'idx_rts_user_id'])
+            ->addIndex(['d_effective_date', 'i_status'], ['name' => 'idx_rts_effective_date'])
+            ->create();
+    }
+}

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -149,6 +149,17 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/MUserInfo/logout', ['controller' => 'MUserInfo', 'action' => 'logout']);
         $builder->connect('/MUserInfo/view/*', ['controller' => 'MUserInfo', 'action' => 'view']);
 
+        // MRoomTransferSchedule（部屋異動予約）
+        $builder->connect('/MRoomTransferSchedule', ['controller' => 'MRoomTransferSchedule', 'action' => 'index']);
+        $builder->connect('/MRoomTransferSchedule/add', ['controller' => 'MRoomTransferSchedule', 'action' => 'add']);
+        $builder->connect(
+            '/MRoomTransferSchedule/cancel/:id',
+            ['controller' => 'MRoomTransferSchedule', 'action' => 'cancel']
+        )
+            ->setPass(['id'])
+            ->setPatterns(['id' => '\d+'])
+            ->setMethods(['POST']);
+
         // Pages
         $builder->connect('/pages/*', 'Pages::display');
 

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -89,6 +89,11 @@ return function (RouteBuilder $routes): void {
             ['controller' => 'TReservationInfo', 'action' => 'getPersonalReservation']
         )->setMethods(['GET']);
 
+        $builder->connect(
+            '/TReservationInfo/getReservationSnapshots',
+            ['controller' => 'TReservationInfo', 'action' => 'getReservationSnapshots']
+        )->setMethods(['POST']);
+
         $builder->connect('/TReservationInfo/changeEdit/*', ['controller' => 'TReservationInfo', 'action' => 'changeEdit']);
         $builder->connect(
             '/TReservationInfo/changeEdit/:roomId/:date/:mealType',

--- a/src_web/kamaho-shokusu/src/Command/ApplyRoomTransferScheduleCommand.php
+++ b/src_web/kamaho-shokusu/src/Command/ApplyRoomTransferScheduleCommand.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\RoomTransferScheduleService;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\I18n\DateTime;
+
+/**
+ * 部屋異動予約適用バッチ
+ *
+ * 有効開始日が到来した予約中スケジュールを適用する。
+ * 毎日0時頃にcronで実行することを想定。
+ *
+ * 使用例:
+ *   bin/cake apply_room_transfer_schedule
+ *   bin/cake apply_room_transfer_schedule --dry-run
+ *   bin/cake apply_room_transfer_schedule --date 2026-04-01
+ */
+class ApplyRoomTransferScheduleCommand extends Command
+{
+    public static function defaultName(): string
+    {
+        return 'apply_room_transfer_schedule';
+    }
+
+    public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        $parser = parent::buildOptionParser($parser);
+
+        return $parser
+            ->addOption('date', [
+                'help'  => '基準日 (YYYY-MM-DD)。未指定は今日(JST)。',
+                'short' => 'd',
+            ])
+            ->addOption('dry-run', [
+                'help'    => 'ドライラン（件数のみ表示しコミットしない）',
+                'boolean' => true,
+                'short'   => 'r',
+            ]);
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        $dryRun  = (bool)$args->getOption('dry-run');
+        $dateOpt = $args->getOption('date');
+
+        $today = $dateOpt
+            ? (new DateTime($dateOpt . ' 00:00:00', 'Asia/Tokyo'))->format('Y-m-d')
+            : DateTime::now('Asia/Tokyo')->format('Y-m-d');
+
+        if ($dryRun) {
+            $io->out('[DRY-RUN] 基準日: ' . $today);
+        } else {
+            $io->out('部屋異動予約の適用を開始します。基準日: ' . $today);
+        }
+
+        $service = new RoomTransferScheduleService();
+
+        try {
+            $result = $service->applyPending($today, $dryRun);
+        } catch (\Throwable $e) {
+            $io->err('致命的エラー: ' . $e->getMessage());
+            return self::CODE_ERROR;
+        }
+
+        $prefix = $dryRun ? '[DRY-RUN] ' : '';
+        $io->out(sprintf('%s適用%s: %d件', $prefix, $dryRun ? '予定' : '完了', $result['applied']));
+
+        if (!empty($result['errors'])) {
+            foreach ($result['errors'] as $err) {
+                $io->err('エラー: ' . $err);
+            }
+            return self::CODE_ERROR;
+        }
+
+        return self::CODE_SUCCESS;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Model\Table\MRoomTransferScheduleTable;
+use App\Service\RoomTransferScheduleService;
+use Authorization\Exception\ForbiddenException;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\NotFoundException;
+
+/**
+ * 部屋異動予約コントローラー
+ *
+ * 管理者が将来日付での部屋異動を事前登録・確認・キャンセルする画面を提供する。
+ */
+class MRoomTransferScheduleController extends AppController
+{
+    private RoomTransferScheduleService $transferService;
+
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->viewBuilder()->setLayout('default');
+        $this->transferService = new RoomTransferScheduleService();
+    }
+
+    /**
+     * 異動予約一覧
+     */
+    public function index(): void
+    {
+        $table    = $this->fetchTable('MRoomTransferSchedule');
+        $resource = $table->newEmptyEntity();
+
+        try {
+            $this->Authorization->authorize($resource, 'index');
+        } catch (ForbiddenException $e) {
+            $this->Flash->error(__('この機能は管理者のみ利用できます。'));
+            $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
+            return;
+        }
+
+        $statusFilter = $this->request->getQuery('status');
+        $conditions   = [];
+        if (in_array($statusFilter, ['0', '1', '2'], true)) {
+            $conditions['MRoomTransferSchedule.i_status'] = (int)$statusFilter;
+        }
+
+        $schedules = $table->find()
+            ->contain(['MUserInfo', 'RoomFrom', 'RoomTo'])
+            ->where($conditions)
+            ->orderByDesc('MRoomTransferSchedule.d_effective_date')
+            ->all();
+
+        $this->set(compact('schedules', 'statusFilter'));
+    }
+
+    /**
+     * 異動予約登録フォーム・保存
+     */
+    public function add(): void
+    {
+        $this->request->allowMethod(['get', 'post']);
+
+        $table    = $this->fetchTable('MRoomTransferSchedule');
+        $resource = $table->newEmptyEntity();
+
+        try {
+            $this->Authorization->authorize($resource, 'add');
+        } catch (ForbiddenException $e) {
+            $this->Flash->error(__('この機能は管理者のみ利用できます。'));
+            $this->redirect(['action' => 'index']);
+            return;
+        }
+
+        if ($this->request->is('post')) {
+            $data = $this->request->getData();
+
+            $userId      = isset($data['i_id_user'])      ? (int)$data['i_id_user']      : null;
+            $roomFromId  = isset($data['i_id_room_from']) && $data['i_id_room_from'] !== ''
+                ? (int)$data['i_id_room_from']
+                : null;
+            $roomToId    = isset($data['i_id_room_to'])   ? (int)$data['i_id_room_to']   : null;
+            $effectiveDate = (string)($data['d_effective_date'] ?? '');
+
+            if (!$userId || !$roomToId || $effectiveDate === '') {
+                $this->Flash->error(__('ユーザー・異動先部屋・有効開始日は必須です。'));
+            } else {
+                $identity = $this->request->getAttribute('identity');
+                $actor    = $identity ? $identity->get('c_user_name') : '管理者';
+
+                try {
+                    $this->transferService->create($userId, $roomFromId, $roomToId, $effectiveDate, $actor);
+                    $this->Flash->success(__('部屋異動予約を登録しました。'));
+                    $this->redirect(['action' => 'index']);
+                    return;
+                } catch (\RuntimeException $e) {
+                    $this->Flash->error($e->getMessage());
+                } catch (\Throwable $e) {
+                    $this->Flash->error(__('登録処理中にエラーが発生しました。'));
+                }
+            }
+        }
+
+        $users = $this->fetchTable('MUserInfo')->find('list', [
+            'keyField'   => 'i_id_user',
+            'valueField' => 'c_user_name',
+        ])->where(['i_del_flag' => 0])->orderByAsc('i_disp_no')->toArray();
+
+        $rooms = $this->fetchTable('MRoomInfo')->find('list', [
+            'keyField'   => 'i_id_room',
+            'valueField' => 'c_room_name',
+        ])->toArray();
+
+        $this->set(compact('users', 'rooms'));
+    }
+
+    /**
+     * 異動予約キャンセル
+     *
+     * @param int $id スケジュールID
+     */
+    public function cancel(int $id): void
+    {
+        $this->request->allowMethod(['post']);
+
+        $table    = $this->fetchTable('MRoomTransferSchedule');
+        $resource = $table->newEmptyEntity();
+
+        try {
+            $this->Authorization->authorize($resource, 'cancel');
+        } catch (ForbiddenException $e) {
+            $this->Flash->error(__('この機能は管理者のみ利用できます。'));
+            $this->redirect(['action' => 'index']);
+            return;
+        }
+
+        try {
+            $table->get($id);
+        } catch (\Cake\Datasource\Exception\RecordNotFoundException $e) {
+            throw new NotFoundException('指定された予約が見つかりません。');
+        }
+
+        $identity = $this->request->getAttribute('identity');
+        $actor    = $identity ? $identity->get('c_user_name') : '管理者';
+
+        try {
+            $this->transferService->cancel($id, $actor);
+            $this->Flash->success(__('異動予約をキャンセルしました。'));
+        } catch (\RuntimeException $e) {
+            $this->Flash->error($e->getMessage());
+        } catch (\Throwable $e) {
+            $this->Flash->error(__('キャンセル処理中にエラーが発生しました。'));
+        }
+
+        $this->redirect(['action' => 'index']);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Model/Entity/MRoomTransferSchedule.php
+++ b/src_web/kamaho-shokusu/src/Model/Entity/MRoomTransferSchedule.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * MRoomTransferSchedule Entity
+ *
+ * @property int $i_id
+ * @property int $i_id_user
+ * @property int|null $i_id_room_from
+ * @property int $i_id_room_to
+ * @property \Cake\I18n\Date $d_effective_date
+ * @property int $i_status
+ * @property string|null $c_create_user
+ * @property \Cake\I18n\DateTime|null $dt_create
+ * @property string|null $c_update_user
+ * @property \Cake\I18n\DateTime|null $dt_update
+ * @property \App\Model\Entity\MUserInfo $m_user_info
+ * @property \App\Model\Entity\MRoomInfo $room_from
+ * @property \App\Model\Entity\MRoomInfo $room_to
+ */
+class MRoomTransferSchedule extends Entity
+{
+    protected array $_accessible = [
+        'i_id_user'        => true,
+        'i_id_room_from'   => true,
+        'i_id_room_to'     => true,
+        'd_effective_date' => true,
+        'i_status'         => true,
+        'c_create_user'    => true,
+        'dt_create'        => true,
+        'c_update_user'    => true,
+        'dt_update'        => true,
+    ];
+}

--- a/src_web/kamaho-shokusu/src/Model/Table/MRoomTransferScheduleTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/MRoomTransferScheduleTable.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+class MRoomTransferScheduleTable extends Table
+{
+    public const STATUS_PENDING   = 0;
+    public const STATUS_APPLIED   = 1;
+    public const STATUS_CANCELLED = 2;
+
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('m_room_transfer_schedule');
+        $this->setPrimaryKey('i_id');
+
+        $this->belongsTo('MUserInfo', [
+            'foreignKey' => 'i_id_user',
+            'joinType'   => 'INNER',
+        ]);
+        $this->belongsTo('RoomFrom', [
+            'className'  => 'MRoomInfo',
+            'foreignKey' => 'i_id_room_from',
+            'joinType'   => 'LEFT',
+        ]);
+        $this->belongsTo('RoomTo', [
+            'className'  => 'MRoomInfo',
+            'foreignKey' => 'i_id_room_to',
+            'joinType'   => 'INNER',
+        ]);
+    }
+
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('i_id_user')
+            ->requirePresence('i_id_user', 'create')
+            ->notEmptyString('i_id_user');
+
+        $validator
+            ->integer('i_id_room_to')
+            ->requirePresence('i_id_room_to', 'create')
+            ->notEmptyString('i_id_room_to');
+
+        $validator
+            ->date('d_effective_date')
+            ->requirePresence('d_effective_date', 'create')
+            ->notEmptyDate('d_effective_date');
+
+        $validator
+            ->integer('i_status')
+            ->inList('i_status', [self::STATUS_PENDING, self::STATUS_APPLIED, self::STATUS_CANCELLED]);
+
+        return $validator;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Policy/MRoomTransferSchedulePolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MRoomTransferSchedulePolicy.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use Authorization\IdentityInterface;
+
+class MRoomTransferSchedulePolicy
+{
+    public function canIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    public function canAdd(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    public function canCancel(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    private function isAdmin(?IdentityInterface $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        $identity = $user->getOriginalData();
+        if ($identity === null) {
+            return false;
+        }
+
+        if (is_object($identity) && method_exists($identity, 'get')) {
+            return (int)$identity->get('i_admin') === 1;
+        }
+
+        if (is_array($identity)) {
+            return (int)($identity['i_admin'] ?? 0) === 1;
+        }
+
+        return false;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/RoomTransferScheduleService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomTransferScheduleService.php
@@ -1,0 +1,351 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Model\Table\MRoomTransferScheduleTable;
+use Cake\Cache\Cache;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use Cake\ORM\TableRegistry;
+
+/**
+ * 部屋異動予約サービス
+ *
+ * 予約の登録・キャンセル・適用（m_user_group切替 + 個人予約移行 + 集計更新）を担う。
+ */
+class RoomTransferScheduleService
+{
+    /**
+     * 部屋異動予約を登録する。
+     *
+     * @param int         $userId        対象ユーザーID
+     * @param int|null    $roomFromId    異動元部屋ID（NULL=新規配属）
+     * @param int         $roomToId      異動先部屋ID
+     * @param string      $effectiveDate 有効開始日 (Y-m-d)
+     * @param string      $actor         操作者名
+     * @return int 登録されたスケジュールID
+     * @throws \RuntimeException バリデーション失敗時
+     * @throws \Throwable DB保存失敗時
+     */
+    public function create(
+        int $userId,
+        ?int $roomFromId,
+        int $roomToId,
+        string $effectiveDate,
+        string $actor
+    ): int {
+        $table = TableRegistry::getTableLocator()->get('MRoomTransferSchedule');
+
+        $entity = $table->newEntity([
+            'i_id_user'        => $userId,
+            'i_id_room_from'   => $roomFromId,
+            'i_id_room_to'     => $roomToId,
+            'd_effective_date' => $effectiveDate,
+            'i_status'         => MRoomTransferScheduleTable::STATUS_PENDING,
+            'c_create_user'    => $actor,
+            'dt_create'        => DateTime::now(),
+        ]);
+
+        if ($entity->hasErrors()) {
+            $messages = array_map(
+                fn(array $errs) => implode(', ', $errs),
+                array_map('array_values', $entity->getErrors())
+            );
+            throw new \RuntimeException('バリデーションエラー: ' . implode(' / ', array_merge(...array_values($messages))));
+        }
+
+        $table->saveOrFail($entity);
+
+        return (int)$entity->i_id;
+    }
+
+    /**
+     * 予約中のスケジュールをキャンセルする。
+     *
+     * @param int    $scheduleId スケジュールID
+     * @param string $actor      操作者名
+     * @throws \RuntimeException 対象が存在しない・既に適用済みの場合
+     * @throws \Throwable DB保存失敗時
+     */
+    public function cancel(int $scheduleId, string $actor): void
+    {
+        $table    = TableRegistry::getTableLocator()->get('MRoomTransferSchedule');
+        $schedule = $table->get($scheduleId);
+
+        if ((int)$schedule->i_status !== MRoomTransferScheduleTable::STATUS_PENDING) {
+            throw new \RuntimeException('キャンセルできるのは予約中のスケジュールのみです。');
+        }
+
+        $schedule->i_status      = MRoomTransferScheduleTable::STATUS_CANCELLED;
+        $schedule->c_update_user = $actor;
+        $schedule->dt_update     = DateTime::now();
+
+        $table->saveOrFail($schedule);
+    }
+
+    /**
+     * 有効開始日が到来した予約中スケジュールをすべて適用する。
+     *
+     * 各スケジュールに対してトランザクション内で以下を実行する:
+     *   1. m_user_group の部屋切替
+     *   2. t_individual_reservation_info の予約移行（DELETE + INSERT）
+     *   3. t_reservation_info（集計）の更新
+     *   4. スケジュールを適用済みにマーク
+     *   5. キャッシュ無効化
+     *
+     * @param string $today 基準日 (Y-m-d)
+     * @param bool   $dryRun トゥルーの場合コミットしない
+     * @return array{applied: int, errors: array<string>}
+     */
+    public function applyPending(string $today, bool $dryRun = false): array
+    {
+        $scheduleTable    = TableRegistry::getTableLocator()->get('MRoomTransferSchedule');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $indvResTable     = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $groupResTable    = TableRegistry::getTableLocator()->get('TReservationInfo');
+
+        $pending = $scheduleTable->find()
+            ->where([
+                'i_status'            => MRoomTransferScheduleTable::STATUS_PENDING,
+                'd_effective_date <=' => $today,
+            ])
+            ->all();
+
+        $applied = 0;
+        $errors  = [];
+
+        foreach ($pending as $schedule) {
+            $conn = $scheduleTable->getConnection();
+            $conn->begin();
+
+            try {
+                $userId        = (int)$schedule->i_id_user;
+                $roomFromId    = $schedule->i_id_room_from !== null ? (int)$schedule->i_id_room_from : null;
+                $roomToId      = (int)$schedule->i_id_room_to;
+                $effectiveDate = (string)$schedule->d_effective_date;
+                $now           = DateTime::now();
+
+                // Step 1: m_user_group 切替
+                if ($roomFromId !== null) {
+                    $userGroupTable->updateAll(
+                        ['active_flag' => 1, 'dt_update' => $now, 'c_update_user' => 'batch'],
+                        ['i_id_user' => $userId, 'i_id_room' => $roomFromId, 'active_flag' => 0]
+                    );
+                }
+
+                $existingGroup = $userGroupTable->find()
+                    ->where(['i_id_user' => $userId, 'i_id_room' => $roomToId])
+                    ->first();
+
+                if ($existingGroup) {
+                    $existingGroup->active_flag   = 0;
+                    $existingGroup->dt_update     = $now;
+                    $existingGroup->c_update_user = 'batch';
+                    $userGroupTable->saveOrFail($existingGroup);
+                } else {
+                    $newGroup = $userGroupTable->newEntity([
+                        'i_id_user'     => $userId,
+                        'i_id_room'     => $roomToId,
+                        'active_flag'   => 0,
+                        'dt_create'     => $now,
+                        'c_create_user' => 'batch',
+                    ]);
+                    $userGroupTable->saveOrFail($newGroup);
+                }
+
+                // Step 2 & 3: 個人予約移行 + 集計更新
+                if ($roomFromId !== null) {
+                    $this->migrateIndividualReservations(
+                        $indvResTable,
+                        $groupResTable,
+                        $userId,
+                        $roomFromId,
+                        $roomToId,
+                        $effectiveDate,
+                        $now
+                    );
+                }
+
+                // Step 4: スケジュールを適用済みにマーク
+                $schedule->i_status      = MRoomTransferScheduleTable::STATUS_APPLIED;
+                $schedule->c_update_user = 'batch';
+                $schedule->dt_update     = $now;
+                $scheduleTable->saveOrFail($schedule);
+
+                if ($dryRun) {
+                    $conn->rollback();
+                } else {
+                    $conn->commit();
+                    // Step 5: キャッシュ無効化
+                    $this->invalidateCaches($userId, $roomFromId, $roomToId, $effectiveDate, $today);
+                }
+
+                $applied++;
+
+            } catch (\Throwable $e) {
+                if ($conn->inTransaction()) {
+                    $conn->rollback();
+                }
+                $errors[] = sprintf('スケジュールID=%d: %s', (int)$schedule->i_id, $e->getMessage());
+            }
+        }
+
+        return ['applied' => $applied, 'errors' => $errors];
+    }
+
+    /**
+     * 個人予約レコードを旧部屋から新部屋へ移行し、集計テーブルも更新する。
+     *
+     * t_individual_reservation_info のPKに i_id_room が含まれるため
+     * UPDATE は不可。DELETE + INSERT で対応する。
+     *
+     * @param \Cake\ORM\Table $indvResTable
+     * @param \Cake\ORM\Table $groupResTable
+     * @param int             $userId
+     * @param int             $roomFromId
+     * @param int             $roomToId
+     * @param string          $effectiveDate
+     * @param DateTime        $now
+     */
+    private function migrateIndividualReservations(
+        object $indvResTable,
+        object $groupResTable,
+        int $userId,
+        int $roomFromId,
+        int $roomToId,
+        string $effectiveDate,
+        DateTime $now
+    ): void {
+        $oldRows = $indvResTable->find()
+            ->where([
+                'i_id_user'                => $userId,
+                'i_id_room'                => $roomFromId,
+                'd_reservation_date >='    => $effectiveDate,
+            ])
+            ->all();
+
+        foreach ($oldRows as $old) {
+            $dateStr  = (string)$old->d_reservation_date;
+            $mealType = (int)$old->i_reservation_type;
+            $eatFlag  = (int)$old->eat_flag;
+
+            // 移行先に同一PKが既にある場合はスキップ（古い行のみ削除）
+            $alreadyExists = $indvResTable->exists([
+                'i_id_user'          => $userId,
+                'i_id_room'          => $roomToId,
+                'd_reservation_date' => $dateStr,
+                'i_reservation_type' => $mealType,
+            ]);
+
+            $indvResTable->deleteAll([
+                'i_id_user'          => $userId,
+                'i_id_room'          => $roomFromId,
+                'd_reservation_date' => $dateStr,
+                'i_reservation_type' => $mealType,
+            ]);
+
+            if (!$alreadyExists) {
+                $newRow = $indvResTable->newEntity([
+                    'i_id_user'          => $userId,
+                    'i_id_room'          => $roomToId,
+                    'd_reservation_date' => $dateStr,
+                    'i_reservation_type' => $mealType,
+                    'eat_flag'           => $eatFlag,
+                    'i_change_flag'      => (int)$old->i_change_flag,
+                    'i_version'          => (int)$old->i_version,
+                    'c_create_user'      => (string)$old->c_create_user,
+                    'dt_create'          => $old->dt_create,
+                    'c_update_user'      => 'batch',
+                    'dt_update'          => $now,
+                ]);
+                $indvResTable->saveOrFail($newRow);
+
+                // eat_flag=1 の行だけ集計テーブルを更新
+                if ($eatFlag === 1) {
+                    $this->adjustGroupReservationCount($groupResTable, $dateStr, $roomFromId, $mealType, -1, $now);
+                    $this->adjustGroupReservationCount($groupResTable, $dateStr, $roomToId, $mealType, +1, $now);
+                }
+            }
+        }
+    }
+
+    /**
+     * t_reservation_info の i_taberu_ninzuu を delta 分増減する。
+     * レコードが存在しない場合は新規作成する（delta=+1 の時のみ）。
+     *
+     * @param \Cake\ORM\Table $groupResTable
+     * @param string          $date
+     * @param int             $roomId
+     * @param int             $mealType
+     * @param int             $delta  +1 or -1
+     * @param DateTime        $now
+     */
+    private function adjustGroupReservationCount(
+        object $groupResTable,
+        string $date,
+        int $roomId,
+        int $mealType,
+        int $delta,
+        DateTime $now
+    ): void {
+        $row = $groupResTable->find()
+            ->where([
+                'd_reservation_date'  => $date,
+                'i_id_room'           => $roomId,
+                'c_reservation_type'  => $mealType,
+            ])
+            ->first();
+
+        if ($row) {
+            $newCount = max(0, (int)$row->i_taberu_ninzuu + $delta);
+            $groupResTable->updateAll(
+                ['i_taberu_ninzuu' => $newCount, 'dt_update' => $now, 'c_update_user' => 'batch'],
+                [
+                    'd_reservation_date' => $date,
+                    'i_id_room'          => $roomId,
+                    'c_reservation_type' => $mealType,
+                ]
+            );
+            return;
+        }
+
+        if ($delta > 0) {
+            $newRow = $groupResTable->newEntity([
+                'd_reservation_date' => $date,
+                'i_id_room'          => $roomId,
+                'c_reservation_type' => $mealType,
+                'i_taberu_ninzuu'    => 1,
+                'i_tabenai_ninzuu'   => 0,
+                'dt_create'          => $now,
+                'c_create_user'      => 'batch',
+            ]);
+            $groupResTable->saveOrFail($newRow);
+        }
+    }
+
+    /**
+     * 影響する日付・部屋・ユーザーのキャッシュを無効化する。
+     */
+    private function invalidateCaches(
+        int $userId,
+        ?int $roomFromId,
+        int $roomToId,
+        string $effectiveDate,
+        string $today
+    ): void {
+        // 有効開始日以降の今日分だけキャッシュ削除（全日削除は重すぎるため当日のみ対象）
+        Cache::delete('meal_counts:' . $today, 'default');
+
+        $rooms = array_filter([$roomFromId, $roomToId]);
+        foreach ($rooms as $roomId) {
+            Cache::delete(sprintf('users_by_room_edit:%d:%s', $roomId, $today), 'default');
+        }
+
+        Cache::delete(sprintf('today_report:%d:%s', $userId, $today), 'default');
+
+        $current = Cache::read('reservation_version', 'default');
+        $next    = (is_int($current) && $current > 0) ? $current + 1 : 2;
+        Cache::write('reservation_version', $next, 'default');
+    }
+}

--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/add.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/add.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array $users
+ * @var array $rooms
+ */
+
+$this->assign('title', '部屋異動予約 登録');
+$today = date('Y-m-d');
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<div class="content" style="max-width: 640px;">
+    <h3 class="mb-4">
+        <i class="bi bi-arrow-left-right"></i> 部屋異動予約 登録
+    </h3>
+
+    <?= $this->Flash->render() ?>
+
+    <?= $this->Form->create(null, ['url' => ['action' => 'add'], 'method' => 'post']) ?>
+
+    <div class="form-group mb-3">
+        <label for="i_id_user" class="font-weight-bold">対象ユーザー <span class="text-danger">*</span></label>
+        <?= $this->Form->select('i_id_user', $users, [
+            'id'       => 'i_id_user',
+            'class'    => 'form-control',
+            'empty'    => '-- ユーザーを選択 --',
+            'required' => true,
+        ]) ?>
+    </div>
+
+    <div class="form-group mb-3">
+        <label for="i_id_room_from" class="font-weight-bold">異動元部屋</label>
+        <small class="text-muted d-block">空欄の場合は「新規配属」として扱います。</small>
+        <?= $this->Form->select('i_id_room_from', $rooms, [
+            'id'    => 'i_id_room_from',
+            'class' => 'form-control',
+            'empty' => '-- （新規配属） --',
+        ]) ?>
+    </div>
+
+    <div class="form-group mb-3">
+        <label for="i_id_room_to" class="font-weight-bold">異動先部屋 <span class="text-danger">*</span></label>
+        <?= $this->Form->select('i_id_room_to', $rooms, [
+            'id'       => 'i_id_room_to',
+            'class'    => 'form-control',
+            'empty'    => '-- 部屋を選択 --',
+            'required' => true,
+        ]) ?>
+    </div>
+
+    <div class="form-group mb-4">
+        <label for="d_effective_date" class="font-weight-bold">有効開始日 <span class="text-danger">*</span></label>
+        <small class="text-muted d-block">当日を指定すると即日適用（バッチ次回実行時）になります。</small>
+        <?= $this->Form->control('d_effective_date', [
+            'type'     => 'date',
+            'id'       => 'd_effective_date',
+            'class'    => 'form-control',
+            'label'    => false,
+            'required' => true,
+            'min'      => $today,
+        ]) ?>
+    </div>
+
+    <div class="d-flex gap-2">
+        <?= $this->Form->submit('登録する', ['class' => 'btn btn-primary']) ?>
+        <?= $this->Html->link('キャンセル', ['action' => 'index'], ['class' => 'btn btn-secondary']) ?>
+    </div>
+
+    <?= $this->Form->end() ?>
+</div>

--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var iterable $schedules
+ * @var string|null $statusFilter
+ */
+
+$this->assign('title', '部屋異動予約一覧');
+$csrfToken = $this->request->getAttribute('csrfToken');
+
+$statusLabels = [
+    0 => ['label' => '予約中',   'class' => 'badge-warning'],
+    1 => ['label' => '適用済み', 'class' => 'badge-success'],
+    2 => ['label' => 'キャンセル', 'class' => 'badge-secondary'],
+];
+?>
+<meta name="csrfToken" content="<?= h($csrfToken) ?>">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<div class="content">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">
+            <i class="bi bi-arrow-left-right"></i> 部屋異動予約一覧
+        </h3>
+        <?= $this->Html->link(
+            '<i class="bi bi-plus-circle"></i> 新規登録',
+            ['action' => 'add'],
+            ['class' => 'btn btn-success', 'escape' => false]
+        ) ?>
+    </div>
+
+    <!-- ステータスフィルター -->
+    <div class="mb-3">
+        <?= $this->Html->link('すべて', ['action' => 'index'], [
+            'class' => 'btn btn-sm ' . ($statusFilter === null ? 'btn-primary' : 'btn-outline-primary'),
+        ]) ?>
+        <?= $this->Html->link('予約中', ['action' => 'index', '?' => ['status' => '0']], [
+            'class' => 'btn btn-sm ' . ($statusFilter === '0' ? 'btn-warning' : 'btn-outline-warning'),
+        ]) ?>
+        <?= $this->Html->link('適用済み', ['action' => 'index', '?' => ['status' => '1']], [
+            'class' => 'btn btn-sm ' . ($statusFilter === '1' ? 'btn-success' : 'btn-outline-success'),
+        ]) ?>
+        <?= $this->Html->link('キャンセル', ['action' => 'index', '?' => ['status' => '2']], [
+            'class' => 'btn btn-sm ' . ($statusFilter === '2' ? 'btn-secondary' : 'btn-outline-secondary'),
+        ]) ?>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-bordered table-hover">
+            <thead class="thead-light">
+                <tr>
+                    <th>ID</th>
+                    <th>対象ユーザー</th>
+                    <th>異動元部屋</th>
+                    <th>異動先部屋</th>
+                    <th>有効開始日</th>
+                    <th>ステータス</th>
+                    <th>登録者</th>
+                    <th>登録日時</th>
+                    <th>操作</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($schedules as $schedule): ?>
+                <?php
+                    $statusInfo = $statusLabels[(int)$schedule->i_status] ?? ['label' => '不明', 'class' => 'badge-dark'];
+                ?>
+                <tr>
+                    <td><?= h($schedule->i_id) ?></td>
+                    <td><?= h($schedule->m_user_info->c_user_name ?? '-') ?></td>
+                    <td><?= $schedule->room_from ? h($schedule->room_from->c_room_name) : '<span class="text-muted">（新規配属）</span>' ?></td>
+                    <td><?= h($schedule->room_to->c_room_name ?? '-') ?></td>
+                    <td><?= h($schedule->d_effective_date) ?></td>
+                    <td>
+                        <span class="badge <?= $statusInfo['class'] ?>">
+                            <?= h($statusInfo['label']) ?>
+                        </span>
+                    </td>
+                    <td><?= h($schedule->c_create_user) ?></td>
+                    <td><?= h($schedule->dt_create) ?></td>
+                    <td>
+                        <?php if ((int)$schedule->i_status === 0): ?>
+                            <?= $this->Form->postLink(
+                                '<i class="bi bi-x-circle"></i> キャンセル',
+                                ['action' => 'cancel', $schedule->i_id],
+                                [
+                                    'class'   => 'btn btn-sm btn-danger',
+                                    'escape'  => false,
+                                    'confirm' => sprintf(
+                                        'ID=%d の異動予約をキャンセルしますか？',
+                                        $schedule->i_id
+                                    ),
+                                ]
+                            ) ?>
+                        <?php else: ?>
+                            <span class="text-muted">—</span>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            <?php if (empty(iterator_to_array($schedules))): ?>
+                <tr>
+                    <td colspan="9" class="text-center text-muted">登録されている異動予約はありません。</td>
+                </tr>
+            <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -227,6 +227,11 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                         <div class="menu-title-text">問い合わせ一覧</div>
                         <div class="menu-desc">ユーザーからの問い合わせを確認する</div>
                     </a>
+                    <a class="menu-card" href="<?= $this->Url->build('/MRoomTransferSchedule') ?>">
+                        <div class="menu-icon" style="background:#f0f4ff;color:#3b5bdb;">🔄</div>
+                        <div class="menu-title-text">部屋異動予約</div>
+                        <div class="menu-desc">将来日付での部屋移動を事前登録する</div>
+                    </a>
                 </div>
             <?php endif; ?>
         </main>

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -66,6 +66,8 @@ $recentNotifications = $recentNotifications ?? [];
                             <ul class="dropdown-menu animate__animated animate__fadeIn" aria-labelledby="adminDropdown">
                                 <li><?= $this->Html->link('💰 食数単価一覧', ['controller' => 'MMealPriceInfo', 'action' => 'index'], ['class' => 'dropdown-item']) ?></li>
                                 <li><?= $this->Html->link('📄 食事控除表ダウンロード', ['controller' => 'MMealPriceInfo', 'action' => 'GetMealSummary'], ['class' => 'dropdown-item']) ?></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><?= $this->Html->link('🔄 部屋異動予約', ['controller' => 'MRoomTransferSchedule', 'action' => 'index'], ['class' => 'dropdown-item']) ?></li>
                             </ul>
                         </li>
                     <?php endif; ?>


### PR DESCRIPTION
Closes #207

## 変更内容

### データベース
- `m_room_transfer_schedule` テーブル新設（Migration + SQLスキーマ）
- `sql/updates/20260514_001_create_m_room_transfer_schedule.sql` を追加（ステージング即時適用用）

### バックエンド
- `MRoomTransferScheduleTable` — ORM Table クラス・ステータス定数定義
- `MRoomTransferSchedule` エンティティクラス — ポリシー解決に必要
- `RoomTransferScheduleService` — 予約登録・キャンセル・適用ロジック
  - `t_individual_reservation_info` 予約移行（DELETE + INSERT、PK制約対応）
  - `t_reservation_info` 集計テーブル更新（eat_flag=1 分を部屋間で増減）
  - キャッシュ無効化
- `MRoomTransferScheduleController` — 一覧 / 登録 / キャンセル（管理者限定）
- `MRoomTransferSchedulePolicy` — 管理者のみ許可
- `ApplyRoomTransferScheduleCommand` — 日次バッチ（`--dry-run` / `--date` 対応）
- `routes.php` に `/MRoomTransferSchedule` と `/TReservationInfo/getReservationSnapshots` を追加

### フロントエンド
- `templates/MRoomTransferSchedule/index.php` — 予約一覧（ステータスフィルター・キャンセルボタン）
- `templates/MRoomTransferSchedule/add.php` — 予約登録フォーム
- `templates/Pages/dashboard.php` — 管理者機能セクションに「🔄 部屋異動予約」カード追加
- `templates/layout/default.php` — ナビ「予約情報」ドロップダウンにリンク追加

### インフラ
- `scripts/apply_room_transfer_schedule.sh` — PHPコンテナ内でバッチ実行
- `.github/workflows/room_transfer_apply.yml` — 毎日 JST 0:00 に自動実行・Slack通知

## 動作確認ポイント
- [ ] `/MRoomTransferSchedule` から予約登録・一覧・キャンセルが動作する
- [ ] ダッシュボードの管理者機能セクションからアクセスできる
- [ ] `bin/cake apply_room_transfer_schedule --dry-run` でドライラン確認
- [ ] 有効開始日当日に適用バッチが正しく動作する