### PR TITLE
Fix FormProtection 'Unexpected field' error in contact form

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use App\Model\Table\TContactsTable;
 use App\Service\ContactService;
 use Authorization\Exception\ForbiddenException;
+use Cake\Event\EventInterface;
 use Cake\Http\Response;
 
 class ContactsController extends AppController
@@ -19,12 +20,22 @@ class ContactsController extends AppController
     }
 
     /**
+     * @throws \Exception
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+        if ($this->request->getParam('action') === 'index') {
+            $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
+        }
+    }
+
+    /**
      * フィードバック・お問い合わせフォーム（全ユーザー共通）
      */
     public function index(): ?Response
     {
         $this->Authorization->authorize($this, 'index');
-        $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
 
         $user = $this->Authentication->getIdentity();
         $categories = TContactsTable::CATEGORIES;

--- a/src_web/kamaho-shokusu/src/Controller/ContactsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ContactsController.php
@@ -24,6 +24,7 @@ class ContactsController extends AppController
     public function index(): ?Response
     {
         $this->Authorization->authorize($this, 'index');
+        $this->FormProtection->setConfig('unlockedFields', ['name', 'email', 'category', 'body']);
 
         $user = $this->Authentication->getIdentity();
         $categories = TContactsTable::CATEGORIES;


### PR DESCRIPTION
This pull request introduces an important update to the `ContactsController` by adding a `beforeFilter` method that customizes form protection settings for the `index` action. This ensures that specific form fields are unlocked and not subject to CSRF protection, which is necessary for proper form handling.

**Controller enhancements:**

* Added a `beforeFilter` method to `ContactsController` to unlock the `name`, `email`, `category`, and `body` fields from CakePHP's form protection when the `index` action is accessed. This helps avoid CSRF validation issues for these fields.
* Imported `Cake\Event\EventInterface` to support the new `beforeFilter` method.