### PR TITLE
fix: Slack通知の送信者名をDeployBotに修正

### DIFF
--- a/.github/workflows/db_backup.yml
+++ b/.github/workflows/db_backup.yml
@@ -35,6 +35,8 @@ jobs:
           curl -fsSL -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-type: application/json' \
             -d '{
+              "username": "DeployBot",
+              "icon_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
               "attachments": [{
                 "color": "good",
                 "title": "DB Backup / Success",
@@ -50,6 +52,8 @@ jobs:
           curl -fsSL -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-type: application/json' \
             -d "{
+              \"username\": \"DeployBot\",
+              \"icon_url\": \"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\",
               \"attachments\": [{
                 \"color\": \"danger\",
                 \"title\": \"DB Backup / Failure\",


### PR DESCRIPTION
## Summary
- curlペイロードに `"username": "DeployBot"` と `"icon_url"` を追加
- rtCamp/action-slack-notify@v2 から curl に移行した際、`SLACK_USERNAME` env var の代替が漏れていたことが原因
- 成功・失敗両方の通知に対応

## Root Cause
`rtCamp/action-slack-notify@v2` では `SLACK_USERNAME: DeployBot` で表示名を設定していたが、curl置き換え後にJSONペイロードへの `username` フィールドの追加が漏れ、Slackがデフォルト名 "Incoming Webhook" を使用するようになっていた。

## Test plan
- [ ] workflow_dispatch で手動実行してSlack通知がDeployBotとして届くことを確認