### PR TITLE
fix: #207 部屋異動予約一覧のステータスバッジ・日付フォーマットのUX改善

### DIFF
--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
@@ -9,10 +9,13 @@ $this->assign('title', '部屋異動予約一覧');
 $csrfToken = $this->request->getAttribute('csrfToken');
 
 $statusLabels = [
-    0 => ['label' => '予約中',   'class' => 'badge-warning'],
-    1 => ['label' => '適用済み', 'class' => 'badge-success'],
-    2 => ['label' => 'キャンセル', 'class' => 'badge-secondary'],
+    0 => ['label' => '予約中',    'class' => 'text-bg-warning',  'icon' => 'bi-clock'],
+    1 => ['label' => '適用済み',  'class' => 'text-bg-success',  'icon' => 'bi-check-circle-fill'],
+    2 => ['label' => 'キャンセル','class' => 'text-bg-secondary', 'icon' => 'bi-x-circle-fill'],
 ];
+
+$today = new \DateTime('today');
+$dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 ?>
 <meta name="csrfToken" content="<?= h($csrfToken) ?>">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -30,65 +33,99 @@ $statusLabels = [
     </div>
 
     <!-- ステータスフィルター -->
-    <div class="mb-3">
+    <div class="mb-3 d-flex gap-2 flex-wrap">
         <?= $this->Html->link('すべて', ['action' => 'index'], [
             'class' => 'btn btn-sm ' . ($statusFilter === null ? 'btn-primary' : 'btn-outline-primary'),
         ]) ?>
-        <?= $this->Html->link('予約中', ['action' => 'index', '?' => ['status' => '0']], [
-            'class' => 'btn btn-sm ' . ($statusFilter === '0' ? 'btn-warning' : 'btn-outline-warning'),
-        ]) ?>
-        <?= $this->Html->link('適用済み', ['action' => 'index', '?' => ['status' => '1']], [
-            'class' => 'btn btn-sm ' . ($statusFilter === '1' ? 'btn-success' : 'btn-outline-success'),
-        ]) ?>
-        <?= $this->Html->link('キャンセル', ['action' => 'index', '?' => ['status' => '2']], [
-            'class' => 'btn btn-sm ' . ($statusFilter === '2' ? 'btn-secondary' : 'btn-outline-secondary'),
-        ]) ?>
+        <?= $this->Html->link(
+            '<i class="bi bi-clock"></i> 予約中',
+            ['action' => 'index', '?' => ['status' => '0']],
+            ['class' => 'btn btn-sm ' . ($statusFilter === '0' ? 'btn-warning' : 'btn-outline-warning'), 'escape' => false]
+        ) ?>
+        <?= $this->Html->link(
+            '<i class="bi bi-check-circle-fill"></i> 適用済み',
+            ['action' => 'index', '?' => ['status' => '1']],
+            ['class' => 'btn btn-sm ' . ($statusFilter === '1' ? 'btn-success' : 'btn-outline-success'), 'escape' => false]
+        ) ?>
+        <?= $this->Html->link(
+            '<i class="bi bi-x-circle-fill"></i> キャンセル',
+            ['action' => 'index', '?' => ['status' => '2']],
+            ['class' => 'btn btn-sm ' . ($statusFilter === '2' ? 'btn-secondary' : 'btn-outline-secondary'), 'escape' => false]
+        ) ?>
     </div>
 
     <div class="table-responsive">
-        <table class="table table-bordered table-hover">
-            <thead class="thead-light">
+        <table class="table table-bordered table-hover align-middle">
+            <thead class="table-light">
                 <tr>
-                    <th>ID</th>
-                    <th>対象ユーザー</th>
-                    <th>異動元部屋</th>
-                    <th>異動先部屋</th>
-                    <th>有効開始日</th>
-                    <th>ステータス</th>
-                    <th>登録者</th>
-                    <th>登録日時</th>
-                    <th>操作</th>
+                    <th class="text-nowrap">対象ユーザー</th>
+                    <th class="text-nowrap">異動元部屋</th>
+                    <th class="text-nowrap">異動先部屋</th>
+                    <th class="text-nowrap">有効開始日</th>
+                    <th class="text-nowrap">ステータス</th>
+                    <th class="text-nowrap">登録者</th>
+                    <th class="text-nowrap">登録日時</th>
+                    <th class="text-nowrap">操作</th>
                 </tr>
             </thead>
             <tbody>
+            <?php $rowCount = 0; ?>
             <?php foreach ($schedules as $schedule): ?>
                 <?php
-                    $statusInfo = $statusLabels[(int)$schedule->i_status] ?? ['label' => '不明', 'class' => 'badge-dark'];
+                    $rowCount++;
+                    $statusInfo = $statusLabels[(int)$schedule->i_status] ?? ['label' => '不明', 'class' => 'text-bg-dark', 'icon' => 'bi-question'];
+
+                    $effectiveDateObj = $schedule->d_effective_date instanceof \DateTime
+                        ? $schedule->d_effective_date
+                        : new \DateTime((string)$schedule->d_effective_date);
+                    $diff = (int)$today->diff($effectiveDateObj)->days * ($effectiveDateObj >= $today ? 1 : -1);
+                    $dow  = $dayNames[(int)$effectiveDateObj->format('w')];
+                    $dateFormatted = $effectiveDateObj->format('Y/m/d') . "（{$dow}）";
+
+                    if ($diff < 0) {
+                        $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
+                    } elseif ($diff === 0) {
+                        $dateBadge = '<span class="badge text-bg-danger">本日 ' . h($dateFormatted) . '</span>';
+                    } elseif ($diff <= 7) {
+                        $dateBadge = '<span class="badge text-bg-warning text-dark">まもなく ' . h($dateFormatted) . '</span>';
+                    } else {
+                        $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
+                    }
+
+                    $dtCreate = $schedule->dt_create
+                        ? (new \DateTime((string)$schedule->dt_create))->format('Y/m/d H:i')
+                        : '-';
                 ?>
                 <tr>
-                    <td><?= h($schedule->i_id) ?></td>
                     <td><?= h($schedule->m_user_info->c_user_name ?? '-') ?></td>
-                    <td><?= $schedule->room_from ? h($schedule->room_from->c_room_name) : '<span class="text-muted">（新規配属）</span>' ?></td>
-                    <td><?= h($schedule->room_to->c_room_name ?? '-') ?></td>
-                    <td><?= h($schedule->d_effective_date) ?></td>
                     <td>
-                        <span class="badge <?= $statusInfo['class'] ?>">
-                            <?= h($statusInfo['label']) ?>
+                        <?php if ($schedule->room_from): ?>
+                            <?= h($schedule->room_from->c_room_name) ?>
+                        <?php else: ?>
+                            <span class="text-muted fst-italic">新規配属</span>
+                        <?php endif; ?>
+                    </td>
+                    <td class="fw-semibold"><?= h($schedule->room_to->c_room_name ?? '-') ?></td>
+                    <td class="text-nowrap"><?= $dateBadge ?></td>
+                    <td>
+                        <span class="badge rounded-pill <?= $statusInfo['class'] ?>">
+                            <i class="bi <?= $statusInfo['icon'] ?> me-1"></i><?= h($statusInfo['label']) ?>
                         </span>
                     </td>
-                    <td><?= h($schedule->c_create_user) ?></td>
-                    <td><?= h($schedule->dt_create) ?></td>
+                    <td class="text-muted small"><?= h($schedule->c_create_user) ?></td>
+                    <td class="text-muted small text-nowrap"><?= h($dtCreate) ?></td>
                     <td>
                         <?php if ((int)$schedule->i_status === 0): ?>
                             <?= $this->Form->postLink(
                                 '<i class="bi bi-x-circle"></i> キャンセル',
                                 ['action' => 'cancel', $schedule->i_id],
                                 [
-                                    'class'   => 'btn btn-sm btn-danger',
+                                    'class'   => 'btn btn-sm btn-outline-danger',
                                     'escape'  => false,
                                     'confirm' => sprintf(
-                                        'ID=%d の異動予約をキャンセルしますか？',
-                                        $schedule->i_id
+                                        '%s の異動予約（→ %s）をキャンセルしますか？',
+                                        $schedule->m_user_info->c_user_name ?? '',
+                                        $schedule->room_to->c_room_name ?? ''
                                     ),
                                 ]
                             ) ?>
@@ -98,9 +135,12 @@ $statusLabels = [
                     </td>
                 </tr>
             <?php endforeach; ?>
-            <?php if (empty(iterator_to_array($schedules))): ?>
+            <?php if ($rowCount === 0): ?>
                 <tr>
-                    <td colspan="9" class="text-center text-muted">登録されている異動予約はありません。</td>
+                    <td colspan="8" class="text-center text-muted py-4">
+                        <i class="bi bi-inbox fs-4 d-block mb-1"></i>
+                        登録されている異動予約はありません。
+                    </td>
                 </tr>
             <?php endif; ?>
             </tbody>


### PR DESCRIPTION
## 変更内容

### ステータスバッジ
- Bootstrap 4 の `badge-*` から Bootstrap 5 対応の `text-bg-*` クラスに統一
- アイコンを追加（予約中: 🕐 `bi-clock`、適用済み: ✅ `bi-check-circle-fill`、キャンセル: ✖ `bi-x-circle-fill`）
- フィルターボタンにもアイコンを追加

### 有効開始日フォーマット
- 生の `Y-m-d` 出力から `2026/05/14（木）` 形式に変更
- 日付に応じた色分けを追加:
  - 過去: グレー（`text-muted`）
  - 本日: 赤バッジ「本日 2026/05/14（木）」
  - 7日以内: 黄バッジ「まもなく 2026/05/21（木）」
  - それ以降: 太字

### 登録日時フォーマット
- DateTime オブジェクトの生出力から `2026/05/14 17:00` 形式に変更

### その他
- ID列を削除（一覧に不要）
- 空行メッセージにアイコン追加
- キャンセル確認ダイアログをユーザー名・部屋名入りに改善（`ID=X` から `〇〇 の異動予約（→ △△）をキャンセルしますか？`）