### PR TITLE
feat: 日時表示を Y/m/d（曜） H:i 形式に全体統一

### DIFF
--- a/src_web/kamaho-shokusu/templates/Contacts/admin_detail.php
+++ b/src_web/kamaho-shokusu/templates/Contacts/admin_detail.php
@@ -2,6 +2,11 @@
 /** @var \App\View\AppView $this */
 /** @var \App\Model\Entity\TContact $contact */
 $this->assign('title', 'お問い合わせ詳細');
+$_dow = ['日', '月', '火', '水', '木', '金', '土'];
+$fmtDt = static function (?\DateTimeInterface $dt) use ($_dow): string {
+    if ($dt === null) return '-';
+    return $dt->format('Y/m/d') . '（' . $_dow[(int)$dt->format('w')] . '）' . $dt->format(' H:i');
+};
 ?>
 
 <div class="d-flex align-items-center mb-3 gap-2">
@@ -17,7 +22,7 @@ $this->assign('title', 'お問い合わせ詳細');
 <div class="card mb-4">
     <div class="card-header bg-light">
         <span class="badge bg-secondary me-2"><?= h($contact->category) ?></span>
-        <span class="text-muted small"><?= h($contact->created->format('Y-m-d H:i')) ?></span>
+        <span class="text-muted small"><?= h($fmtDt($contact->created)) ?></span>
     </div>
     <div class="card-body">
         <dl class="row mb-0">
@@ -41,7 +46,7 @@ $this->assign('title', 'お問い合わせ詳細');
     <?php foreach ($contact->t_contact_replies as $reply): ?>
         <div class="card mb-2 border-start border-primary border-3">
             <div class="card-body py-2">
-                <div class="text-muted small mb-1"><?= h($reply->sent_at->format('Y-m-d H:i')) ?> 送信</div>
+                <div class="text-muted small mb-1"><?= h($fmtDt($reply->sent_at)) ?> 送信</div>
                 <div style="white-space: pre-wrap;"><?= h($reply->body) ?></div>
             </div>
         </div>

--- a/src_web/kamaho-shokusu/templates/Contacts/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Contacts/admin_index.php
@@ -1,6 +1,11 @@
 <?php
 /** @var \App\View\AppView $this */
 $this->assign('title', 'お問い合わせ一覧（管理者）');
+$_dow = ['日', '月', '火', '水', '木', '金', '土'];
+$fmtDt = static function (?\DateTimeInterface $dt) use ($_dow): string {
+    if ($dt === null) return '-';
+    return $dt->format('Y/m/d') . '（' . $_dow[(int)$dt->format('w')] . '）' . $dt->format(' H:i');
+};
 ?>
 
 <div class="d-flex align-items-center justify-content-between mb-3">
@@ -27,7 +32,7 @@ $this->assign('title', 'お問い合わせ一覧（管理者）');
             <tbody>
                 <?php foreach ($contacts as $contact): ?>
                     <tr>
-                        <td class="text-muted small"><?= h($contact->created->format('Y-m-d H:i')) ?></td>
+                        <td class="text-muted small text-nowrap"><?= h($fmtDt($contact->created)) ?></td>
                         <td>
                             <span class="badge bg-secondary"><?= h($contact->category) ?></span>
                         </td>

--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
@@ -93,9 +93,14 @@ $dayNames = ['日', '月', '火', '水', '木', '金', '土'];
                         $dateBadge = '<span class="fw-semibold">' . h($dateFormatted) . '</span>';
                     }
 
-                    $dtCreate = $schedule->dt_create
-                        ? (new \DateTime((string)$schedule->dt_create))->format('Y/m/d H:i')
-                        : '-';
+                    if ($schedule->dt_create) {
+                        $dtCreateObj = new \DateTime((string)$schedule->dt_create);
+                        $dtCreate    = $dtCreateObj->format('Y/m/d')
+                            . '（' . $dayNames[(int)$dtCreateObj->format('w')] . '）'
+                            . $dtCreateObj->format(' H:i');
+                    } else {
+                        $dtCreate = '-';
+                    }
 
                     $cancelMessage = sprintf(
                         '%s の異動予約（→ %s）をキャンセルしますか？',

--- a/src_web/kamaho-shokusu/templates/Notifications/index.php
+++ b/src_web/kamaho-shokusu/templates/Notifications/index.php
@@ -1,6 +1,11 @@
 <?php
 /** @var \App\View\AppView $this */
 $notifications = $notifications ?? [];
+$_dow = ['日', '月', '火', '水', '木', '金', '土'];
+$fmtDt = static function (?\DateTimeInterface $dt) use ($_dow): string {
+    if ($dt === null) return '-';
+    return $dt->format('Y/m/d') . '（' . $_dow[(int)$dt->format('w')] . '）' . $dt->format(' H:i');
+};
 ?>
 
 <div class="d-flex justify-content-between align-items-center mb-3">
@@ -30,7 +35,7 @@ $notifications = $notifications ?? [];
                             <?php endif; ?>
                         </div>
                         <div class="mb-2"><?= h($notification->c_message) ?></div>
-                        <div class="small text-muted"><?= h($notification->dt_create?->format('Y-m-d H:i')) ?></div>
+                        <div class="small text-muted"><?= h($fmtDt($notification->dt_create)) ?></div>
                     </div>
                     <div class="d-flex flex-column gap-2">
                         <?php if ($link !== '#'): ?>


### PR DESCRIPTION
## 概要

アプリ全体で `Y-m-d H:i` 形式のまま表示されていた日時を、曜日付きの `Y/m/d（曜） H:i` 形式に統一しました。

## 変更ファイル

| ファイル | 変更箇所 | 変更前 | 変更後 |
|---------|---------|-------|-------|
| `Contacts/admin_detail.php` | 受信日時・返信送信日時 | `2026-02-21 14:30` | `2026/02/21（土） 14:30` |
| `Contacts/admin_index.php` | 受信日時列 | `2026-02-21 14:30` | `2026/02/21（土） 14:30` |
| `Notifications/index.php` | 通知作成日時 | `2026-02-21 14:30` | `2026/02/21（土） 14:30` |
| `MRoomTransferSchedule/index.php` | 登録日時 | `2026/02/21 14:30` | `2026/02/21（土） 14:30` |

## 実装方針

- `$fmtDt` ヘルパークロージャを各テンプレートの先頭で定義し、`null` セーフで統一フォーマットを適用
- `MRoomTransferSchedule/index.php` は既に `$dayNames` が定義済みのため、登録日時の行のみ更新
- `Contacts/admin_index.php` の受信日時セルに `text-nowrap` を追加し折り返しを防止