### PR TITLE
Resolve #226: 認証・認可周りの脆弱性対応

### DIFF
--- a/src_web/kamaho-shokusu/config/app.php
+++ b/src_web/kamaho-shokusu/config/app.php
@@ -420,5 +420,6 @@ return [
      */
     'Session' => [
         'defaults' => 'php',
+        'timeout' => 60, // 60分でセッションを失効させる
     ],
 ];

--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -114,7 +114,9 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
     {
         // コントローラークラス → ポリシークラスの明示マッピング
         $mapResolver = new MapResolver([
-            \App\Controller\ApprovalController::class => \App\Policy\ApprovalPolicy::class,
+            \App\Controller\ApprovalController::class     => \App\Policy\ApprovalPolicy::class,
+            \App\Controller\NotificationsController::class => \App\Policy\NotificationPolicy::class,
+            \App\Controller\ContactsController::class      => \App\Policy\ContactsPolicy::class,
         ]);
 
         // MapResolver で解決できない場合は OrmResolver（エンティティ→ポリシー）にフォールバック

--- a/src_web/kamaho-shokusu/src/Controller/AppController.php
+++ b/src_web/kamaho-shokusu/src/Controller/AppController.php
@@ -62,10 +62,17 @@ class AppController extends Controller
         if (!is_string($url) || $url === '') {
             return false;
         }
-        // '//' や 'http://' 等の外部URLは拒否
-        if (preg_match('#^(https?:)?//#i', $url)) {
+
+        $parsed = parse_url($url);
+        if ($parsed === false) {
             return false;
         }
+
+        // スキームまたはホストが含まれる場合は外部URLとして拒否（//evil.com 亜種も含む）
+        if (!empty($parsed['scheme']) || !empty($parsed['host'])) {
+            return false;
+        }
+
         // '/' から始まる内部パスのみ許可
         return str_starts_with($url, '/');
     }

--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Policy\ApprovalPolicy;
 use App\Service\ApprovalService;
 use App\Service\RoomAccessService;
 use Cake\Http\Response;
@@ -12,20 +11,18 @@ use Cake\Http\Response;
  * 承認フロー コントローラー
  *
  * ブロック長（i_admin = 2）と管理者（i_admin = 1）向けの承認画面を提供する。
- * Authorization は skipAuthorization() + ApprovalPolicy の直接呼び出しで制御する。
+ * 認可は ApprovalPolicy を通じて Authorization::authorize() で制御する。
  */
 class ApprovalController extends AppController
 {
     private ApprovalService $approvalService;
     private RoomAccessService $roomAccessService;
-    private ApprovalPolicy $approvalPolicy;
 
     public function initialize(): void
     {
         parent::initialize();
         $this->approvalService   = new ApprovalService();
         $this->roomAccessService = new RoomAccessService();
-        $this->approvalPolicy    = new ApprovalPolicy();
 
         $this->FormProtection->setConfig('unlockedActions', [
             'blockLeaderApprove',
@@ -45,13 +42,9 @@ class ApprovalController extends AppController
      */
     public function blockLeaderIndex(): ?Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'blockLeaderIndex');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canBlockLeaderIndex($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user    = $this->Authentication->getIdentity();
         $userId  = (int)$user->get('i_id_user');
         $roomIds = $this->roomAccessService->getUserRoomIds($userId);
 
@@ -77,14 +70,10 @@ class ApprovalController extends AppController
      */
     public function blockLeaderApprove(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'blockLeaderApprove');
         $this->request->allowMethod('post');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canBlockLeaderApprove($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user     = $this->Authentication->getIdentity();
         $approver = (int)$user->get('i_id_user');
         $actor    = $user->get('c_login_account') ?? (string)$approver;
         $keys     = (array)($this->request->getData('keys') ?? []);
@@ -107,14 +96,10 @@ class ApprovalController extends AppController
      */
     public function blockLeaderReject(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'blockLeaderReject');
         $this->request->allowMethod('post');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canBlockLeaderReject($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user     = $this->Authentication->getIdentity();
         $approver = (int)$user->get('i_id_user');
         $actor    = $user->get('c_login_account') ?? (string)$approver;
         $keys     = (array)($this->request->getData('keys') ?? []);
@@ -142,12 +127,7 @@ class ApprovalController extends AppController
      */
     public function adminIndex(): ?Response
     {
-        $this->Authorization->skipAuthorization();
-
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canAdminIndex($user, null)) {
-            return $this->jsonForbidden();
-        }
+        $this->Authorization->authorize($this, 'adminIndex');
 
         $filterRoomId = $this->request->getQuery('room_id') ? (int)$this->request->getQuery('room_id') : null;
         $filterStatus = $this->request->getQuery('status') !== null && $this->request->getQuery('status') !== ''
@@ -170,14 +150,10 @@ class ApprovalController extends AppController
      */
     public function adminApprove(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'adminApprove');
         $this->request->allowMethod('post');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canAdminApprove($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user     = $this->Authentication->getIdentity();
         $approver = (int)$user->get('i_id_user');
         $actor    = $user->get('c_login_account') ?? (string)$approver;
         $keys     = (array)($this->request->getData('keys') ?? []);
@@ -200,14 +176,10 @@ class ApprovalController extends AppController
      */
     public function adminReject(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'adminReject');
         $this->request->allowMethod('post');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canAdminReject($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user     = $this->Authentication->getIdentity();
         $approver = (int)$user->get('i_id_user');
         $actor    = $user->get('c_login_account') ?? (string)$approver;
         $keys     = (array)($this->request->getData('keys') ?? []);
@@ -231,14 +203,10 @@ class ApprovalController extends AppController
      */
     public function adminReflect(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'adminReflect');
         $this->request->allowMethod('post');
 
-        $user = $this->Authentication->getIdentity();
-        if (!$this->approvalPolicy->canAdminReflect($user, null)) {
-            return $this->jsonForbidden();
-        }
-
+        $user  = $this->Authentication->getIdentity();
         $actor  = $user->get('c_login_account') ?? (string)$user->get('i_id_user');
         $roomId = $this->request->getData('room_id') ? (int)$this->request->getData('room_id') : null;
         $date   = $this->request->getData('date');

--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -22,13 +22,9 @@ class ContactsController extends AppController
      */
     public function index(): ?Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'index');
 
         $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
         $categories = TContactsTable::CATEGORIES;
 
         // ログインユーザーの情報を初期値として渡す
@@ -61,18 +57,7 @@ class ContactsController extends AppController
      */
     public function adminIndex(): ?Response
     {
-        $this->Authorization->skipAuthorization();
-
-        $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
-        // 管理者のみアクセス可能
-        if ((int)$user->get('i_admin') !== 1) {
-            $this->Flash->error('管理者のみアクセスできます。');
-            return $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
-        }
+        $this->Authorization->authorize($this, 'adminIndex');
 
         $page    = (int)($this->request->getQuery('page') ?? 1);
         $contacts = $this->contactService->getList($page);
@@ -86,17 +71,7 @@ class ContactsController extends AppController
      */
     public function adminDetail(int $id): ?Response
     {
-        $this->Authorization->skipAuthorization();
-
-        $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
-        if ((int)$user->get('i_admin') !== 1) {
-            $this->Flash->error('管理者のみアクセスできます。');
-            return $this->redirect(['controller' => 'TReservationInfo', 'action' => 'index']);
-        }
+        $this->Authorization->authorize($this, 'adminDetail');
 
         $contact = $this->contactService->getDetail($id);
 

--- a/src_web/kamaho-shokusu/src/Controller/MMenuInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MMenuInfoController.php
@@ -25,11 +25,13 @@ class MMenuInfoController extends AppController
 
     public function index()
     {
+        // メニュー情報は全認証ユーザーが参照可能な共通情報のため認可チェックをスキップする
         $this->Authorization->skipAuthorization();
     }
 
     public function generateMenuChat()
     {
+        // AI チャット生成は全認証ユーザーが利用可能な共通機能のため認可チェックをスキップする
         $this->Authorization->skipAuthorization();
         $this->autoRender = false;
     }

--- a/src_web/kamaho-shokusu/src/Controller/NotificationsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/NotificationsController.php
@@ -23,13 +23,9 @@ class NotificationsController extends AppController
 
     public function index(): ?Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'index');
 
         $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->redirect(['controller' => 'MUserInfo', 'action' => 'login']);
-        }
-
         $userId = (int)$user->get('i_id_user');
         $notifications = $this->notificationService->getNotifications($userId);
         $this->set(compact('notifications'));
@@ -39,14 +35,10 @@ class NotificationsController extends AppController
 
     public function markRead(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'markRead');
         $this->request->allowMethod('post');
 
         $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->jsonError('認証が必要です', 401);
-        }
-
         $ids = (array)($this->request->getData('ids') ?? []);
         $count = $this->notificationService->markAsRead((int)$user->get('i_id_user'), $ids);
 
@@ -55,14 +47,10 @@ class NotificationsController extends AppController
 
     public function markAllRead(): Response
     {
-        $this->Authorization->skipAuthorization();
+        $this->Authorization->authorize($this, 'markAllRead');
         $this->request->allowMethod('post');
 
         $user = $this->Authentication->getIdentity();
-        if ($user === null) {
-            return $this->jsonError('認証が必要です', 401);
-        }
-
         $count = $this->notificationService->markAllAsRead((int)$user->get('i_id_user'));
 
         return $this->jsonResponse(['success' => true, 'count' => $count]);

--- a/src_web/kamaho-shokusu/src/Policy/ContactsPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/ContactsPolicy.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use Authorization\IdentityInterface;
+
+/**
+ * お問い合わせ機能のアクセス制御ポリシー
+ *
+ * - index / adminDetail の送信：認証済みユーザー全員
+ * - adminIndex / adminDetail：管理者（i_admin = 1）のみ
+ */
+final class ContactsPolicy
+{
+    /** お問い合わせフォーム（全認証ユーザー） */
+    public function canIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAuthenticated($user);
+    }
+
+    /** 管理者：問い合わせ一覧 */
+    public function canAdminIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    /** 管理者：問い合わせ詳細・返信 */
+    public function canAdminDetail(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAdmin($user);
+    }
+
+    private function isAuthenticated(?IdentityInterface $user): bool
+    {
+        return $user !== null;
+    }
+
+    private function isAdmin(?IdentityInterface $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+        $identity = $user->getOriginalData();
+
+        if (is_object($identity) && method_exists($identity, 'get')) {
+            return (int)$identity->get('i_admin') === 1;
+        }
+
+        if (is_array($identity) || $identity instanceof \ArrayAccess) {
+            return (int)($identity['i_admin'] ?? 0) === 1;
+        }
+
+        return false;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Policy/NotificationPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/NotificationPolicy.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use Authorization\IdentityInterface;
+
+/**
+ * 通知機能のアクセス制御ポリシー
+ *
+ * 認証済みユーザーは自分の通知のみ操作可能。
+ * 実際のユーザー絞り込みは NotificationService の各メソッドで行う。
+ */
+final class NotificationPolicy
+{
+    /** 通知一覧の閲覧 */
+    public function canIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAuthenticated($user);
+    }
+
+    /** 通知の既読化 */
+    public function canMarkRead(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAuthenticated($user);
+    }
+
+    /** 全通知の既読化 */
+    public function canMarkAllRead(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isAuthenticated($user);
+    }
+
+    private function isAuthenticated(?IdentityInterface $user): bool
+    {
+        return $user !== null;
+    }
+}


### PR DESCRIPTION
Closes #226

## 変更内容

### 🟡 `skipAuthorization()` の整理と NotificationPolicy / ContactsPolicy の導入

- **`NotificationPolicy`（新規）**: 認証済みユーザーのみ通知の閲覧・既読化を許可するポリシーを追加
- **`ContactsPolicy`（新規）**: `index` は全認証ユーザー、`adminIndex` / `adminDetail` は管理者（`i_admin = 1`）のみに制限するポリシーを追加
- **`Application.php`**: `MapResolver` に `NotificationsController` と `ContactsController` のポリシーマッピングを追加
- **`NotificationsController`**: `skipAuthorization()` を `Authorization::authorize($this, 'アクション名')` に置き換え、不要な null チェックを削除
- **`ApprovalController`**: `skipAuthorization()` + `ApprovalPolicy` の手動インスタンス化・直接呼び出しを廃止し、公式の `authorize($this, 'アクション名')` に統一
- **`ContactsController`**: `skipAuthorization()` + 手動 `i_admin` チェックを廃止し、`ContactsPolicy` 経由の `authorize()` に置き換え
- **`MMenuInfoController`**: `skipAuthorization()` が意図的であることを示すコメントを追加（全認証ユーザー向け共通機能）

### 🟡 セッションタイムアウトの明示設定

- **`config/app.php`**: `Session.timeout` を `60`（60分）に明示設定し、PHPデフォルト依存を解消

### 🟢 `isSafeRedirect` の強化

- **`AppController`**: `parse_url()` ベースのバリデーションを追加し、`scheme` または `host` が含まれる URL を拒否することで `//evil.com` 系の亜種によるオープンリダイレクトを防止