### PR TITLE
fix: #226 FormProtectionのunlockedFields設定をbeforeFilterに移動

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use App\Model\Table\TContactsTable;
 use App\Service\ContactService;
 use Authorization\Exception\ForbiddenException;
+use Cake\Event\EventInterface;
 use Cake\Http\Response;
 
 class ContactsController extends AppController
@@ -19,12 +20,22 @@ class ContactsController extends AppController
     }
 
     /**
+     * @throws \Exception
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+        if ($this->request->getParam('action') === 'index') {
+            $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
+        }
+    }
+
+    /**
      * フィードバック・お問い合わせフォーム（全ユーザー共通）
      */
     public function index(): ?Response
     {
         $this->Authorization->authorize($this, 'index');
-        $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
 
         $user = $this->Authentication->getIdentity();
         $categories = TContactsTable::CATEGORIES;


### PR DESCRIPTION
## 背景

前回の修正（#255）はアクション内で `setConfig('unlockedFields', ...)` を呼んでいたが、`FormProtection` のバリデーションは `startup()` イベント（アクション実行前）で完了するため効果がなかった。

## 変更内容

- `ContactsController::index()` 内の `unlockedFields` 設定を `beforeFilter()` に移動
- `beforeFilter()` は `startup()` より前に実行されるため、正しくバリデーション前に設定が反映される