### PR TITLE
fix: ステージングcronをdocker exec直接実行に変更

### DIFF
--- a/.github/workflows/room_transfer_apply.yml
+++ b/.github/workflows/room_transfer_apply.yml
@@ -60,8 +60,7 @@ jobs:
           key: ${{ secrets.STG_SSH_PRIVATE_KEY }}
           port: 22
           script: |
-            cd /home/ubuntu/shokusuu1
-            bash scripts/apply_room_transfer_schedule.sh stg_web
+            docker exec stg_web bash -c "cd /var/www/html/kamaho-shokusu && php bin/cake.php apply_room_transfer_schedule"
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## 変更内容

- ステージングジョブのSSH script を `bash scripts/apply_room_transfer_schedule.sh stg_web` から `docker exec stg_web` 直接実行に変更
- サーバー側の古いスクリプト（コンテナ名ハードコード版）に依存しないよう修正
- `No such container: kamakura-shokusu_web` エラーの解消