### PR TITLE
feat: 部屋異動cronを本番・ステージング両対応に変更

### DIFF
--- a/.github/workflows/room_transfer_apply.yml
+++ b/.github/workflows/room_transfer_apply.yml
@@ -6,10 +6,9 @@ on:
   workflow_dispatch:         # 手動実行も可能
 
 jobs:
-  apply:
-    name: Apply Room Transfer Schedule
+  apply-production:
+    name: Apply Room Transfer Schedule (Production)
     runs-on: ubuntu-latest
-    # 本番サーバー専用: main ブランチのみ実行
     if: github.ref == 'refs/heads/main'
     env:
       SLACK_USERNAME: DeployBot
@@ -26,20 +25,56 @@ jobs:
           port: 22
           script: |
             cd ${{ secrets.DEPLOY_PATH }}
-            bash scripts/apply_room_transfer_schedule.sh
+            bash scripts/apply_room_transfer_schedule.sh kamakura-shokusu_web
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2
         if: ${{ success() }}
         env:
-          SLACK_TITLE: Room Transfer Apply / Success
+          SLACK_TITLE: Room Transfer Apply (Production) / Success
           SLACK_COLOR: good
-          SLACK_MESSAGE: 部屋異動予約の適用が完了しました✅
+          SLACK_MESSAGE: "[本番] 部屋異動予約の適用が完了しました✅"
 
       - name: Slack Notification on Failure
         uses: rtCamp/action-slack-notify@v2
         if: ${{ failure() }}
         env:
-          SLACK_TITLE: Room Transfer Apply / Failure
+          SLACK_TITLE: Room Transfer Apply (Production) / Failure
           SLACK_COLOR: danger
-          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> 部屋異動予約の適用に失敗しました😢"
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> [本番] 部屋異動予約の適用に失敗しました😢"
+
+  apply-staging:
+    name: Apply Room Transfer Schedule (Staging)
+    runs-on: ubuntu-latest
+    env:
+      SLACK_USERNAME: DeployBot
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+    steps:
+      - name: SSH into staging server and apply room transfer schedule
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.STG_HOST }}
+          username: ubuntu
+          key: ${{ secrets.STG_SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            cd /home/ubuntu/shokusuu1
+            bash scripts/apply_room_transfer_schedule.sh stg_web
+
+      - name: Slack Notification on Success
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ success() }}
+        env:
+          SLACK_TITLE: Room Transfer Apply (Staging) / Success
+          SLACK_COLOR: good
+          SLACK_MESSAGE: "[ステージング] 部屋異動予約の適用が完了しました✅"
+
+      - name: Slack Notification on Failure
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_TITLE: Room Transfer Apply (Staging) / Failure
+          SLACK_COLOR: danger
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> [ステージング] 部屋異動予約の適用に失敗しました😢"

--- a/scripts/apply_room_transfer_schedule.sh
+++ b/scripts/apply_room_transfer_schedule.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -e
 
-# PHP コンテナ内で CakePHP コマンドを実行する
-CONTAINER_NAME="kamakura-shokusu_web"
+CONTAINER_NAME="${1:-kamakura-shokusu_web}"
 APP_PATH="/var/www/html/kamaho-shokusu"
 
-echo "Starting room transfer schedule apply: $(date)"
+echo "Starting room transfer schedule apply: $(date) [container: ${CONTAINER_NAME}]"
 
 docker exec "$CONTAINER_NAME" \
   bash -c "cd ${APP_PATH} && php bin/cake.php apply_room_transfer_schedule"


### PR DESCRIPTION
## 変更内容

### scripts/apply_room_transfer_schedule.sh
- コンテナ名をハードコードから引数（第1引数、デフォルト: `kamakura-shokusu_web`）に変更

### .github/workflows/room_transfer_apply.yml
- `apply-production` ジョブ: 本番VPS（パスワード認証）で `kamakura-shokusu_web` コンテナを対象
- `apply-staging` ジョブ: ステージング（`STG_SSH_PRIVATE_KEY`）で `stg_web` コンテナを対象
- 毎日JST 0:00 のスケジュール実行・`workflow_dispatch` 手動実行の両方に対応