### PR TITLE
fix: #277 エクセル食数予約でグリッドが全セル空白になるバグを修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1768,8 +1768,11 @@ class TReservationInfoController extends AppController
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $loginUserId);
         $canViewAll   = $isAdmin || $isOfficeUser;
 
+        // 前回の表示状態をセッションから復元（クエリパラメータが優先）
+        $session = $this->request->getSession();
+
         // 表示モード: 個人 / 各部屋 / 全部
-        $viewMode = $this->request->getQuery('mode') ?? 'individual';
+        $viewMode = $this->request->getQuery('mode') ?? $session->read('mealCountGrid.mode') ?? 'individual';
         if (!in_array($viewMode, ['individual', 'room', 'all'], true)) {
             $viewMode = 'individual';
         }
@@ -1792,10 +1795,12 @@ class TReservationInfoController extends AppController
             $allRooms = array_intersect_key($allRooms, array_flip($userRoomIds));
         }
 
-        // 選択中の部屋
-        $selectedRoomId = $this->request->getQuery('room_id')
-            ? (int)$this->request->getQuery('room_id')
-            : (!empty($allRooms) ? (int)array_key_first($allRooms) : null);
+        // 選択中の部屋（クエリ → セッション → デフォルト）
+        $roomIdQuery = $this->request->getQuery('room_id');
+        $sessionRoomId = $session->read('mealCountGrid.roomId');
+        $selectedRoomId = $roomIdQuery
+            ? (int)$roomIdQuery
+            : ($sessionRoomId !== null ? (int)$sessionRoomId : (!empty($allRooms) ? (int)array_key_first($allRooms) : null));
         if ($selectedRoomId !== null && !isset($allRooms[$selectedRoomId])) {
             $selectedRoomId = !empty($allRooms) ? (int)array_key_first($allRooms) : null;
         }
@@ -1803,20 +1808,18 @@ class TReservationInfoController extends AppController
         $gridService = new \App\Service\MealCountGridService();
         $today       = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
 
-        // 4週間ナビゲーション（4週単位で移動）
-        $weekNav       = $gridService->resolveWeekNavigation(
-            $this->request->getQuery('week'),
-            $isAdmin,
-            $today
-        );
+        // 4週間ナビゲーション（クエリ → セッション → デフォルト）
+        $weekParam     = $this->request->getQuery('week') ?? $session->read('mealCountGrid.week');
+        $weekNav       = $gridService->resolveWeekNavigation($weekParam, $isAdmin, $today);
         $weekMondayStr = $weekNav['weekMondayStr'];
         $dates         = $gridService->buildDateRange($weekMondayStr, 28); // 4週間=28日
         $periodLabel   = $gridService->buildPeriodLabel($dates);
 
         // 表示対象ユーザーを先に確定（individual モードの部屋自動決定に使う）
-        $selectedUserId = $this->request->getQuery('user_id')
-            ? (int)$this->request->getQuery('user_id')
-            : $loginUserId;
+        $userIdQuery = $this->request->getQuery('user_id');
+        $selectedUserId = $userIdQuery
+            ? (int)$userIdQuery
+            : ($canViewAll ? (int)($session->read('mealCountGrid.userId') ?? $loginUserId) : $loginUserId);
         if (!$canViewAll) {
             $selectedUserId = $loginUserId;
         }
@@ -1873,6 +1876,14 @@ class TReservationInfoController extends AppController
             } else {
                 $nameList[$loginUserId] = $loginName;
             }
+        }
+
+        // 表示状態をセッションに保存（次回アクセス時のデフォルト値として使用）
+        $session->write('mealCountGrid.week', $weekMondayStr);
+        $session->write('mealCountGrid.mode', $viewMode);
+        $session->write('mealCountGrid.roomId', $selectedRoomId);
+        if ($canViewAll) {
+            $session->write('mealCountGrid.userId', $selectedUserId);
         }
 
         $this->set([

--- a/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
@@ -372,6 +372,10 @@ class MealCountGridService
         if ($value instanceof \DateTimeInterface) {
             return $value->format('Y-m-d');
         }
+        // Cake\I18n\Date does not implement DateTimeInterface but has format()
+        if (is_object($value) && method_exists($value, 'format')) {
+            return $value->format('Y-m-d');
+        }
         return (string)$value;
     }
 }

--- a/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
@@ -282,12 +282,6 @@ class MealCountGridService
             $change = $row['i_change_flag'];
             $eat    = $row['eat_flag'];
 
-            $dateObj = new Date($date);
-            if ($dateObj <= $borderDate) {
-                $effective = $change !== null ? (int)$change : (int)($eat ?? 0);
-            } else {
-                $effective = (int)($eat ?? 0);
-            }
             // i_change_flag が設定済み(直前編集あり)ならそれを優先。
             // 未設定(NULL)の場合は eat_flag にフォールバック。
             // 過去日・未来日問わず直前編集を優先することで、

--- a/src_web/kamaho-shokusu/webroot/js/bulk_add_form.js
+++ b/src_web/kamaho-shokusu/webroot/js/bulk_add_form.js
@@ -558,9 +558,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 selectionsByRoom[roomId][activeDate][uid] = selectionsByRoom[roomId][activeDate][uid] || {};
                 serverReservedByRoom[roomId][activeDate][uid][Number(type)] = true;
-                if (selectionsByRoom[roomId][activeDate][uid][Number(type)] !== false) {
-                    selectionsByRoom[roomId][activeDate][uid][Number(type)] = true;
-                }
+                selectionsByRoom[roomId][activeDate][uid][Number(type)] = true;
             });
         });
     }

--- a/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
+++ b/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
@@ -553,6 +553,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function applyLocks(resMap) {
         ensureState(activeDate);
         locked[activeDate] = {};
+        // 前回のサーバー既読状態を退避してからリセット
+        // - previousServerReserved が存在する = このセッションで一度サーバーデータを読み込み済み
+        // - その場合はユーザーが意図してfalseにした状態（キャンセル操作）を保持する
+        // - previousServerReserved が存在しない = ページ初回ロードや初めてこの日付を見た場合
+        // - この場合はlocalStorageの古いfalseを無視してサーバー状態を必ず反映する
+        const previousServerReserved = serverReserved[activeDate] ? { ...serverReserved[activeDate] } : null;
         serverReserved[activeDate] = {};
         Object.keys(resMap || {}).forEach((uid) => {
             locked[activeDate][uid] = locked[activeDate][uid] || {};
@@ -564,7 +570,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 selections[activeDate][uid] = selections[activeDate][uid] || {};
                 serverReserved[activeDate][uid][Number(type)] = true;
-                if (selections[activeDate][uid][Number(type)] !== false) {
+                const wasAlreadyLoadedFromServer = !!(previousServerReserved?.[uid]?.[Number(type)]);
+                if (selections[activeDate][uid][Number(type)] !== false || !wasAlreadyLoadedFromServer) {
                     selections[activeDate][uid][Number(type)] = true;
                 }
             });


### PR DESCRIPTION
Closes #277

## 原因

`MealCountGridService::normalizeDateString()` で日付形式の不一致が発生していた。

CakePHP 5 の `Cake\I18n\Date` は PHP の `\DateTimeInterface` を実装していない。
そのため `instanceof \DateTimeInterface` チェックが `false` となり
`(string)$value` にフォールバックしてロケール形式 `"6/2/26"` が返されていた。

一方 `buildDateRange()` は ISO 形式 `"2026-06-02"` の文字列を生成するため、
マップのキーが一致せず **全セルが予約なし** と判定されていた。

この結果、ページ再ロード時に PHP がグリッドをゼロから描画すると
すべてのセルが空白になっていた（登録直後は JS が DOM を直接更新するため
一時的に "1" が表示されていたが、ページ遷移後に消える）。

## 変更内容

### `MealCountGridService.php` — 根本原因の修正
- `normalizeDateString()` に `method_exists($value, 'format')` チェックを追加
- `Cake\I18n\Date` を含む `format()` メソッドを持つすべてのオブジェクトに対して `format('Y-m-d')` を呼び出すよう修正

### `TReservationInfoController.php` — セッションによる表示状態の復元
- ダッシュボード等から URL パラメータなしで再アクセスした場合に、前回の表示状態（週・モード・部屋・ユーザー）をセッションから復元するよう修正
- セッション優先順位: クエリパラメータ > セッション値 > デフォルト値

### `MealCountGridService.php` — デッドコード削除
- `buildGrid()` 内のデッドコード（`eat_flag` のみを参照する条件分岐）を削除し、`i_change_flag` 優先の統一ロジックに整理

### `bulk_add_form.js` / `bulk_change_edit_form.js` — localStorage 古い false 状態の修正
- 初回ロード時に localStorage の古い `false` 状態が予約情報表示を妨げるバグを修正
- `bulk_change_edit_form.js` で `previousServerReserved` パターンを導入し、ユーザーが意図したキャンセル操作を保持しつつ古い状態を無視するよう改善