### PR TITLE
feat: #248 ContactsPolicy導入とJSONデコードの堅牢化

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 
 use App\Model\Table\TContactsTable;
 use App\Service\ContactService;
+use Authorization\Exception\ForbiddenException;
 use Cake\Http\Response;
 
 class ContactsController extends AppController
@@ -22,12 +23,10 @@ class ContactsController extends AppController
      */
     public function index(): ?Response
     {
-        $this->Authorization->skipAuthorization();
+        $entity = $this->fetchTable('TContacts')->newEmptyEntity();
+        $this->Authorization->authorize($entity, 'index');
 
         $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
 
         $categories = TContactsTable::CATEGORIES;
 
@@ -61,15 +60,10 @@ class ContactsController extends AppController
      */
     public function adminIndex(): ?Response
     {
-        $this->Authorization->skipAuthorization();
-
-        $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
-        // 管理者のみアクセス可能
-        if ((int)$user->get('i_admin') !== 1) {
+        $entity = $this->fetchTable('TContacts')->newEmptyEntity();
+        try {
+            $this->Authorization->authorize($entity, 'adminIndex');
+        } catch (ForbiddenException $e) {
             $this->Flash->error('管理者のみアクセスできます。');
             return $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
         }
@@ -86,14 +80,10 @@ class ContactsController extends AppController
      */
     public function adminDetail(int $id): ?Response
     {
-        $this->Authorization->skipAuthorization();
-
-        $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
-        if ((int)$user->get('i_admin') !== 1) {
+        $entity = $this->fetchTable('TContacts')->newEmptyEntity();
+        try {
+            $this->Authorization->authorize($entity, 'adminDetail');
+        } catch (ForbiddenException $e) {
             $this->Flash->error('管理者のみアクセスできます。');
             return $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
         }

--- a/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use App\Model\Entity\TContact;
+use Authorization\IdentityInterface;
+
+/**
+ * お問い合わせのアクセス制御ポリシー
+ *
+ * index: 全認証ユーザー
+ * adminIndex / adminDetail: 管理者（i_admin = 1）のみ
+ */
+class TContactPolicy
+{
+    /**
+     * お問い合わせフォーム（全認証ユーザー）
+     */
+    public function canIndex(?IdentityInterface $user, TContact $resource): bool
+    {
+        return $this->isAuthenticated($user);
+    }
+
+    /**
+     * 管理者用：お問い合わせ一覧
+     */
+    public function canAdminIndex(?IdentityInterface $user, TContact $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    /**
+     * 管理者用：お問い合わせ詳細・返信
+     */
+    public function canAdminDetail(?IdentityInterface $user, TContact $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    private function isAuthenticated(?IdentityInterface $user): bool
+    {
+        return $this->getOriginalIdentity($user) !== null;
+    }
+
+    private function isAdmin(?IdentityInterface $user): bool
+    {
+        $identity = $this->getOriginalIdentity($user);
+        if ($identity === null) {
+            return false;
+        }
+
+        if (is_object($identity) && method_exists($identity, 'get')) {
+            return (int)$identity->get('i_admin') === 1;
+        }
+
+        if (is_array($identity)) {
+            return (int)($identity['i_admin'] ?? 0) === 1;
+        }
+
+        if ($identity instanceof \ArrayAccess) {
+            return (int)($identity['i_admin'] ?? 0) === 1;
+        }
+
+        return false;
+    }
+
+    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    {
+        if ($user === null) {
+            return null;
+        }
+
+        return $user->getOriginalData();
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -32,9 +32,10 @@ class ReservationWriteService
             return $this->err('入力データが無効です。', 400);
         }
 
-        $data = is_string($jsonData) ? json_decode($jsonData, true) : $jsonData;
-        if (is_null($data) || json_last_error() !== JSON_ERROR_NONE) {
-            Log::error('JSONデコードエラー: ' . json_last_error_msg());
+        try {
+            $data = is_string($jsonData) ? json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR) : $jsonData;
+        } catch (\JsonException $e) {
+            Log::error('JSONデコードエラー: ' . $e->getMessage());
             return $this->err('データの形式が不正です。', 400);
         }
 
@@ -263,9 +264,10 @@ class ReservationWriteService
             return $this->err('入力データが無効です。', 400);
         }
 
-        $data = is_string($jsonData) ? json_decode($jsonData, true) : $jsonData;
-        if (is_null($data) || json_last_error() !== JSON_ERROR_NONE) {
-            Log::error('JSON デコードエラー: ' . json_last_error_msg());
+        try {
+            $data = is_string($jsonData) ? json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR) : $jsonData;
+        } catch (\JsonException $e) {
+            Log::error('JSON デコードエラー: ' . $e->getMessage());
             return $this->err('データの形式が不正です。', 400);
         }
 


### PR DESCRIPTION
## 概要

Issue #248 の高優先度項目（セキュリティ脆弱性）を修正します。

## 変更内容

### 1. `TContactPolicy` の新規作成

`ContactsController` のアクション別アクセス制御を集約するポリシークラスを追加しました。

| メソッド | 許可対象 |
|---------|---------|
| `canIndex` | 全認証ユーザー |
| `canAdminIndex` | 管理者（i_admin = 1）のみ |
| `canAdminDetail` | 管理者（i_admin = 1）のみ |

### 2. `ContactsController` の認可方式を修正

**Before:**
```php
$this->Authorization->skipAuthorization();
$user = $this->Authentication->getIdentity();
if ((int)$user->get('i_admin') !== 1) { ... }  // 手動チェック
```

**After:**
```php
$entity = $this->fetchTable('TContacts')->newEmptyEntity();
try {
    $this->Authorization->authorize($entity, 'adminIndex');
} catch (ForbiddenException $e) { ... }
```

OrmResolver が `TContact` エンティティ → `TContactPolicy` を自動解決するため、`Application.php` への追記は不要です。

### 3. `ReservationWriteService` の JSON デコード修正

**Before:**
```php
$data = json_decode($jsonData, true);
if (is_null($data) || json_last_error() !== JSON_ERROR_NONE) { ... }
```

**After:**
```php
try {
    $data = json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR);
} catch (\JsonException $e) { ... }
```

`processIndividualReservation` と `processGroupReservation` の両メソッドを修正しました。

## 対象外（別PRで対応）

- DDDレイヤー構成（Domain/Application/Infrastructure）の整備
- Repository パターンの全面導入
- `TableRegistry` 直接参照の排除

## テスト方針

- [ ] 一般ユーザーで `/contacts/index` にアクセスできる
- [ ] 一般ユーザーで `/contacts/admin-index` にアクセスすると `TReservationInfo` にリダイレクトされる
- [ ] 管理者で `/contacts/admin-index` にアクセスできる
- [ ] 不正な JSON を送信した際に 400 エラーが返る