### PR TITLE
Resolve #251: 部屋異動予約の「異動元部屋」をユーザーの現在所属に限定する

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
@@ -113,7 +113,17 @@ class MRoomTransferScheduleController extends AppController
             'valueField' => 'c_room_name',
         ])->toArray();
 
-        $this->set(compact('users', 'rooms'));
+        $userRoomRows = $this->fetchTable('MUserGroup')->find()
+            ->select(['i_id_user', 'i_id_room'])
+            ->where(['active_flag' => 0])
+            ->toArray();
+
+        $userRoomMap = [];
+        foreach ($userRoomRows as $row) {
+            $userRoomMap[$row->i_id_user][] = $row->i_id_room;
+        }
+
+        $this->set(compact('users', 'rooms', 'userRoomMap'));
     }
 
     /**

--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/add.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/add.php
@@ -3,6 +3,7 @@
  * @var \App\View\AppView $this
  * @var array $users
  * @var array $rooms
+ * @var array<int, int[]> $userRoomMap ユーザーID→現在所属部屋IDリスト
  */
 
 $this->assign('title', '部屋異動予約 登録');
@@ -69,3 +70,43 @@ $today = date('Y-m-d');
 
     <?= $this->Form->end() ?>
 </div>
+
+<script>
+(function () {
+    const userRoomMap = <?= json_encode($userRoomMap, JSON_THROW_ON_ERROR) ?>;
+    const allRooms    = <?= json_encode($rooms, JSON_THROW_ON_ERROR) ?>;
+
+    const userSelect    = document.getElementById('i_id_user');
+    const roomFromSelect = document.getElementById('i_id_room_from');
+
+    function updateRoomFromOptions(userId) {
+        const currentValue = roomFromSelect.value;
+        while (roomFromSelect.options.length > 0) {
+            roomFromSelect.remove(0);
+        }
+
+        const emptyOption = new Option('-- （新規配属） --', '');
+        roomFromSelect.add(emptyOption);
+
+        const allowedRoomIds = userId ? (userRoomMap[userId] || []) : Object.keys(allRooms).map(Number);
+
+        allowedRoomIds.forEach(function (roomId) {
+            if (allRooms[roomId] !== undefined) {
+                const opt = new Option(allRooms[roomId], roomId);
+                if (String(roomId) === String(currentValue)) {
+                    opt.selected = true;
+                }
+                roomFromSelect.add(opt);
+            }
+        });
+    }
+
+    userSelect.addEventListener('change', function () {
+        updateRoomFromOptions(this.value ? parseInt(this.value, 10) : null);
+    });
+
+    if (userSelect.value) {
+        updateRoomFromOptions(parseInt(userSelect.value, 10));
+    }
+})();
+</script>


### PR DESCRIPTION
Closes #251

## 変更内容

### `MRoomTransferScheduleController.php`
- `add()` メソッドで `m_user_group`（`active_flag=0` = 有効な所属）からレコードを取得
- ユーザーID→所属部屋IDリストの `$userRoomMap` を構築してビューに渡す

### `templates/MRoomTransferSchedule/add.php`
- `$userRoomMap` を JSON でJavaScriptに渡す変数として埋め込み
- 「対象ユーザー」セレクトの `change` イベントで `updateRoomFromOptions()` を呼び出し、「異動元部屋」の選択肢をそのユーザーの現在所属部屋（`m_user_group.active_flag=0`）のみに動的フィルタリング
- ユーザー未選択時は全部屋を表示、所属部屋がない場合は「新規配属」のみ表示
- ページロード時にユーザーが選択済みの場合（バリデーションエラー後の再表示等）も自動的にフィルタリングを適用