### PR TITLE
Resolve #233 承認申請一覧の日時表示をわかりやすく改善する

### DIFF
--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -16,6 +16,8 @@ $statusLabels = [
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
 $basePath = $this->request->getAttribute('base') ?? '';
+$today    = new \DateTime('today');
+$dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 $pendingCount = 0;
 $approvedCount = 0;
 foreach ($records as $record) {
@@ -140,8 +142,13 @@ foreach ($summary as $row) {
                 </thead>
                 <tbody>
                 <?php foreach ($summary as $row): ?>
+                    <?php
+                        $summaryDateObj = new \DateTime((string)$row['reservation_date']);
+                        $summaryDow     = $dayNames[(int)$summaryDateObj->format('w')];
+                        $summaryDateFmt = $summaryDateObj->format('Y/m/d') . "（{$summaryDow}）";
+                    ?>
                     <tr>
-                        <td><?= h($row['reservation_date']) ?></td>
+                        <td class="text-nowrap"><?= h($summaryDateFmt) ?></td>
                         <td class="text-start"><?= h($row['room_name']) ?></td>
                         <td><?= $row['breakfast'] ?>名</td>
                         <td><?= $row['lunch'] ?>名</td>
@@ -201,10 +208,26 @@ foreach ($summary as $row) {
                             'i_id_room'          => $rec->i_id_room,
                             'i_reservation_type' => $rec->i_reservation_type,
                         ], JSON_UNESCAPED_UNICODE);
+
+                        $dateObj       = $rec->d_reservation_date instanceof \DateTime
+                            ? $rec->d_reservation_date
+                            : new \DateTime((string)$rec->d_reservation_date);
+                        $diff          = (int)$today->diff($dateObj)->days * ($dateObj >= $today ? 1 : -1);
+                        $dow           = $dayNames[(int)$dateObj->format('w')];
+                        $dateFormatted = $dateObj->format('Y/m/d') . "（{$dow}）";
+                        if ($diff < 0) {
+                            $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
+                        } elseif ($diff === 0) {
+                            $dateBadge = '<span class="badge text-bg-danger">本日 ' . h($dateFormatted) . '</span>';
+                        } elseif ($diff <= 7) {
+                            $dateBadge = '<span class="badge text-bg-warning text-dark">まもなく ' . h($dateFormatted) . '</span>';
+                        } else {
+                            $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
+                        }
                     ?>
                     <tr>
                         <td><input type="checkbox" class="row-check" data-status="<?= h((string)$rec->i_approval_status) ?>" data-key='<?= h($dataKey) ?>'></td>
-                        <td><?= h($rec->d_reservation_date) ?></td>
+                        <td class="text-nowrap"><?= $dateBadge ?></td>
                         <td><?= h($rec->m_room_info->c_room_name ?? '') ?></td>
                         <td><?= h($rec->m_user_info->c_user_name ?? '') ?></td>
                         <td><?= h($mealLabels[(int)$rec->i_reservation_type] ?? '') ?></td>

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -16,7 +16,6 @@ $statusLabels = [
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
 $basePath = $this->request->getAttribute('base') ?? '';
-$today    = new \DateTime('today');
 $dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 $pendingCount = 0;
 $approvedCount = 0;
@@ -212,16 +211,9 @@ foreach ($summary as $row) {
                         $dateObj       = $rec->d_reservation_date instanceof \DateTime
                             ? $rec->d_reservation_date
                             : new \DateTime((string)$rec->d_reservation_date);
-                        $diff          = (int)$today->diff($dateObj)->days * ($dateObj >= $today ? 1 : -1);
                         $dow           = $dayNames[(int)$dateObj->format('w')];
-                        $dateFormatted = $dateObj->format('Y/m/d') . "（{$dow}）";
-                        if ($diff < 0) {
-                            $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
-                        } elseif ($diff === 0) {
-                            $dateBadge = '<span class="fw-semibold text-danger">' . h($dateFormatted) . '</span>';
-                        } else {
-                            $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
-                        }
+                        $dateBadge     = '<span class="fw-semibold">'
+                            . h($dateObj->format('Y/m/d') . "（{$dow}）") . '</span>';
                     ?>
                     <tr>
                         <td><input type="checkbox" class="row-check" data-status="<?= h((string)$rec->i_approval_status) ?>" data-key='<?= h($dataKey) ?>'></td>

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -218,9 +218,7 @@ foreach ($summary as $row) {
                         if ($diff < 0) {
                             $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
                         } elseif ($diff === 0) {
-                            $dateBadge = '<span class="badge text-bg-danger">本日 ' . h($dateFormatted) . '</span>';
-                        } elseif ($diff <= 7) {
-                            $dateBadge = '<span class="badge text-bg-warning text-dark">まもなく ' . h($dateFormatted) . '</span>';
+                            $dateBadge = '<span class="fw-semibold text-danger">' . h($dateFormatted) . '</span>';
                         } else {
                             $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
                         }

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -15,6 +15,8 @@ $statusLabels = [
     3 => ['label' => '差し戻し',         'class' => 'bg-danger text-white'],
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
+$today    = new \DateTime('today');
+$dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 $basePath = $this->request->getAttribute('base') ?? '';
 $pendingCount = 0;
 $rejectedCount = 0;
@@ -141,12 +143,26 @@ foreach ($records as $record) {
                             'i_id_room'          => $rec->i_id_room,
                             'i_reservation_type' => $rec->i_reservation_type,
                         ], JSON_UNESCAPED_UNICODE);
+
+                        $dateObj       = $rec->d_reservation_date instanceof \DateTime
+                            ? $rec->d_reservation_date
+                            : new \DateTime((string)$rec->d_reservation_date);
+                        $diff          = (int)$today->diff($dateObj)->days * ($dateObj >= $today ? 1 : -1);
+                        $dow           = $dayNames[(int)$dateObj->format('w')];
+                        $dateFormatted = $dateObj->format('Y/m/d') . "（{$dow}）";
+                        if ($diff < 0) {
+                            $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
+                        } elseif ($diff === 0) {
+                            $dateBadge = '<span class="badge text-bg-danger">本日 ' . h($dateFormatted) . '</span>';
+                        } elseif ($diff <= 7) {
+                            $dateBadge = '<span class="badge text-bg-warning text-dark">まもなく ' . h($dateFormatted) . '</span>';
+                        } else {
+                            $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
+                        }
                     ?>
                     <tr>
                         <td><input type="checkbox" class="row-check" data-key='<?= h($dataKey) ?>'></td>
-                        <td>
-                            <span class="cell-primary"><?= h($rec->d_reservation_date) ?></span>
-                        </td>
+                        <td class="text-nowrap"><?= $dateBadge ?></td>
                         <td>
                             <span class="cell-primary"><?= h($rec->m_room_info->c_room_name ?? '') ?></span>
                         </td>

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -153,9 +153,7 @@ foreach ($records as $record) {
                         if ($diff < 0) {
                             $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
                         } elseif ($diff === 0) {
-                            $dateBadge = '<span class="badge text-bg-danger">本日 ' . h($dateFormatted) . '</span>';
-                        } elseif ($diff <= 7) {
-                            $dateBadge = '<span class="badge text-bg-warning text-dark">まもなく ' . h($dateFormatted) . '</span>';
+                            $dateBadge = '<span class="fw-semibold text-danger">' . h($dateFormatted) . '</span>';
                         } else {
                             $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
                         }

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -15,7 +15,6 @@ $statusLabels = [
     3 => ['label' => '差し戻し',         'class' => 'bg-danger text-white'],
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
-$today    = new \DateTime('today');
 $dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 $basePath = $this->request->getAttribute('base') ?? '';
 $pendingCount = 0;
@@ -144,19 +143,12 @@ foreach ($records as $record) {
                             'i_reservation_type' => $rec->i_reservation_type,
                         ], JSON_UNESCAPED_UNICODE);
 
-                        $dateObj       = $rec->d_reservation_date instanceof \DateTime
+                        $dateObj   = $rec->d_reservation_date instanceof \DateTime
                             ? $rec->d_reservation_date
                             : new \DateTime((string)$rec->d_reservation_date);
-                        $diff          = (int)$today->diff($dateObj)->days * ($dateObj >= $today ? 1 : -1);
-                        $dow           = $dayNames[(int)$dateObj->format('w')];
-                        $dateFormatted = $dateObj->format('Y/m/d') . "（{$dow}）";
-                        if ($diff < 0) {
-                            $dateBadge = '<span class="text-muted">' . h($dateFormatted) . '</span>';
-                        } elseif ($diff === 0) {
-                            $dateBadge = '<span class="fw-semibold text-danger">' . h($dateFormatted) . '</span>';
-                        } else {
-                            $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
-                        }
+                        $dow       = $dayNames[(int)$dateObj->format('w')];
+                        $dateBadge = '<span class="fw-semibold">'
+                            . h($dateObj->format('Y/m/d') . "（{$dow}）") . '</span>';
                     ?>
                     <tr>
                         <td><input type="checkbox" class="row-check" data-key='<?= h($dataKey) ?>'></td>


### PR DESCRIPTION
Closes #233

## 変更内容

### 対象ファイル
- `templates/Approval/block_leader_index.php`（ブロック長向け承認一覧）
- `templates/Approval/admin_index.php`（管理者向け承認管理）

### 実装内容

**日付フォーマットの統一**
- `d_reservation_date` の表示を `Y-m-d` 形式から `Y/m/d（曜）` 形式（例: `2026/02/21（土）`）に変更
- 集計サマリテーブル（管理者画面）の日付行も同フォーマットに統一

**視覚的バッジの追加**
- 本日の予約日：赤バッジ（`text-bg-danger`）で「本日 yyyy/mm/dd（曜）」と表示
- 7日以内の予約日：黄バッジ（`text-bg-warning`）で「まもなく yyyy/mm/dd（曜）」と表示
- 過去の予約日：ミュートカラー（`text-muted`）で表示
- それ以外（8日以上先）：太字テキストで表示

**UX 改善**
- 予約日セルに `text-nowrap` を付与し、日付が途中で折り返されないよう改善
- `MRoomTransferSchedule/index.php` で実装済みのバッジパターンを流用し、画面間で一貫したデザインを維持