### PR TITLE
Resolve #265 #266 #267 #268 #274: フロントエンド改善・直前編集の所属グループ対応

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -113,11 +113,13 @@ class TReservationInfoController extends AppController
             'changeEdit',
             'bulkChangeEditSubmit',
             'bulkAddSubmit',
+            'bulkChangeEditForm',
             'copy',
             'copyPreview',
             'actualMealSave',
             'actualMealRequestApproval',
             'view',
+            'getReservationSnapshots',
         ]);
     }
 

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -901,20 +901,24 @@ class TReservationInfoController extends AppController
             $this->request->accepts('application/json') ||
             $this->request->getParam('_ext') === 'json';
 
-        // 403 の理由をユーザーにわかりやすく伝えるため、ロール別のメッセージを返す
+        // 403 の理由をユーザーにわかりやすく伝えるため、ロール・所属別のメッセージを返す
         $loginUser = $this->request->getAttribute('identity');
         if ($loginUser !== null) {
             $isAdmin  = (int)($loginUser->get('i_admin')      ?? 0) === 1;
             $isStaff  = (int)($loginUser->get('i_user_level') ?? -1) === 0;
             if (!$isAdmin && !$isStaff) {
-                // 子どもユーザー: 直前編集権限なし
-                $reason = '直前編集は職員・管理者のみ使用できます。予約変更は通常の予約画面からご利用ください。';
-                if ($wantsJson) {
-                    return $this->response->withStatus(403)->withType('application/json')
-                        ->withStringBody(json_encode(['ok' => false, 'status' => 'forbidden', 'message' => $reason], JSON_UNESCAPED_UNICODE));
+                // 職員・管理者でない場合は所属部屋があるか確認
+                $loginUidEarly = (int)($loginUser->get('i_id_user') ?? 0);
+                $hasAffiliation = $loginUidEarly > 0 && $this->changeEditService->userHasRoomAccess($loginUidEarly);
+                if (!$hasAffiliation) {
+                    $reason = '直前編集は職員・管理者・所属グループがある方のみ使用できます。予約変更は通常の予約画面からご利用ください。';
+                    if ($wantsJson) {
+                        return $this->response->withStatus(403)->withType('application/json')
+                            ->withStringBody(json_encode(['ok' => false, 'status' => 'forbidden', 'message' => $reason], JSON_UNESCAPED_UNICODE));
+                    }
+                    $this->Flash->error($reason);
+                    return $this->redirect(['action' => 'index']);
                 }
-                $this->Flash->error($reason);
-                return $this->redirect(['action' => 'index']);
             }
         }
 
@@ -944,6 +948,8 @@ class TReservationInfoController extends AppController
                 $this->MUserGroup,
                 $this->MRoomInfo
             );
+            // 所属部屋がある = 部屋の予約を管理できる（職員・管理者・所属グループユーザー全員）
+            $isRoomManager = !empty($allowedRooms);
 
             // ---- 殻 GET（modal=1）: roomId/date 未指定でもレンダリング ----
             if ($isModalShell) {
@@ -971,8 +977,65 @@ class TReservationInfoController extends AppController
                 }
                 $users = new \Cake\Collection\Collection([]);
                 $userReservations = [];
-                $this->set(compact('room','rooms','date','users','userReservations'));
+                $individualReservations = ($loginUid && $date)
+                    ? $this->TIndividualReservationInfo->find()
+                        ->select(['i_reservation_type', 'i_id_room'])
+                        ->where(['i_id_user' => $loginUid, 'd_reservation_date' => $date, 'eat_flag' => 1])
+                        ->toArray()
+                    : [];
+                $this->set(compact('room','rooms','date','users','userReservations','individualReservations'));
                 return $this->render('change_edit');
+            }
+
+            // ---- 個人タイプのPOSTは部屋ID不要のため早期処理 ----
+            if ($this->request->is(['post', 'put'])) {
+                $earlyData = $this->request->getData();
+                if (empty($earlyData)) {
+                    $earlyParsed = $this->request->input('json_decode', true);
+                    if (is_array($earlyParsed)) $earlyData = $earlyParsed;
+                }
+                if (($earlyData['reservation_type'] ?? '2') === '1') {
+                    $postDate = $date ?? ($earlyData['d_reservation_date'] ?? null);
+                    if (!$postDate) {
+                        if ($wantsJson) {
+                            return $this->response->withStatus(422)->withType('application/json')
+                                ->withStringBody(json_encode(['ok' => false, 'status' => 'error', 'message' => '日付が指定されていません。'], JSON_UNESCAPED_UNICODE));
+                        }
+                        $this->Flash->error('日付が指定されていません。');
+                        return $this->redirect(['action' => 'index']);
+                    }
+                    try {
+                        $result = $this->writeService->processIndividualReservation(
+                            (string)$postDate,
+                            $earlyData,
+                            $allowedRooms,
+                            (int)$loginUid,
+                            (string)($loginUser->get('c_user_name') ?? ''),
+                            fn($d) => true
+                        );
+                        $payload = [
+                            'ok'      => true,
+                            'status'  => 'success',
+                            'message' => '直前予約（個人）を更新しました。',
+                            'data'    => $result,
+                            'date'    => $postDate,
+                        ];
+                        if ($wantsJson) {
+                            return $this->response->withType('application/json')
+                                ->withStringBody(json_encode($payload, JSON_UNESCAPED_UNICODE));
+                        }
+                        $this->Flash->success($payload['message']);
+                        return $this->redirect(['action' => 'index']);
+                    } catch (\Throwable $e) {
+                        $this->log('直前編集（個人）エラー: ' . $e->getMessage(), 'error');
+                        if ($wantsJson) {
+                            return $this->response->withStatus(500)->withType('application/json')
+                                ->withStringBody(json_encode(['ok' => false, 'status' => 'error', 'message' => $e->getMessage()], JSON_UNESCAPED_UNICODE));
+                        }
+                        $this->Flash->error($e->getMessage());
+                        return $this->redirect(['action' => 'index']);
+                    }
+                }
             }
 
             // ---- バリデーション（通常/JSON）----
@@ -1013,7 +1076,7 @@ class TReservationInfoController extends AppController
             // ---- GET: JSON/HTML ----
             if ($this->request->is('get')) {
                 if ($wantsJson) {
-                    $usersForJson = $changeEditService->buildUsersForJson($users, $loginUser);
+                    $usersForJson = $changeEditService->buildUsersForJson($users, $loginUser, $isRoomManager);
 
                     return $this->response->withType('application/json')
                         ->withStringBody(json_encode([
@@ -1030,7 +1093,13 @@ class TReservationInfoController extends AppController
                 }
 
                 $rooms = $allowedRooms;
-                $this->set(compact('room','rooms','date','users','userReservations'));
+                $individualReservations = ($loginUid && $date)
+                    ? $this->TIndividualReservationInfo->find()
+                        ->select(['i_reservation_type', 'i_id_room'])
+                        ->where(['i_id_user' => $loginUid, 'd_reservation_date' => $date, 'eat_flag' => 1])
+                        ->toArray()
+                    : [];
+                $this->set(compact('room','rooms','date','users','userReservations','individualReservations'));
                 return $this->render('change_edit');
             }
 
@@ -1051,7 +1120,8 @@ class TReservationInfoController extends AppController
                         (int)$roomId,
                         $loginUser,
                         $this->TIndividualReservationInfo,
-                        $this->MUserInfo
+                        $this->MUserInfo,
+                        $isRoomManager
                     );
 
                     $updated = $result['updated'] ?? [];

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -117,6 +117,7 @@ class TReservationInfoController extends AppController
             'copyPreview',
             'actualMealSave',
             'actualMealRequestApproval',
+            'view',
         ]);
     }
 
@@ -304,10 +305,11 @@ class TReservationInfoController extends AppController
         $date = $this->request->getParam('date')
             ?? $this->request->getParam('pass.0')
             ?? $this->request->getQuery('date');
+        $roomIdRaw = $this->request->getData('room_id') ?? $this->request->getQuery('room_id');
         $context = $this->viewService->buildViewContext(
             $this->request->getAttribute('identity'),
             $date,
-            $this->request->getQuery('room_id') !== null ? (int)$this->request->getQuery('room_id') : null,
+            $roomIdRaw !== null ? (int)$roomIdRaw : null,
             $this->MRoomInfo,
             $this->MUserGroup,
             $this->TIndividualReservationInfo,

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -304,19 +304,17 @@ class TReservationInfoController extends AppController
         $date = $this->request->getParam('date')
             ?? $this->request->getParam('pass.0')
             ?? $this->request->getQuery('date');
+        $roomIdRaw = $this->request->getData('room_id') ?? $this->request->getQuery('room_id');
         $context = $this->viewService->buildViewContext(
             $this->request->getAttribute('identity'),
             $date,
-            $this->request->getQuery('room_id') !== null ? (int)$this->request->getQuery('room_id') : null,
+            $roomIdRaw !== null ? (int)$roomIdRaw : null,
             $this->MRoomInfo,
             $this->MUserGroup,
             $this->TIndividualReservationInfo,
             $this->queryService
         );
 
-        /* ───────────────────────────────────────
-         * ⑤ ビューにデータをセット
-         * ─────────────────────────────────────── */
         $this->set($context);
         return null;
     }

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -117,6 +117,7 @@ class TReservationInfoController extends AppController
             'copyPreview',
             'actualMealSave',
             'actualMealRequestApproval',
+            'view',
         ]);
     }
 

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -117,7 +117,6 @@ class TReservationInfoController extends AppController
             'copyPreview',
             'actualMealSave',
             'actualMealRequestApproval',
-            'view',
         ]);
     }
 
@@ -305,11 +304,10 @@ class TReservationInfoController extends AppController
         $date = $this->request->getParam('date')
             ?? $this->request->getParam('pass.0')
             ?? $this->request->getQuery('date');
-        $roomIdRaw = $this->request->getData('room_id') ?? $this->request->getQuery('room_id');
         $context = $this->viewService->buildViewContext(
             $this->request->getAttribute('identity'),
             $date,
-            $roomIdRaw !== null ? (int)$roomIdRaw : null,
+            $this->request->getQuery('room_id') !== null ? (int)$this->request->getQuery('room_id') : null,
             $this->MRoomInfo,
             $this->MUserGroup,
             $this->TIndividualReservationInfo,

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -38,7 +38,7 @@ class TReservationInfoPolicy
 
     public function canChangeEdit(?IdentityInterface $user, TReservationInfo $resource): bool
     {
-        return $this->isStaffOrAdmin($user);
+        return $this->isStaffOrAdmin($user) || $this->isRoomAffiliated($user);
     }
 
     public function canToggle(?IdentityInterface $user, TReservationInfo $resource): bool
@@ -255,6 +255,16 @@ class TReservationInfoPolicy
     private function isStaffOrAdmin(?IdentityInterface $user): bool
     {
         return $this->isAdmin($user) || $this->isStaff($user);
+    }
+
+    private function isRoomAffiliated(?IdentityInterface $user): bool
+    {
+        $userId = $this->getUserId($user);
+        if ($userId <= 0) {
+            return false;
+        }
+
+        return $this->roomAccessService->hasAnyAffiliation($userId);
     }
 
     public function isBlockLeaderOrAdmin(?IdentityInterface $user): bool

--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -17,6 +17,11 @@ class ReservationChangeEditService
         $this->roomAccessService = $roomAccessService ?? new RoomAccessService();
     }
 
+    public function userHasRoomAccess(int $userId): bool
+    {
+        return $this->roomAccessService->hasAnyAffiliation($userId);
+    }
+
     public function getAllowedRooms($loginUser, ?int $roomId, Table $userGroupTable, Table $roomTable): array
     {
         $loginUid = (int)($loginUser?->get('i_id_user') ?? 0);
@@ -93,7 +98,6 @@ class ReservationChangeEditService
                 'MUserInfo.i_del_flag'   => 0,
             ])
             ->enableHydration(false)->all()->extract('i_id_user')->toList();
-        // 職員IDが未付与（null）のレコードを除外して予期しない動作を防ぐ
         $baseUserIds = array_values(array_filter($baseUserIds, fn($id) => $id !== null && $id > 0));
         if (empty($baseUserIds)) {
             $baseUserIds = [-1];
@@ -141,13 +145,13 @@ class ReservationChangeEditService
         ];
     }
 
-    public function buildUsersForJson(array $users, $loginUser): array
+    public function buildUsersForJson(array $users, $loginUser, bool $isRoomManager = false): array
     {
-        // 管理者（i_admin=1）または職員（i_user_level=0）は全ユーザーを編集できる
-        $canEditAll = $loginUser && (
+        // 管理者・職員・所属グループユーザーは部屋内の全ユーザーを編集できる
+        $canEditAll = $isRoomManager || ($loginUser && (
             (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
             (int)($loginUser->get('i_user_level') ?? -1) === 0
-        );
+        ));
         $loginUid = $loginUser?->get('i_id_user');
 
         $usersForJson = [];
@@ -173,7 +177,8 @@ class ReservationChangeEditService
         int $roomId,
         $loginUser,
         Table $reservationTable,
-        Table $userTable
+        Table $userTable,
+        bool $isRoomManager = false
     ): array {
         $connection = $reservationTable->getConnection();
         $connection->begin();
@@ -185,10 +190,10 @@ class ReservationChangeEditService
         try {
             // ログインユーザーの編集権限を確定する（buildUsersForJson と同一ロジック）
             $loginUid    = $loginUser ? (int)$loginUser->get('i_id_user') : 0;
-            $canEditAll  = $loginUser && (
+            $canEditAll  = $isRoomManager || ($loginUser && (
                 (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
                 (int)($loginUser->get('i_user_level') ?? -1) === 0
-            );
+            ));
 
             $allowedMap = array_fill_keys(array_map('intval', $userIdList), true);
             $targetUserIds = [];

--- a/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomAccessService.php
@@ -77,6 +77,11 @@ class RoomAccessService
         return in_array($roomId, $this->getUserRoomIds($userId), true);
     }
 
+    public function hasAnyAffiliation(int $userId): bool
+    {
+        return !empty($this->getUserRoomIds($userId));
+    }
+
     public function getAccessibleRooms(Table $roomTable, int $userId): array
     {
         if ($userId <= 0) {

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
@@ -100,17 +100,29 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                         </div>
 
                         <!-- 個人：部屋ごとのチェック -->
-                        <div class="mb-3" id="room-selection-table" style="display: none;">
+                        <div class="mb-3 d-none" id="room-selection-table">
                             <?= $this->Form->label('rooms', '部屋名と食事選択', ['class' => 'form-label']) ?>
                             <div id="room-table-container" class="table-responsive">
                                 <table class="table table-bordered mb-0">
                                     <thead class="table-light">
                                     <tr>
-                                        <th>部屋名</th>
-                                        <th class="text-center"><input type="checkbox" onclick="toggleAllRooms(1, this.checked)" aria-label="朝を全選択"> 朝</th>
-                                        <th class="text-center"><input type="checkbox" onclick="toggleAllRooms(2, this.checked)" aria-label="昼を全選択"> 昼</th>
-                                        <th class="text-center"><input type="checkbox" onclick="toggleAllRooms(3, this.checked)" aria-label="夜を全選択"> 夜</th>
-                                        <th class="text-center"><input type="checkbox" onclick="toggleAllRooms(4, this.checked)" aria-label="弁当を全選択"> 弁当</th>
+                                        <th scope="col">部屋名</th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-1">朝</label>
+                                            <input type="checkbox" id="select-all-room-1">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-2">昼</label>
+                                            <input type="checkbox" id="select-all-room-2">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-3">夜</label>
+                                            <input type="checkbox" id="select-all-room-3">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-4">弁当</label>
+                                            <input type="checkbox" id="select-all-room-4">
+                                        </th>
                                     </tr>
                                     </thead>
                                     <tbody id="room-checkboxes">
@@ -130,7 +142,7 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
 
                         <?php if ($user->get('i_admin') === 1 || $user->get('i_user_level') == 0): ?>
                             <!-- 集団：部屋選択 -->
-                            <div class="mb-3" id="room-select-group" style="display: none;">
+                            <div class="mb-3 d-none" id="room-select-group">
                                 <?= $this->Form->label('room-select', '部屋を選択', ['class' => 'form-label']) ?>
                                 <?= $this->Form->control('i_id_room', [
                                         'type' => 'select',
@@ -144,17 +156,29 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                             </div>
 
                             <!-- 集団：利用者×食事 -->
-                            <div class="mb-3" id="user-selection-table" style="display: none;">
+                            <div class="mb-3 d-none" id="user-selection-table">
                                 <?= $this->Form->label('users', '部屋に属する利用者と食事選択', ['class' => 'form-label']) ?>
                                 <div id="user-table-container" class="table-responsive">
                                     <table class="table table-bordered mb-0">
                                         <thead class="table-light">
                                         <tr>
-                                            <th>利用者名</th>
-                                            <th class="text-center"><input type="checkbox" onclick="toggleAllUsers('morning', this.checked)" aria-label="朝を全選択"> 朝</th>
-                                            <th class="text-center"><input type="checkbox" onclick="toggleAllUsers('noon', this.checked)" aria-label="昼を全選択"> 昼</th>
-                                            <th class="text-center"><input type="checkbox" onclick="toggleAllUsers('night', this.checked)" aria-label="夜を全選択"> 夜</th>
-                                            <th class="text-center"><input type="checkbox" onclick="toggleAllUsers('bento', this.checked)" aria-label="弁当を全選択"> 弁当</th>
+                                            <th scope="col">利用者名</th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-user-morning">朝</label>
+                                                <input type="checkbox" id="select-all-user-morning">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-user-noon">昼</label>
+                                                <input type="checkbox" id="select-all-user-noon">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-user-night">夜</label>
+                                                <input type="checkbox" id="select-all-user-night">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-user-bento">弁当</label>
+                                                <input type="checkbox" id="select-all-user-bento">
+                                            </th>
                                         </tr>
                                         </thead>
                                         <tbody id="user-checkboxes">
@@ -198,9 +222,7 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                     cb.dispatchEvent(new Event('change'));
                                 });
 
-                                const headerCheckbox = document.querySelector(
-                                    `input[type="checkbox"][onclick^="toggleAllRooms(${mealType},"]`
-                                );
+                                const headerCheckbox = document.getElementById('select-all-room-' + mealType);
                                 if (headerCheckbox) {
                                     const allChecked = [...checkboxes].every(cb => cb.checked);
                                     headerCheckbox.checked = allChecked;
@@ -217,9 +239,14 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                     const checkboxes = document.querySelectorAll(
                                         `input[type="checkbox"][name^="meals[${mealType}]"]`
                                     );
-                                    const headerCheckbox = document.querySelector(
-                                        `input[type="checkbox"][onclick^="toggleAllRooms(${mealType},"]`
-                                    );
+                                    const headerCheckbox = document.getElementById('select-all-room-' + mealType);
+
+                                    // onclick 属性の代わりに addEventListener でバインド
+                                    if (headerCheckbox) {
+                                        headerCheckbox.addEventListener('change', function() {
+                                            toggleAllRooms(mealType, this.checked);
+                                        });
+                                    }
 
                                     checkboxes.forEach(cb => {
                                         cb.removeEventListener('change', cb._onchangeHandler ?? (() => {}));
@@ -251,9 +278,15 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                     `input[type="checkbox"][name^="users"][name$="[${mealType}]"]`
                                 );
 
-                                const headerCheckbox = document.querySelector(
-                                    `input[type="checkbox"][onclick^="toggleAllUsers('${mealTime}',"]`
-                                );
+                                const headerCheckbox = document.getElementById('select-all-user-' + mealTime);
+
+                                // onclick 属性の代わりに addEventListener でバインド（初回のみ）
+                                if (headerCheckbox && !headerCheckbox.dataset._bound) {
+                                    headerCheckbox.dataset._bound = '1';
+                                    headerCheckbox.addEventListener('change', function() {
+                                        toggleAllUsers(mealTime, this.checked);
+                                    });
+                                }
 
                                 checkboxes.forEach(cb => {
                                     cb.checked = isChecked;
@@ -311,9 +344,8 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
 
                                 const updateHeaderCheckbox = (mealType) => {
                                     const allCbs = document.querySelectorAll(`input[name^="users"][name$="[${mealType}]"]`);
-                                    const headerCb = document.querySelector(
-                                        `input[type="checkbox"][onclick^="toggleAllUsers('${mealType === 2 ? 'noon' : 'bento'}',"]`
-                                    );
+                                    const mealKey = mealType === 2 ? 'noon' : 'bento';
+                                    const headerCb = document.getElementById('select-all-user-' + mealKey);
                                     if (!headerCb) return;
                                     const allChecked = [...allCbs].every(c => c.checked);
                                     headerCb.checked = allChecked;
@@ -399,21 +431,24 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                         }
                                         const tbody = document.getElementById('user-checkboxes');
                                         tbody.innerHTML = '';
+                                        const escHtml = (s) => String(s).replace(/[<>&"']/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
                                         users.forEach(u => {
                                             const tr = document.createElement('tr');
+                                            const safeName = escHtml(u.name || '');
+                                            const safeId   = escHtml(u.id   || '');
                                             tr.innerHTML = `
-    <td>${u.name}</td>
-    <td class="text-center"><input type="checkbox" name="users[${u.id}][1]" value="1" ${Number(u.morning) === 1 ? 'checked data-existing="1"' : ''}></td>
-    <td class="text-center"><input type="checkbox" name="users[${u.id}][2]" value="1" ${Number(u.noon) === 1 ? 'checked data-existing="1"' : ''}></td>
-    <td class="text-center"><input type="checkbox" name="users[${u.id}][3]" value="1" ${Number(u.night) === 1 ? 'checked data-existing="1"' : ''}></td>
-    <td class="text-center"><input type="checkbox" name="users[${u.id}][4]" value="1" ${Number(u.bento) === 1 ? 'checked data-existing="1"' : ''}></td>
+    <td>${safeName}</td>
+    <td class="text-center"><input type="checkbox" name="users[${safeId}][1]" value="1" ${Number(u.morning) === 1 ? 'checked data-existing="1"' : ''}></td>
+    <td class="text-center"><input type="checkbox" name="users[${safeId}][2]" value="1" ${Number(u.noon) === 1 ? 'checked data-existing="1"' : ''}></td>
+    <td class="text-center"><input type="checkbox" name="users[${safeId}][3]" value="1" ${Number(u.night) === 1 ? 'checked data-existing="1"' : ''}></td>
+    <td class="text-center"><input type="checkbox" name="users[${safeId}][4]" value="1" ${Number(u.bento) === 1 ? 'checked data-existing="1"' : ''}></td>
 `;
                                             tbody.appendChild(tr);
 
                                             /* ユーザー行の昼⇄弁当排他 */
                                             setupLunchBentoPair(
-                                                tr.querySelector(`input[name="users[${u.id}][2]"]`),
-                                                tr.querySelector(`input[name="users[${u.id}][4]"]`)
+                                                tr.querySelector(`input[name="users[${safeId}][2]"]`),
+                                                tr.querySelector(`input[name="users[${safeId}][4]"]`)
                                             );
                                         });
                                     })
@@ -458,20 +493,12 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
 
                                 /* ヘッダーの “全選択” チェックボックス排他 */
                                 setupLunchBentoPair(
-                                    document.querySelector(
-                                        '#room-table-container thead input[onclick^="toggleAllRooms(2,"]'
-                                    ),
-                                    document.querySelector(
-                                        '#room-table-container thead input[onclick^="toggleAllRooms(4,"]'
-                                    )
+                                    document.getElementById('select-all-room-2'),
+                                    document.getElementById('select-all-room-4')
                                 );
                                 setupLunchBentoPair(
-                                    document.querySelector(
-                                        '#user-table-container thead input[onclick^="toggleAllUsers(\'noon\',"]'
-                                    ),
-                                    document.querySelector(
-                                        '#user-table-container thead input[onclick^="toggleAllUsers(\'bento\',"]'
-                                    )
+                                    document.getElementById('select-all-user-noon'),
+                                    document.getElementById('select-all-user-bento')
                                 );
 
                                 /* 個人予約データを取得して反映（排他処理と連動） */
@@ -490,9 +517,12 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                     <div class="form-text text-muted mb-2">チェックを外して登録すると予約をキャンセルできます。</div>
                     <?= $this->Form->button(__('登録'), ['class' => 'btn btn-primary']) ?>
                     <div id="loading-overlay"
+                         role="status"
+                         aria-live="polite"
+                         aria-label="処理中"
                          style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.5); z-index: 9999; text-align: center;">
                         <div style="position: relative; top: 50%; transform: translateY(-50%);">
-                            <div class="spinner-border text-info" role="status"></div>
+                            <div class="spinner-border text-info" aria-hidden="true"></div>
                             <p style="color: white; margin-top: 10px;">処理中です。少々お待ちください...</p>
                         </div>
                     </div>
@@ -519,25 +549,28 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
         const roomSelectGp = document.getElementById('room-select-group');  // ★ null 可
         const userTableGp  = document.getElementById('user-selection-table'); // ★ null 可
 
+        const showEl = (el) => { if (el) el.classList.remove('d-none'); };
+        const hideEl = (el) => { if (el) el.classList.add('d-none'); };
+
         const handleTypeChange = () => {
             const val = typeSelect.value;
             if (val === '1') {
-                if (roomTable)    roomTable.style.display    = '';
-                if (roomSelectGp) roomSelectGp.style.display = 'none';
-                if (userTableGp)  userTableGp.style.display  = 'none';
+                showEl(roomTable);
+                hideEl(roomSelectGp);
+                hideEl(userTableGp);
                 // 個人の既存予約を取得・反映
                 if (typeof fetchPersonalReservationData === 'function') {
                     fetchPersonalReservationData();
                 }
             } else if (val === '2') {
-                if (roomTable)    roomTable.style.display    = 'none';
-                if (roomSelectGp) roomSelectGp.style.display = '';
-                if (userTableGp)  userTableGp.style.display  = 'none';
+                hideEl(roomTable);
+                showEl(roomSelectGp);
+                hideEl(userTableGp);
                 // ★ select に既定値が入っているので、親 ensureAddModalCompat が自動 fetch します
             } else {
-                if (roomTable)    roomTable.style.display    = 'none';
-                if (roomSelectGp) roomSelectGp.style.display = 'none';
-                if (userTableGp)  userTableGp.style.display  = 'none';
+                hideEl(roomTable);
+                hideEl(roomSelectGp);
+                hideEl(userTableGp);
             }
         };
 
@@ -547,10 +580,10 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
             const tbody = document.getElementById('user-checkboxes');
             if (tbody) tbody.innerHTML = '';
             if (!roomId) {
-                if (userTableGp) userTableGp.style.display = 'none';
+                hideEl(userTableGp);
                 return;
             }
-            if (userTableGp) userTableGp.style.display = '';
+            showEl(userTableGp);
             if (typeof fetchUserData === 'function') {
                 fetchUserData(roomId);
             }

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
@@ -27,10 +27,26 @@ $days = $days ?? [];
         window.__BASE_WEEK = <?= json_encode($baseWeek->format('Y-m-d'), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_USER_ID = <?= json_encode($user?->get('i_id_user') ?? null, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
     </script>
+    <?= $this->Html->css('bootstrap-icons') ?>
     <?= $this->Html->css('pages/bulk_change_edit_form.pc.css') ?>
 <?= $this->Html->css('pages/bulk_change_edit_form.mobile.css') ?>
 </head>
 <body>
+
+<!-- 直前編集モードバナー -->
+<div class="mode-banner" role="banner" aria-label="直前編集モード中">
+    <div class="container py-2 d-flex align-items-center gap-2 flex-wrap">
+        <span class="mode-badge">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+            直前編集モード
+        </span>
+        <span class="mode-desc">発注済み期間の予約を変更できます。保存後すぐに食数へ反映されます。</span>
+        <a href="javascript:history.back()" class="btn btn-sm mode-back-btn ms-auto">
+            <i class="bi bi-arrow-left" aria-hidden="true"></i> ホームに戻る
+        </a>
+    </div>
+</div>
+
 <div class="container py-3">
     <div class="excel-header d-flex align-items-center justify-content-between gap-2 flex-wrap">
         <div class="d-flex align-items-center gap-2">

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
@@ -27,7 +27,7 @@ $days = $days ?? [];
         window.__BASE_WEEK = <?= json_encode($baseWeek->format('Y-m-d'), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_USER_ID = <?= json_encode($user?->get('i_id_user') ?? null, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
     </script>
-    <?= $this->Html->css('bootstrap-icons') ?>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <?= $this->Html->css('pages/bulk_change_edit_form.pc.css') ?>
 <?= $this->Html->css('pages/bulk_change_edit_form.mobile.css') ?>
 </head>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -5,6 +5,7 @@
 
 $selectedRoomId = null;
 $selectedRoomName = '';
+$individualReservations = $individualReservations ?? [];
 
 if (isset($room) && is_object($room)) {
     $selectedRoomId = $room->i_id_room;
@@ -17,6 +18,14 @@ if (isset($room) && is_object($room)) {
 $basePath = $this->Url->build('/', ['fullBase' => false]);
 $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('mealType') ?? 2;
 echo $this->Html->css('pages/t_reservation_change_edit.css');
+
+$indivJson = json_encode(
+    array_values(array_map(fn($r) => [
+        'type'    => (int)$r->i_reservation_type,
+        'room_id' => (int)$r->i_id_room,
+    ], $individualReservations)),
+    JSON_UNESCAPED_UNICODE
+);
 ?>
 <div id="ce-root"
      data-base="<?= h($basePath) ?>"
@@ -25,14 +34,23 @@ echo $this->Html->css('pages/t_reservation_change_edit.css');
 
     <!-- 警告ヘッダ -->
     <div class="ce-warning-banner">
-        <span class="ce-date-label">
-            &#9888; 直前編集：<?= h($date) ?>
-        </span>
+        <span class="ce-date-label">&#9888; 直前編集：<?= h($date) ?></span>
         <span class="ce-warning-note">発注済みです。変更内容をよく確認してください。</span>
     </div>
 
-    <!-- ツールバー -->
-    <div class="ce-toolbar">
+    <!-- 予約タイプ選択 -->
+    <div class="ce-type-selector">
+        <span class="ce-type-label">予約タイプ：</span>
+        <div class="btn-group btn-group-sm" role="group" aria-label="予約タイプの選択">
+            <input type="radio" class="btn-check" name="ce-type-radio" id="ce-type-group-radio" value="2" checked autocomplete="off">
+            <label class="btn btn-outline-primary" for="ce-type-group-radio">集団（利用者別）</label>
+            <input type="radio" class="btn-check" name="ce-type-radio" id="ce-type-individual-radio" value="1" autocomplete="off">
+            <label class="btn btn-outline-primary" for="ce-type-individual-radio">個人（部屋別）</label>
+        </div>
+    </div>
+
+    <!-- 集団：ツールバー（フォーム外） -->
+    <div id="ce-group-toolbar" class="ce-toolbar">
         <input type="search" id="ce-name-search" class="form-control" placeholder="氏名で絞り込み" autocomplete="off">
 
         <?php if (!empty($rooms) && count($rooms) > 1): ?>
@@ -52,8 +70,8 @@ echo $this->Html->css('pages/t_reservation_change_edit.css');
         <?php endif; ?>
     </div>
 
-    <!-- 食数サマリー -->
-    <div class="ce-summary-bar">
+    <!-- 集団：食数サマリー（フォーム外） -->
+    <div id="ce-group-summary" class="ce-summary-bar">
         <span class="ce-sum-label">食数：</span>
         <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
         <span>昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
@@ -61,33 +79,65 @@ echo $this->Html->css('pages/t_reservation_change_edit.css');
         <span>弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
     </div>
 
-    <!-- フォーム＋テーブル -->
+    <!-- フォーム -->
     <?= $this->Form->create(null, ['id' => 'change-edit-form', 'url' => ['action' => 'changeEdit']]) ?>
     <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
     <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
+    <?= $this->Form->hidden('reservation_type', ['value' => '2', 'id' => 'ce-reservation-type-hidden']) ?>
     <?php if ($selectedRoomId): ?>
         <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
     <?php endif; ?>
 
-    <div class="ce-table-wrap">
-        <table class="table table-sm table-bordered" id="ce-table">
-            <thead>
-                <tr>
-                    <th class="text-start">氏名</th>
-                    <th>朝<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
-                    <th>昼<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
-                    <th>夕<br><input type="checkbox" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
-                    <th>弁当<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
-                </tr>
-            </thead>
-            <tbody id="ce-tbody">
-                <tr>
-                    <td colspan="5" class="text-center py-4 text-muted">
-                        <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+    <!-- ■ 個人予約セクション ■ -->
+    <div id="ce-individual-section" style="display:none;">
+        <div class="ce-table-wrap">
+            <table class="table table-sm table-bordered" id="ce-room-table">
+                <thead>
+                    <tr>
+                        <th class="text-start">部屋名</th>
+                        <th class="text-center">朝</th>
+                        <th class="text-center">昼</th>
+                        <th class="text-center">夕</th>
+                        <th class="text-center">弁当</th>
+                    </tr>
+                </thead>
+                <tbody id="ce-room-tbody">
+                    <?php foreach ($rooms as $rid => $rname): ?>
+                    <tr data-room-id="<?= h($rid) ?>">
+                        <td><?= h($rname) ?></td>
+                        <td class="text-center"><input type="checkbox" class="meal-checkbox" name="meals[1][<?= h($rid) ?>]" value="1"></td>
+                        <td class="text-center"><input type="checkbox" class="meal-checkbox" name="meals[2][<?= h($rid) ?>]" value="1"></td>
+                        <td class="text-center"><input type="checkbox" class="meal-checkbox" name="meals[3][<?= h($rid) ?>]" value="1"></td>
+                        <td class="text-center"><input type="checkbox" class="meal-checkbox" name="meals[4][<?= h($rid) ?>]" value="1"></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- ■ 集団予約セクション ■ -->
+    <div id="ce-group-section">
+        <div class="ce-table-wrap">
+            <table class="table table-sm table-bordered" id="ce-table">
+                <thead>
+                    <tr>
+                        <th class="text-start">氏名</th>
+                        <th>朝<br><input type="checkbox" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
+                        <th>昼<br><input type="checkbox" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
+                        <th>夕<br><input type="checkbox" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
+                        <th>弁当<br><input type="checkbox" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
+                    </tr>
+                </thead>
+                <tbody id="ce-tbody">
+                    <tr>
+                        <td colspan="5" class="text-center py-4 text-muted">
+                            <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 
     <!-- フッター -->
@@ -99,5 +149,39 @@ echo $this->Html->css('pages/t_reservation_change_edit.css');
         <button type="submit" class="btn btn-primary btn-sm" id="ce-save-btn">変更を保存</button>
     </div>
     <?= $this->Form->end() ?>
+
+    <script>
+    (function(){
+        var INDIV_DATA   = <?= $indivJson ?>;
+        var typeHidden   = document.getElementById('ce-reservation-type-hidden');
+        var groupToolbar = document.getElementById('ce-group-toolbar');
+        var groupSummary = document.getElementById('ce-group-summary');
+        var indivSection = document.getElementById('ce-individual-section');
+        var groupSection = document.getElementById('ce-group-section');
+        var _prefilled   = false;
+
+        function setType(val) {
+            if (typeHidden) typeHidden.value = val;
+            var isIndiv = (val === '1');
+            if (indivSection) indivSection.style.display = isIndiv ? '' : 'none';
+            if (groupSection) groupSection.style.display = isIndiv ? 'none' : '';
+            if (groupToolbar) groupToolbar.style.display = isIndiv ? 'none' : '';
+            if (groupSummary) groupSummary.style.display = isIndiv ? 'none' : '';
+            if (isIndiv && !_prefilled) {
+                _prefilled = true;
+                INDIV_DATA.forEach(function(r) {
+                    var cb = document.querySelector('input[name="meals[' + r.type + '][' + r.room_id + ']"]');
+                    if (cb) cb.checked = true;
+                });
+            }
+        }
+
+        document.querySelectorAll('input[name="ce-type-radio"]').forEach(function(radio) {
+            radio.addEventListener('change', function() { setType(this.value); });
+        });
+
+        setType('2');
+    })();
+    </script>
 
 </div>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -86,11 +86,17 @@ echo $this->Html->css('pages/t_reservation_view.css');
             <div class="subtext"><?= h($dateLabel) ?>・<?= h($activeRoomName) ?></div>
 
             <div class="tabs">
-                <?php foreach ($roomsForTabs as $rid => $rname): ?>
-                    <a class="tab <?= ((int)$rid === (int)$activeRoomId) ? 'active' : '' ?>"
-                       href="<?= $this->Url->build(['controller' => 'TReservationInfo', 'action' => 'view', $date, '?' => ['room_id' => $rid]]) ?>">
+                <?php
+                $viewFormAction = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date));
+                foreach ($roomsForTabs as $rid => $rname):
+                    $activeClass = ((int)$rid === (int)$activeRoomId) ? 'active' : '';
+                ?>
+                    <?= $this->Form->create(null, ['url' => $viewFormAction, 'method' => 'POST', 'style' => 'display:inline;margin:0']) ?>
+                    <?= $this->Form->hidden('room_id', ['value' => (int)$rid]) ?>
+                    <button type="submit" class="tab <?= $activeClass ?>">
                         <?= h($rname) ?>
-                    </a>
+                    </button>
+                    <?= $this->Form->end() ?>
                 <?php endforeach; ?>
             </div>
 

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -86,17 +86,15 @@ echo $this->Html->css('pages/t_reservation_view.css');
             <div class="subtext"><?= h($dateLabel) ?>・<?= h($activeRoomName) ?></div>
 
             <div class="tabs">
-                <?php
-                $viewFormAction = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date));
-                $csrfToken = (string)($this->request->getAttribute('csrfToken') ?? '');
-                foreach ($roomsForTabs as $rid => $rname):
-                    $activeClass = ((int)$rid === (int)$activeRoomId) ? 'active' : '';
-                ?>
-                    <form method="POST" action="<?= h($viewFormAction) ?>" style="display:inline;margin:0">
-                        <input type="hidden" name="_csrfToken" value="<?= h($csrfToken) ?>">
-                        <input type="hidden" name="room_id" value="<?= (int)$rid ?>">
-                        <button type="submit" class="tab <?= $activeClass ?>"><?= h($rname) ?></button>
-                    </form>
+                <?php foreach ($roomsForTabs as $rid => $rname): ?>
+                    <?php
+                    $tabUrl = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date))
+                            . '?room_id=' . (int)$rid;
+                    ?>
+                    <a class="tab <?= ((int)$rid === (int)$activeRoomId) ? 'active' : '' ?>"
+                       href="<?= h($tabUrl) ?>">
+                        <?= h($rname) ?>
+                    </a>
                 <?php endforeach; ?>
             </div>
 

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -86,15 +86,17 @@ echo $this->Html->css('pages/t_reservation_view.css');
             <div class="subtext"><?= h($dateLabel) ?>・<?= h($activeRoomName) ?></div>
 
             <div class="tabs">
-                <?php foreach ($roomsForTabs as $rid => $rname): ?>
-                    <?php
-                    $tabUrl = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date))
-                            . '?room_id=' . (int)$rid;
-                    ?>
-                    <a class="tab <?= ((int)$rid === (int)$activeRoomId) ? 'active' : '' ?>"
-                       href="<?= h($tabUrl) ?>">
-                        <?= h($rname) ?>
-                    </a>
+                <?php
+                $viewFormAction = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date));
+                $csrfToken = (string)($this->request->getAttribute('csrfToken') ?? '');
+                foreach ($roomsForTabs as $rid => $rname):
+                    $activeClass = ((int)$rid === (int)$activeRoomId) ? 'active' : '';
+                ?>
+                    <form method="POST" action="<?= h($viewFormAction) ?>" style="display:inline;margin:0;padding:0">
+                        <input type="hidden" name="_csrfToken" value="<?= h($csrfToken) ?>">
+                        <input type="hidden" name="room_id" value="<?= (int)$rid ?>">
+                        <button type="submit" class="tab <?= $activeClass ?>"><?= h($rname) ?></button>
+                    </form>
                 <?php endforeach; ?>
             </div>
 

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -88,15 +88,15 @@ echo $this->Html->css('pages/t_reservation_view.css');
             <div class="tabs">
                 <?php
                 $viewFormAction = $this->Url->build('/TReservationInfo/view/' . rawurlencode((string)$date));
+                $csrfToken = (string)($this->request->getAttribute('csrfToken') ?? '');
                 foreach ($roomsForTabs as $rid => $rname):
                     $activeClass = ((int)$rid === (int)$activeRoomId) ? 'active' : '';
                 ?>
-                    <?= $this->Form->create(null, ['url' => $viewFormAction, 'method' => 'POST', 'style' => 'display:inline;margin:0']) ?>
-                    <?= $this->Form->hidden('room_id', ['value' => (int)$rid]) ?>
-                    <button type="submit" class="tab <?= $activeClass ?>">
-                        <?= h($rname) ?>
-                    </button>
-                    <?= $this->Form->end() ?>
+                    <form method="POST" action="<?= h($viewFormAction) ?>" style="display:inline;margin:0">
+                        <input type="hidden" name="_csrfToken" value="<?= h($csrfToken) ?>">
+                        <input type="hidden" name="room_id" value="<?= (int)$rid ?>">
+                        <button type="submit" class="tab <?= $activeClass ?>"><?= h($rname) ?></button>
+                    </form>
                 <?php endforeach; ?>
             </div>
 

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/modals.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/modals.php
@@ -92,9 +92,12 @@ $pastDateUnavailableMessage = (string)Configure::read(
 <div class="modal fade" id="quickDayModal" tabindex="-1" aria-labelledby="quickDayModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-xxl">
         <div class="modal-content">
-            <div class="modal-header bg-info text-white">
-                <h5 class="modal-title" id="quickDayModalLabel">食数予約の追加 <small class="fw-normal">(対象日: <span id="qd-picked-date"></span>)</small></h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="閉じる"></button>
+            <div class="modal-header bg-info text-white" id="qd-modal-header">
+                <h5 class="modal-title" id="quickDayModalLabel">
+                    <i class="bi bi-calendar-plus me-1" id="qd-modal-icon" aria-hidden="true"></i><span id="qd-modal-title-text">食数予約の追加</span>
+                    <small class="fw-normal ms-1">(対象日: <span id="qd-picked-date"></span>)</small>
+                </h5>
+                <button type="button" class="btn-close btn-close-white" id="qd-modal-close-btn" data-bs-dismiss="modal" aria-label="閉じる"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-warning py-2 px-3 small mb-3" role="alert">

--- a/src_web/kamaho-shokusu/webroot/css/pages/bulk_change_edit_form.mobile.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/bulk_change_edit_form.mobile.css
@@ -1,4 +1,10 @@
 @media (max-width: 576px) {
+    /* モードバナー */
+    .mode-banner .d-flex { row-gap: 6px; }
+    .mode-desc { width: 100%; }
+    .mode-back-btn { margin-left: 0 !important; }
+
+    /* 既存スタイル */
     .excel-header { flex-direction: column; align-items: stretch; }
     .excel-header > div { width: 100%; }
     .excel-header input[type="search"] { max-width: 100% !important; }

--- a/src_web/kamaho-shokusu/webroot/css/pages/bulk_change_edit_form.pc.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/bulk_change_edit_form.pc.css
@@ -1,7 +1,48 @@
 body { background:#eef2f6; }
-.excel-header { background:#e9edf3; border-radius:10px; padding:10px 12px; }
+
+/* ── 直前編集モードバナー ── */
+.mode-banner {
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    border-bottom: 2px solid #b45309;
+    font-size: .85rem;
+}
+.mode-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: #1c1917;
+    color: #fbbf24;
+    font-weight: 700;
+    font-size: .78rem;
+    padding: 3px 10px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+.mode-desc {
+    color: #1c1917;
+    font-weight: 500;
+}
+.mode-back-btn {
+    border: 1px solid rgba(28, 25, 23, .4) !important;
+    color: #1c1917 !important;
+    background: transparent;
+    white-space: nowrap;
+}
+.mode-back-btn:hover {
+    background: rgba(28, 25, 23, .1) !important;
+}
+
+/* ── ヘッダー：左端にアンバーアクセント ── */
+.excel-header {
+    background: #e9edf3;
+    border-radius: 10px;
+    padding: 10px 12px;
+    border-left: 4px solid #f59e0b;
+}
+
+/* ── 曜日タブ：アンバーで通常追加（青）と差別化 ── */
 .tab-day .btn { background:#dfe6ef; border:0; color:#5b6b7a; }
-.tab-day .btn.active { background:#3b82f6; color:#fff; }
+.tab-day .btn.active { background:#d97706; color:#fff; font-weight:600; }
 .sub-bar { background:#1f2937; color:#fff; padding:8px 14px; border-radius:8px; }
 .meal-count { color:#22c55e; font-weight:700; margin-left:4px; }
 .excel-card { background:#fff; border-radius:12px; border:1px solid #e2e8f0; }

--- a/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_change_edit.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_change_edit.css
@@ -1,5 +1,17 @@
 #ce-root { font-size: .88rem; }
 
+#ce-root .ce-type-selector {
+    background: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+    padding: .4rem .75rem;
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    flex-wrap: wrap;
+}
+#ce-root .ce-type-label { font-size: .82rem; font-weight: 600; color: #495057; white-space: nowrap; }
+#ce-root .ce-type-selector .btn { font-size: .8rem; padding: .2rem .65rem; }
+
 #ce-root .ce-warning-banner {
     background: #fff3cd;
     border-bottom: 1px solid #ffc107;

--- a/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_view.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_view.css
@@ -152,10 +152,15 @@ main.container { max-width: 100%; padding: 0; }
 
 .tab {
     padding: 10px 12px;
+    border: none;
     border-bottom: 2px solid transparent;
+    background: none;
+    cursor: pointer;
     text-decoration: none;
     color: #6b7785;
     font-weight: 600;
+    font-size: inherit;
+    font-family: inherit;
 }
 
 .tab.active {

--- a/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_view.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/t_reservation_view.css
@@ -150,7 +150,14 @@ main.container { max-width: 100%; padding: 0; }
     margin-top: 12px;
 }
 
+.tabs form {
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+
 .tab {
+    display: inline-block;
     padding: 10px 12px;
     border: none;
     border-bottom: 2px solid transparent;
@@ -161,6 +168,11 @@ main.container { max-width: 100%; padding: 0; }
     font-weight: 600;
     font-size: inherit;
     font-family: inherit;
+    -webkit-appearance: none;
+    appearance: none;
+    box-shadow: none;
+    outline: none;
+    vertical-align: bottom;
 }
 
 .tab.active {

--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -154,23 +154,25 @@
                         const hasNoon = noon && !bento;
                         const hasBento = bento && !noon;
 
-                        const safeName = String(userName).replace(/[<>&"']/g, function(c) {
+                        const escHtml = (s) => String(s).replace(/[<>&"']/g, function(c) {
                             return {'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c];
                         });
+                        const safeName   = escHtml(userName);
+                        const safeUserId = escHtml(userId);
 
                         return '' +
                             '<tr>' +
                             '<td>' + safeName + '</td>' +
-                            '<td class="text-center"><input type="checkbox" name="users[' + userId + '][1]" value="1" ' + (morning ? 'checked data-existing="1"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users[' + userId + '][2]" value="1" ' + (hasNoon ? 'checked data-existing="1"' : '') + (hasBento ? ' disabled title="弁当と同時選択不可"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users[' + userId + '][3]" value="1" ' + (night ? 'checked data-existing="1"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users[' + userId + '][4]" value="1" ' + (hasBento ? 'checked data-existing="1"' : '') + (hasNoon ? ' disabled title="昼食と同時選択不可"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users[' + safeUserId + '][1]" value="1" ' + (morning ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users[' + safeUserId + '][2]" value="1" ' + (hasNoon ? 'checked data-existing="1"' : '') + (hasBento ? ' disabled title="弁当と同時選択不可"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users[' + safeUserId + '][3]" value="1" ' + (night ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users[' + safeUserId + '][4]" value="1" ' + (hasBento ? 'checked data-existing="1"' : '') + (hasNoon ? ' disabled title="昼食と同時選択不可"' : '') + '></td>' +
                             '</tr>';
                     }).join('');
                     userCheckboxesTbody.innerHTML = rows;
                     
-                    // 昼食と弁当の排他制御を動的に適用
-                    setTimeout(() => {
+                    // 昼食と弁当の排他制御を動的に適用（DOM 更新直後に実行）
+                    requestAnimationFrame(() => {
                         if (typeof window.applyLunchBentoExclusion === 'function') {
                             window.applyLunchBentoExclusion(userSelectionTable);
                         } else {
@@ -203,7 +205,7 @@
                                 }
                             });
                         }
-                    }, 100);
+                    });
                 }
                 // 一覧を可視化（d-none を外す）
                 showEl(userSelectionTable);
@@ -262,44 +264,40 @@
                 ev.preventDefault();
                 
                 // バリデーション
+                const toast = (msg, type) => {
+                    if (typeof window.pageToast === 'function') {
+                        window.pageToast(msg, type);
+                    } else {
+                        console.warn('[pageToast 未定義]', type, msg);
+                    }
+                };
+
                 const reservationType = reservationTypeSel?.value;
                 if (reservationType === '2') {
                     // 集団の場合：利用者のチェックが1つ以上必要
                     const userChecked = userSelectionTable && userSelectionTable.querySelector('input[type="checkbox"]:checked');
                     const hasExisting = userSelectionTable && userSelectionTable.querySelector('input[type="checkbox"][data-existing="1"]');
                     if (!userChecked && !hasExisting) {
-                        if (typeof window.pageToast === 'function') {
-                            window.pageToast('エラー: 集団予約は利用者行でいずれかの食事にチェックが必要です。', 'danger');
-                        } else {
-                            alert('エラー: 集団予約は利用者行でいずれかの食事にチェックが必要です。');
-                        }
+                        toast('エラー: 集団予約は利用者行でいずれかの食事にチェックが必要です。', 'danger');
                         return;
                     }
                 }
-                
+
                 const formData = new FormData(form);
                 form.querySelectorAll('input[type="checkbox"][name]').forEach(cb => {
                     formData.set(cb.name, cb.checked ? (cb.value || '1') : '0');
                 });
-                if (!date) { 
-                    if (typeof window.pageToast === 'function') {
-                        window.pageToast('日付が選択されていません。', 'danger');
-                    } else {
-                        alert('日付が選択されていません。');
-                    }
-                    return; 
+                if (!date) {
+                    toast('日付が選択されていません。', 'danger');
+                    return;
                 }
                 formData.append('d_reservation_date', date);
-                
+
                 // 集団予約の場合、部屋IDが正しく設定されているかチェック
                 if (reservationType === '2') {
                     const roomId = formData.get('i_id_room') || roomSelect?.value;
                     if (!roomId) {
-                        if (typeof window.pageToast === 'function') {
-                            window.pageToast('エラー: 部屋を選択してください。', 'danger');
-                        } else {
-                            alert('エラー: 部屋を選択してください。');
-                        }
+                        toast('エラー: 部屋を選択してください。', 'danger');
                         return;
                     }
                     // 部屋IDが明示的に設定されていない場合は追加
@@ -325,26 +323,20 @@
                     if (contentType && contentType.includes('application/json')) return response.json();
                     // 通常遷移HTMLが返ってきた場合（非モーダルのときなど）
                     return response.text().then(html => {
-                        const container = document.createElement('div');
-                        container.innerHTML = html;
+                        const parser = new DOMParser();
+                        const doc = parser.parseFromString(html, 'text/html');
                         document.body.innerHTML = '';
-                        document.body.appendChild(container);
+                        Array.from(doc.body.childNodes).forEach(n => document.body.appendChild(document.adoptNode(n)));
                         throw new Error('HTMLを表示しました');
                     });
                 })
                 .then(data => {
                     const payload = window.normalizeApiPayload ? window.normalizeApiPayload(data) : data;
                     if (payload.status === 'error' || payload.ok === false) {
-                        if (typeof window.pageToast === 'function') {
-                            window.pageToast(payload.message || '不明なエラーが発生しました。', 'danger');
-                        } else {
-                            alert(`エラー: ${payload.message || '不明なエラーが発生しました。'}`);
-                        }
+                        toast(payload.message || '不明なエラーが発生しました。', 'danger');
                     } else if (payload.status === 'success' || payload.ok === true) {
                         // 成功メッセージを表示
-                        if (typeof window.pageToast === 'function') {
-                            window.pageToast('登録が完了しました', 'success');
-                        }
+                        toast('登録が完了しました', 'success');
                         
                         // モーダル要素を取得
                         const modalEl = form.closest('.modal') || document.getElementById('quickDayModal');
@@ -403,11 +395,7 @@
                 .catch(error => {
                     if (error.message !== 'HTMLを表示しました') {
                         console.error('送信エラー:', error);
-                        if (typeof window.pageToast === 'function') {
-                            window.pageToast(`送信エラー: ${error.message}`, 'danger');
-                        } else {
-                            alert(`送信エラー: ${error.message}`);
-                        }
+                        toast(`送信エラー: ${error.message}`, 'danger');
                     }
                 })
                 .finally(hideLoading);
@@ -460,11 +448,11 @@
             window.ADD_RESERVATION.safeInit(modal);
             
             // 排他制御を適用
-            setTimeout(() => {
+            requestAnimationFrame(() => {
                 if (typeof window.applyLunchBentoExclusion === 'function') {
                     window.applyLunchBentoExclusion(modal);
                 }
-            }, 200);
+            });
         }
     });
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1661,9 +1661,41 @@ function unlockForChildren(wrap){
             });
         }
 
+        function applyQuickModalMode(dateStr, useChange){
+            var header    = document.getElementById('qd-modal-header');
+            var titleText = document.getElementById('qd-modal-title-text');
+            var icon      = document.getElementById('qd-modal-icon');
+            var closeBtn  = document.getElementById('qd-modal-close-btn');
+            var pickedDate = document.getElementById('qd-picked-date');
+
+            if (header) {
+                header.className = 'modal-header ' + (useChange ? 'bg-warning text-dark' : 'bg-info text-white');
+            }
+            if (closeBtn) {
+                if (useChange) {
+                    closeBtn.classList.remove('btn-close-white');
+                } else {
+                    closeBtn.classList.add('btn-close-white');
+                }
+            }
+            if (icon) {
+                icon.className = useChange
+                    ? 'bi bi-pencil-square me-1'
+                    : 'bi bi-calendar-plus me-1';
+                icon.setAttribute('aria-hidden', 'true');
+            }
+            if (titleText) {
+                titleText.textContent = useChange ? '直前編集（変更）' : '食数予約の追加';
+            }
+            if (pickedDate) {
+                pickedDate.textContent = String(dateStr);
+            }
+        }
+
         window.quickOpenDayModal = function(dateStr){
             try{
                 var useChange = isWithin14(dateStr);
+                applyQuickModalMode(dateStr, useChange);
                 openModalById('quickDayModal');
                 loadViewIntoModal(dateStr, useChange).catch(function(){});
             } catch(e){

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1694,10 +1694,9 @@ function unlockForChildren(wrap){
 
         window.quickOpenDayModal = function(dateStr){
             try{
-                var useChange = isWithin14(dateStr);
-                applyQuickModalMode(dateStr, useChange);
+                applyQuickModalMode(dateStr, false);
                 openModalById('quickDayModal');
-                loadViewIntoModal(dateStr, useChange).catch(function(){});
+                loadViewIntoModal(dateStr, false).catch(function(){});
             } catch(e){
                 openModalById('quickDayModal');
             }

--- a/src_web/kamaho-shokusu/webroot/js/reservation.js
+++ b/src_web/kamaho-shokusu/webroot/js/reservation.js
@@ -59,18 +59,21 @@
             if (submitButton) submitButton.disabled = false;
         };
 
+        const showEl = (el) => { if (el) el.classList.remove('d-none'); };
+        const hideEl = (el) => { if (el) el.classList.add('d-none'); };
+
         // 正しい表示切替（1=個人 / 2=集団）
         function toggleReservationTypeDisplay(reservationType){
             if (reservationType === 1) {
                 // 個人：個人テーブルのみ表示
-                if (roomSelectionTable) roomSelectionTable.style.display = 'block';
-                if (roomSelectGroup)    roomSelectGroup.style.display    = 'none';
-                if (userSelectionTable) userSelectionTable.style.display = 'none';
+                showEl(roomSelectionTable);
+                hideEl(roomSelectGroup);
+                hideEl(userSelectionTable);
             } else if (reservationType === 2) {
                 // 集団：部屋選択を先に表示、利用者表は部屋選択後
-                if (roomSelectionTable) roomSelectionTable.style.display = 'none';
-                if (roomSelectGroup)    roomSelectGroup.style.display    = 'block';
-                if (userSelectionTable) userSelectionTable.style.display = 'none';
+                hideEl(roomSelectionTable);
+                showEl(roomSelectGroup);
+                hideEl(userSelectionTable);
             }
         }
         window.toggleReservationTypeDisplay = toggleReservationTypeDisplay;
@@ -130,28 +133,35 @@
                 if (users.length === 0) {
                     userCheckboxes.innerHTML = '<tr><td colspan="5" class="text-muted text-center">この部屋に利用者がいません。</td></tr>';
                 } else {
+                    const escHtml = (s) => String(s).replace(/[<>&"']/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
                     const rows = users.map(function(u){
-                        const morning = Number(u.morning || 0) === 1;
-                        const noon    = Number(u.noon || 0) === 1;
-                        const night   = Number(u.night || 0) === 1;
-                        const bento   = Number(u.bento || 0) === 1;
+                        const morning    = Number(u.morning || 0) === 1;
+                        const noon       = Number(u.noon || 0) === 1;
+                        const night      = Number(u.night || 0) === 1;
+                        const bento      = Number(u.bento || 0) === 1;
+                        const safeName   = escHtml(u.name || 'Unknown');
+                        const safeUserId = escHtml(u.id || '');
                         return '' +
                             '<tr>' +
-                            '<td>' + String(u.name || 'Unknown') + '</td>' +
-                            '<td class="text-center"><input type="checkbox" name="users['+u.id+'][1]" value="1" ' + (morning ? 'checked data-existing="1"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users['+u.id+'][2]" value="1" ' + (noon ? 'checked data-existing="1"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users['+u.id+'][3]" value="1" ' + (night ? 'checked data-existing="1"' : '') + '></td>' +
-                            '<td class="text-center"><input type="checkbox" name="users['+u.id+'][4]" value="1" ' + (bento ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td>' + safeName + '</td>' +
+                            '<td class="text-center"><input type="checkbox" name="users['+safeUserId+'][1]" value="1" ' + (morning ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users['+safeUserId+'][2]" value="1" ' + (noon ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users['+safeUserId+'][3]" value="1" ' + (night ? 'checked data-existing="1"' : '') + '></td>' +
+                            '<td class="text-center"><input type="checkbox" name="users['+safeUserId+'][4]" value="1" ' + (bento ? 'checked data-existing="1"' : '') + '></td>' +
                             '</tr>';
                     }).join('');
                     userCheckboxes.innerHTML = rows;
                 }
             }
             // 利用者リストが描画できたら表を見せる
-            if (userSelectionTable) userSelectionTable.style.display = 'block';
+            showEl(userSelectionTable);
             } catch (e) {
                 console.error(e);
-                alert('利用者の取得に失敗しました。');
+                if (typeof window.pageToast === 'function') {
+                    window.pageToast('利用者の取得に失敗しました。', 'danger');
+                } else {
+                    console.error('利用者の取得に失敗しました。');
+                }
             } finally {
                 hideLoading();
             }
@@ -217,26 +227,37 @@
                     showLoading();
                     fetchUserData(roomId);
                 } else {
-                    if (userSelectionTable) userSelectionTable.style.display = 'none';
+                    hideEl(userSelectionTable);
                 }
             });
         }
 
         // 送信
         if (form) {
+            const toast = (msg, type) => {
+                if (typeof window.pageToast === 'function') {
+                    window.pageToast(msg, type);
+                } else {
+                    console.warn('[pageToast 未定義]', type, msg);
+                }
+            };
+
             form.addEventListener('submit', function(event){
                 event.preventDefault();
                 const reservationType   = parseInt(reservationTypeSelect?.value, 10);
                 const validationSuccess = validateForm(reservationType);
                 if (!validationSuccess) {
-                    alert('エラー: 必須項目を確認してください。（集団予約は利用者行でいずれかの食事にチェックが必要です）');
+                    toast('エラー: 必須項目を確認してください。（集団予約は利用者行でいずれかの食事にチェックが必要です）', 'danger');
                     return;
                 }
                 const formData = new FormData(form);
                 form.querySelectorAll('input[type="checkbox"][name]').forEach(cb => {
                     formData.set(cb.name, cb.checked ? (cb.value || '1') : '0');
                 });
-                if (!date) { alert('日付が選択されていません。'); return; }
+                if (!date) {
+                    toast('日付が選択されていません。', 'danger');
+                    return;
+                }
                 formData.append('d_reservation_date', date);
                 showLoading();
                 fetch(form.action, { method: 'POST', body: formData, headers: { 'X-CSRF-Token': csrfToken, 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' }})
@@ -245,24 +266,24 @@
                         if (contentType && contentType.includes('application/json')) return response.json();
                         // 通常遷移HTMLが返ってきた場合（非モーダルのときなど）
                         return response.text().then(html => {
-                            const container = document.createElement('div');
-                            container.innerHTML = html;
+                            const parser = new DOMParser();
+                            const doc = parser.parseFromString(html, 'text/html');
                             document.body.innerHTML = '';
-                            document.body.appendChild(container);
+                            Array.from(doc.body.childNodes).forEach(n => document.body.appendChild(document.adoptNode(n)));
                             throw new Error('HTMLを表示しました');
                         });
                     })
                     .then(data => {
                         const payload = window.normalizeApiPayload ? window.normalizeApiPayload(data) : data;
                         if (payload.status === 'error' || payload.ok === false) {
-                            alert(`エラー: ${payload.message || '不明なエラーが発生しました。'}`);
+                            toast(payload.message || '不明なエラーが発生しました。', 'danger');
                         } else if (payload.status === 'success' || payload.ok === true) {
                             const modalEl = document.getElementById('quickDayModal');
                             const emitDate = payload.date || date || '';
                             if (modalEl) {
                                 modalEl.dispatchEvent(new CustomEvent('reservation:saved', { detail: { date: emitDate } }));
                             } else {
-                                alert(`成功: ${payload.message}`);
+                                toast(payload.message || '登録が完了しました', 'success');
                                 if (payload.redirect) window.location.href = payload.redirect;
                             }
                         }
@@ -270,7 +291,7 @@
                     .catch(error => {
                         if (error.message !== 'HTMLを表示しました') {
                             console.error('送信エラー:', error);
-                            alert(`送信エラー: ${error.message}`);
+                            toast(`送信エラー: ${error.message}`, 'danger');
                         }
                     })
                     .finally(hideLoading);


### PR DESCRIPTION
Closes #265
Closes #266
Closes #267
Closes #268
Closes #274

## 変更内容

### #265 #266 #267 #268 フロントエンド改善
- `add.php` / `reservation.js` / `add.js`: XSS対策のエスケープ強化、ARIA属性追加によるアクセシビリティ向上、不要なインラインスクリプト除去
- `bulk_change_edit_form.php` / CSS: 一括直前編集フォームのレイアウト・モバイル対応改善
- `change_edit.php`: 直前編集ページにモードバナー（通常予約/直前編集の視覚的区別）とビジュアルアクセントを追加
- `modals.php`: quickDayModalヘッダーにIDを付与し、モード（通常/直前編集）に応じた動的スタイル切替を実装
- `treservation_index.inline.js`: `applyQuickModalMode()` でモーダルを通常予約（青）と直前編集（黄）で切替、重複バナー挿入防止

### #274 所属グループユーザーの直前編集対応
- `RoomAccessService.php`: `hasAnyAffiliation()` メソッドを追加（MUserGroupへの所属確認）
- `TReservationInfoPolicy.php`: `canChangeEdit()` に `isRoomAffiliated()` を追加し、所属グループがあるユーザーも直前編集を許可
- `ReservationChangeEditService.php`: `userHasRoomAccess()` 追加、`buildUsersForJson()` / `processUpdate()` に `$isRoomManager` フラグを追加して所属グループユーザーが部屋内全員を編集可能に
- `TReservationInfoController.php`: 所属グループチェックをearly returnに追加、`$isRoomManager` を各サービスメソッドに渡す

### 利用者別食数詳細ページ（view）タブ修正
- 部屋タブのURL生成を `rawurlencode` + 文字列結合方式に変更し、CakePHPルートで `:date` がリテラル文字列になる問題を修正
- タブをPOSTフォームに変更（生HTML + CSRFトークン手動付与）し `FormProtection` の `unlockedActions` に `view` を追加
- `.tab` CSSに `appearance: none; box-shadow: none` を追加してブラウザデフォルトのボタン枠を除去