### PR TITLE
fix: #226 お問い合わせフォームのFormProtection「Unexpected field」エラーを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -24,6 +24,7 @@ class ContactsController extends AppController
     public function index(): ?Response
     {
         $this->Authorization->authorize($this, 'index');
+        $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
 
         $user = $this->Authentication->getIdentity();
         $categories = TContactsTable::CATEGORIES;


### PR DESCRIPTION
Closes #226

## 変更内容

- `ContactsController::index()` に `FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body'])` を追加

## 背景・原因

`templates/Contacts/index.php` のフォームフィールド（`name`, `email`, `category`, `body`）が生の HTML (`<input>` / `<select>` / `<textarea>`) で記述されており、CakePHP の Form ヘルパーメソッドを経由していなかった。

`FormProtection` コンポーネントはヘルパー経由で登録されたフィールドのみをトークンに含めるため、これらのフィールドは POST 送信時に「Unexpected field」エラーとして拒否されていた。

## 対処方針

対象フィールドを `unlockedFields` に追加することで、FormProtection のトークン検証から除外した。
CSRF 保護は別のミドルウェアで担保されているため、セキュリティへの影響はない。