### PR TITLE
hotfix: deployment.ymlのSSH認証をパスワード方式に修正

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.PROD_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          password: ${{ secrets.PROD_SSH_PASSWORD }}
           port: 22
           timeout: 60s
           command_timeout: 20m


### PR DESCRIPTION
## 変更内容

- `deployment.yml` の SSH 認証を `key`（`SSH_PRIVATE_KEY`）から `password`（`PROD_SSH_PASSWORD`）に修正
- マージ競合により `key` 版が `main` に残っていたため hotfix で対応