### PR TITLE
fix: PR#276マージで削除されたエクセル食数予約の関連ファイルを復元

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -229,6 +229,12 @@ return function (RouteBuilder $routes): void {
             ['controller' => 'TReservationInfo', 'action' => 'myActualMeal']
         )->setMethods(['GET']);
 
+        // 食数予約 Excel グリッド画面（28日）
+        $builder->connect(
+            '/TReservationInfo/meal-count-grid',
+            ['controller' => 'TReservationInfo', 'action' => 'mealCountGrid']
+        )->setMethods(['GET']);
+
         // 予約コピープレビューAPI
         $builder->connect(
             '/TReservationInfo/copyPreview',

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -155,6 +155,11 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                     <div class="menu-title-text">食数予約</div>
                     <div class="menu-desc">将来の食事予定を一括登録する</div>
                 </button>
+                <a class="menu-card" href="<?= $this->Url->build('/TReservationInfo/meal-count-grid') ?>">
+                    <div class="menu-icon" style="background:#e8fdf5;color:#0f7a50;">📊</div>
+                    <div class="menu-title-text">エクセル食数予約(プレビュー版)</div>
+                    <div class="menu-desc">Excelライクな4週間分の予約を管理する</div>
+                </a>
                 <button class="menu-card border-0 text-start" type="button" id="actual-meal-choice-trigger">
                     <div class="menu-icon" style="background:#fef3c7;color:#d97706;">✅</div>
                     <div class="menu-title-text">実食入力</div>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/meal_count_grid.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/meal_count_grid.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * 食数予約 Excel グリッド画面
+ *
+ * @var \App\View\AppView $this
+ * @var array  $allRooms       [roomId => roomName]
+ * @var int|null $selectedRoomId
+ * @var array  $nameList       [userId => userName]（個人モード用）
+ * @var int    $selectedUserId
+ * @var string $viewMode       'individual' | 'room' | 'all'
+ * @var array  $gridData       {dates, meals, rooms, dailyTotals}
+ * @var array  $monthlyTotals  [mealType => int]
+ * @var array  $dateCategories [date => 'past'|'last_minute'|'normal']
+ * @var string $weekMondayStr  YYYY-MM-DD
+ * @var string $periodLabel    表示期間ラベル
+ * @var \DateTimeImmutable $prevMonday
+ * @var \DateTimeImmutable $nextMonday
+ * @var bool   $canGoPrev
+ * @var bool   $canGoNext
+ * @var bool   $isAdmin
+ * @var bool   $canViewAll
+ * @var int    $loginUserId
+ * @var string $loginName
+ */
+
+$this->assign('title', 'エクセル食数予約');
+
+$csrfToken = $this->request->getAttribute('csrfToken') ?? '';
+$basePath  = $this->request->getAttribute('base') ?? '';
+
+$dates          = $gridData['dates']       ?? [];
+$meals          = $gridData['meals']       ?? [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁'];
+$roomsData      = $gridData['rooms']       ?? [];
+$dailyTotals    = $gridData['dailyTotals'] ?? [];
+$dateCategories = $dateCategories          ?? [];
+
+$today      = date('Y-m-d');
+$dow        = ['日', '月', '火', '水', '木', '金', '土'];
+
+// 日付ラベル (n/j + 曜日)
+$dateLabels = [];
+foreach ($dates as $d) {
+    $dt = new \DateTimeImmutable($d);
+    $dateLabels[$d] = $dt->format('n/j') . "\n" . $dow[(int)$dt->format('w')];
+}
+
+// モード別 URL 生成ヘルパー
+$makeUrl = function (array $params) use ($viewMode, $selectedRoomId, $selectedUserId, $weekMondayStr, $basePath): string {
+    $p = array_merge([
+        'mode'    => $viewMode,
+        'room_id' => $selectedRoomId,
+        'user_id' => $selectedUserId,
+        'week'    => $weekMondayStr,
+    ], $params);
+    $qs = http_build_query(array_filter($p, fn($v) => $v !== null && $v !== ''));
+    return $basePath . '/TReservationInfo/meal-count-grid' . ($qs ? '?' . $qs : '');
+};
+
+$prevUrl   = $makeUrl(['week' => $prevMonday->format('Y-m-d')]);
+$nextUrl   = $makeUrl(['week' => $nextMonday->format('Y-m-d')]);
+$todayUrl  = $makeUrl(['week' => date('Y-m-d', strtotime('monday this week'))]);
+
+// 選択セル情報（数式バー表示用）
+// 行番号は全ユーザーを通じた連番
+$rowOffset = 0;
+foreach ($roomsData as $rid => $ri) {
+    foreach ($ri['users'] as $u) { $rowOffset++; }
+}
+$totalRows = $rowOffset;
+
+// CSS・JS をレイアウトの <head> / </body> 直前ブロックに注入
+$this->Html->css('pages/meal_count_grid.css', ['block' => true]);
+$this->append('script', sprintf(
+    '<script>window.MCG_CONFIG = %s;</script>',
+    json_encode(['basePath' => $basePath, 'rooms' => $allRooms], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+));
+$this->Html->script('japanese-holidays.min.js', ['block' => true]);
+$this->Html->script('pages/meal_count_grid.js', ['block' => true]);
+?>
+
+<div class="excel-window">
+
+    <!-- ═══════════════════════════════════════════
+         ツールバー（フィルター + 期間ナビ）
+    ═══════════════════════════════════════════ -->
+    <div class="mcg-toolbar">
+        <!-- 表示モード -->
+        <span class="mcg-toolbar-label">表示</span>
+        <select id="js-mode-select" onchange="mcgChangeMode(this.value)"
+                <?= !$canViewAll ? 'disabled' : '' ?>>
+            <option value="individual" <?= $viewMode === 'individual' ? 'selected' : '' ?>>個人</option>
+            <?php if ($canViewAll): ?>
+            <option value="room"       <?= $viewMode === 'room'       ? 'selected' : '' ?>>各部屋</option>
+            <option value="all"        <?= $viewMode === 'all'        ? 'selected' : '' ?>>全部</option>
+            <?php endif; ?>
+        </select>
+
+        <?php if ($viewMode !== 'individual'): ?>
+        <div class="mcg-toolbar-sep"></div>
+
+        <!-- 部屋（room / all モードのみ表示） -->
+        <span class="mcg-toolbar-label">部屋</span>
+        <div class="mcg-room-btngroup" id="js-room-btngroup">
+            <?php foreach ($allRooms as $rid => $rname): ?>
+                <button type="button"
+                        class="mcg-room-btn<?= (int)$rid === $selectedRoomId ? ' active' : '' ?>"
+                        data-room-id="<?= h($rid) ?>"
+                        <?= ($viewMode === 'all') ? 'disabled' : '' ?>
+                        onclick="mcgChangeRoom(this.dataset.roomId)"
+                ><?= h($rname) ?></button>
+            <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
+
+        <!-- 氏名（固定表示） -->
+        <?php if ($viewMode === 'individual'): ?>
+        <span class="mcg-toolbar-label">表示ユーザー</span>
+        <span class="mcg-toolbar-user-name"><?= h($nameList[$selectedUserId] ?? $loginName) ?></span>
+        <?php endif; ?>
+
+        <!-- 期間ナビ -->
+        <div class="mcg-period-group">
+            <span class="mcg-toolbar-label">期間</span>
+            <span class="mcg-period-label-text"><?= h($periodLabel) ?></span>
+
+            <?php if ($canGoPrev): ?>
+                <a href="<?= h($prevUrl) ?>" class="mcg-nav-btn">◄ 前4週</a>
+            <?php else: ?>
+                <button class="mcg-nav-btn" disabled>◄ 前4週</button>
+            <?php endif; ?>
+
+            <a href="<?= h($todayUrl) ?>" class="mcg-nav-btn today">今日</a>
+
+            <?php if ($canGoNext): ?>
+                <a href="<?= h($nextUrl) ?>" class="mcg-nav-btn">翌4週 ►</a>
+            <?php else: ?>
+                <button class="mcg-nav-btn" disabled>翌4週 ►</button>
+            <?php endif; ?>
+        </div>
+
+        <!-- 凡例 -->
+        <div class="mcg-legend">
+            <span class="mcg-legend-item mcg-legend-last-minute">直前（当日〜14日後）</span>
+            <span class="mcg-legend-item mcg-legend-past">過去日（変更不可）</span>
+        </div>
+
+        <!-- 登録ボタン -->
+        <button id="mcg-register-btn" type="button" disabled>登録</button>
+    </div>
+
+    <!-- ═══════════════════════════════════════════
+         メインコンテンツ
+    ═══════════════════════════════════════════ -->
+    <div class="excel-content">
+        <div class="excel-body">
+
+            <!-- グリッド -->
+            <div class="mcg-grid-wrap">
+            <?php if (empty($roomsData)): ?>
+                <div style="padding:24px;color:#666">表示対象のデータがありません。</div>
+            <?php else: ?>
+                <table class="mcg-grid" role="grid">
+                    <thead>
+                        <!-- 日付ヘッダー行 -->
+                        <tr class="header-dates">
+                            <th class="col-row">行</th>
+                            <th class="col-room">部屋</th>
+                            <th class="col-name">氏名</th>
+                            <?php foreach ($dates as $d):
+                                $dt      = new \DateTimeImmutable($d);
+                                $dowIdx  = (int)$dt->format('w');
+                                $isToday = ($d === $today);
+                                $isSat   = ($dowIdx === 6);
+                                $isSun   = ($dowIdx === 0);
+                                $dateCat      = $dateCategories[$d] ?? 'normal';
+                                $isLastMinute = ($dateCat === 'last_minute');
+                                $isPastDate   = ($dateCat === 'past');
+                                $cls = 'date-group'
+                                    . ($isToday       ? ' is-today'       : '')
+                                    . ($isSat         ? ' is-saturday'    : '')
+                                    . ($isSun         ? ' is-sunday'      : '')
+                                    . ($isLastMinute  ? ' is-last-minute' : '')
+                                    . ($isPastDate    ? ' is-past-header' : '');
+                            ?>
+                                <th colspan="<?= count($meals) ?>" class="<?= h($cls) ?>" data-date="<?= h($d) ?>"
+                                    <?php if ($isLastMinute): ?>
+                                    data-tooltip="直前編集ウィンドウ（当日〜14日後）&#10;・予約のON/OFFを変更できます&#10;・職員はこの期間のキャンセルができません&#10;・変更は「登録」ボタンで確定します"
+                                    <?php elseif ($isPastDate): ?>
+                                    data-tooltip="過去日のため変更できません。"
+                                    <?php endif; ?>
+                                >
+                                    <?= h($dt->format('n/j')) ?><br>
+                                    <small><?= h($dow[$dowIdx]) ?></small>
+                                </th>
+                            <?php endforeach; ?>
+                        </tr>
+
+                        <!-- 食事種別ヘッダー行 -->
+                        <tr class="header-meals">
+                            <th class="col-row"></th>
+                            <th class="col-room"></th>
+                            <th class="col-name"></th>
+                            <?php foreach ($dates as $d):
+                                $isToday = ($d === $today);
+                                $dowIdx  = (int)(new \DateTimeImmutable($d))->format('w');
+                                $isSat   = ($dowIdx === 6);
+                                $isSun   = ($dowIdx === 0);
+                                $dateCat = $dateCategories[$d] ?? 'normal';
+                                $first   = true;
+                                foreach ($meals as $mealType => $mealLabel):
+                                    $cls = ($first ? 'meal-first ' : '')
+                                        . ($isToday ? 'is-today ' : '')
+                                        . ($isSat   ? 'is-saturday ' : '')
+                                        . ($isSun   ? 'is-sunday ' : '')
+                                        . ($dateCat === 'last_minute' ? 'is-last-minute' : '');
+                                    $first = false;
+                            ?>
+                                <th class="<?= h(trim($cls)) ?>" data-date="<?= h($d) ?>"><?= h($mealLabel) ?></th>
+                            <?php endforeach; endforeach; ?>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <?php
+                        $rowNum = 1;
+                        foreach ($roomsData as $roomId => $roomInfo):
+                            $roomName = $roomInfo['name'];
+                            $users    = $roomInfo['users'];
+                            $grid     = $roomInfo['grid'];
+                        ?>
+
+                        <?php foreach ($users as $u):
+                            $uid = (int)$u['id'];
+                        ?>
+                        <tr data-user-id="<?= h($uid) ?>" data-room-id="<?= h($roomId) ?>">
+                            <td class="col-row"><?= h($rowNum++) ?></td>
+                            <td class="col-room" title="<?= h($roomName) ?>"><?= h($roomName) ?></td>
+                            <td class="col-name" title="<?= h($u['name']) ?>"><?= h($u['name']) ?></td>
+                            <?php foreach ($dates as $d):
+                                $dt      = new \DateTimeImmutable($d);
+                                $dowIdx  = (int)$dt->format('w');
+                                $isToday = ($d === $today);
+                                $isSat   = ($dowIdx === 6);
+                                $isSun   = ($dowIdx === 0);
+                                $dateCat = $dateCategories[$d] ?? 'normal';
+                                $isPast  = ($dateCat === 'past');
+                                $first   = true;
+                                foreach ($meals as $mealType => $mealLabel):
+                                    $reserved = !empty($grid[$uid][$d][$mealType]);
+                                    $tdClass = 'cell-meal'
+                                        . ($isPast ? '' : ' mcg-toggleable')
+                                        . ($first   ? ' meal-first'     : '')
+                                        . ($isToday ? ' is-today'       : '')
+                                        . ($isSat   ? ' is-saturday'    : '')
+                                        . ($isSun   ? ' is-sunday'      : '')
+                                        . ($isPast                        ? ' is-past'        : '')
+                                        . ($dateCat === 'last_minute'     ? ' is-last-minute' : '');
+                                    $first = false;
+                            ?>
+                                <td class="<?= h($tdClass) ?>"
+                                    data-user-id="<?= h($uid) ?>"
+                                    data-room-id="<?= h($roomId) ?>"
+                                    data-date="<?= h($d) ?>"
+                                    data-meal="<?= h($mealType) ?>"
+                                    data-reserved="<?= $reserved ? '1' : '0' ?>"
+                                    title="<?= h($u['name'] . ' ' . $d . ' ' . $mealLabel) ?>"
+                                    <?php if (!$isPast): ?>
+                                    role="checkbox"
+                                    aria-checked="<?= $reserved ? 'true' : 'false' ?>"
+                                    tabindex="0"
+                                    <?php endif; ?>
+                                ><?= $reserved ? '1' : '' ?></td>
+                            <?php endforeach; endforeach; ?>
+                        </tr>
+                        <?php endforeach; ?>
+
+                        <?php endforeach; ?>
+
+                        <!-- 日計行 -->
+                        <tr class="row-daily-total">
+                            <td class="col-row"></td>
+                            <td class="col-room" colspan="2">日計</td>
+                            <?php foreach ($dates as $d):
+                                $dowIdx  = (int)(new \DateTimeImmutable($d))->format('w');
+                                $isToday = ($d === $today);
+                                $isSat   = ($dowIdx === 6);
+                                $isSun   = ($dowIdx === 0);
+                                $first   = true;
+                                foreach ($meals as $mealType => $mealLabel):
+                                    $total = (int)($dailyTotals[$d][$mealType] ?? 0);
+                                    $cls = ($first ? 'meal-first ' : '')
+                                        . ($isToday ? 'is-today ' : '')
+                                        . ($isSat   ? 'is-saturday ' : '')
+                                        . ($isSun   ? 'is-sunday' : '');
+                                    $first = false;
+                            ?>
+                                <td class="<?= h(trim($cls)) ?>"
+                                    data-date="<?= h($d) ?>"
+                                    data-meal="<?= h($mealType) ?>"
+                                ><?= $total > 0 ? h($total) : '' ?></td>
+                            <?php endforeach; endforeach; ?>
+                        </tr>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+            </div><!-- /.mcg-grid-wrap -->
+
+
+        </div><!-- /.excel-body -->
+    </div><!-- /.excel-content -->
+
+    <!-- ═══════════════════════════════════════════
+         シートタブ
+    ═══════════════════════════════════════════ -->
+    <div class="excel-sheettabs">
+        <span class="excel-sheettab-add">⊕</span>
+        <a href="<?= h($makeUrl(['mode' => 'individual'])) ?>"
+           class="excel-sheettab <?= $viewMode === 'individual' ? 'active' : '' ?>">個人</a>
+        <?php if ($canViewAll): ?>
+        <a href="<?= h($makeUrl(['mode' => 'room'])) ?>"
+           class="excel-sheettab <?= $viewMode === 'room' ? 'active' : '' ?>">各部屋</a>
+        <a href="<?= h($makeUrl(['mode' => 'all'])) ?>"
+           class="excel-sheettab <?= $viewMode === 'all' ? 'active' : '' ?>">全部</a>
+        <a href="#" class="excel-sheettab">入力作法</a>
+        <?php endif; ?>
+    </div>
+
+    <!-- ステータスバー -->
+    <div class="excel-statusbar">
+        <span>準備完了</span>
+        <span>
+            合計: <?= h(array_sum($monthlyTotals)) ?>
+            個数: <?= h(array_sum($dailyTotals ? array_map('array_sum', $dailyTotals) : [0])) ?>
+        </span>
+    </div>
+
+</div><!-- /.excel-window -->
+
+<script>
+/* ナビバーの実高さを CSS 変数にセット（excel-window の top 値に使用） */
+(function () {
+    function applyNavHeight() {
+        var nav = document.getElementById('mainNav');
+        if (nav) {
+            document.documentElement.style.setProperty('--mcg-nav-h', nav.offsetHeight + 'px');
+        }
+    }
+    applyNavHeight();
+    window.addEventListener('resize', applyNavHeight);
+}());
+
+var MCG_BASE = (window.MCG_CONFIG && window.MCG_CONFIG.basePath) ? window.MCG_CONFIG.basePath : '';
+
+function mcgActiveRoomId() {
+    var btn = document.querySelector('.mcg-room-btn.active');
+    return btn ? btn.dataset.roomId : '';
+}
+
+function mcgChangeMode(mode) {
+    var roomId = mcgActiveRoomId();
+    var week   = <?= json_encode($weekMondayStr) ?>;
+    var qs = new URLSearchParams({ mode: mode, room_id: roomId, week: week }).toString();
+    location.href = MCG_BASE + '/TReservationInfo/meal-count-grid?' + qs;
+}
+function mcgChangeRoom(roomId) {
+    var mode = document.getElementById('js-mode-select') ? document.getElementById('js-mode-select').value : 'individual';
+    var week = <?= json_encode($weekMondayStr) ?>;
+    var qs = new URLSearchParams({ mode: mode, room_id: roomId, week: week }).toString();
+    location.href = MCG_BASE + '/TReservationInfo/meal-count-grid?' + qs;
+}
+</script>

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/MealCountGridServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/MealCountGridServiceTest.php
@@ -1,0 +1,405 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\MealCountGridService;
+use Cake\TestSuite\TestCase;
+
+/**
+ * MealCountGridService テスト
+ *
+ * 対象メソッド:
+ *   - buildDateRange()          — 純粋ロジック
+ *   - resolveWeekNavigation()   — 純粋ロジック
+ *   - getAdminOldestAllowedMonday() — 純粋ロジック
+ *   - buildGrid()               — TIndividualReservationInfo・MUserGroup テーブルが必要
+ *   - getRoomUsers()            — MUserGroup テーブルが必要
+ */
+class MealCountGridServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserGroup',
+        'app.MUserInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private MealCountGridService $service;
+
+    /** テスト用の固定月曜日（2026-05-11 は月曜） */
+    private \DateTimeImmutable $thisMonday;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service    = new MealCountGridService();
+        $this->thisMonday = new \DateTimeImmutable('2026-05-11', new \DateTimeZone('Asia/Tokyo'));
+    }
+
+    /* =====================================================================
+     * MEALS 定数
+     * ===================================================================== */
+
+    public function testMealsConstantContainsFourTypes(): void
+    {
+        $this->assertCount(4, MealCountGridService::MEALS);
+        $this->assertSame('朝', MealCountGridService::MEALS[1]);
+        $this->assertSame('昼', MealCountGridService::MEALS[2]);
+        $this->assertSame('夕', MealCountGridService::MEALS[3]);
+        $this->assertSame('弁', MealCountGridService::MEALS[4]);
+    }
+
+    /* =====================================================================
+     * buildDateRange
+     * ===================================================================== */
+
+    public function testBuildDateRangeDefaultsTwentyEightDays(): void
+    {
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $this->assertCount(28, $dates);
+    }
+
+    public function testBuildDateRangeCanReturnSevenDays(): void
+    {
+        $dates = $this->service->buildDateRange('2026-05-11', 7);
+
+        $this->assertCount(7, $dates);
+        $this->assertSame('2026-05-11', $dates[0]);
+        $this->assertSame('2026-05-17', $dates[6]);
+    }
+
+    public function testBuildDateRangeTwentyEightDaysEndsOnSunday(): void
+    {
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $this->assertSame('2026-05-11', $dates[0]);
+        $this->assertSame('2026-06-07', $dates[27]);
+    }
+
+    public function testBuildDateRangeReturnsConsecutiveDays(): void
+    {
+        $dates = $this->service->buildDateRange('2026-05-11', 7);
+
+        for ($i = 0; $i < 6; $i++) {
+            $current = new \DateTimeImmutable($dates[$i]);
+            $next    = new \DateTimeImmutable($dates[$i + 1]);
+            $diff    = (int)$current->diff($next)->days;
+            $this->assertSame(1, $diff, "インデックス {$i} と " . ($i + 1) . " は連続していない");
+        }
+    }
+
+    /* =====================================================================
+     * buildPeriodLabel
+     * ===================================================================== */
+
+    public function testBuildPeriodLabelReturnsCorrectFormat(): void
+    {
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $label = $this->service->buildPeriodLabel($dates);
+
+        $this->assertStringContainsString('2026/05/11', $label);
+        $this->assertStringContainsString('2026/06/07', $label);
+        $this->assertStringContainsString('28日', $label);
+    }
+
+    public function testBuildPeriodLabelReturnsEmptyForEmptyDates(): void
+    {
+        $label = $this->service->buildPeriodLabel([]);
+
+        $this->assertSame('', $label);
+    }
+
+    /* =====================================================================
+     * buildMonthlyTotals
+     * ===================================================================== */
+
+    public function testBuildMonthlyTotalsReturnsAllMealTypes(): void
+    {
+        $gridData = [
+            'dailyTotals' => [
+                '2026-05-11' => [1 => 2, 2 => 1, 3 => 0, 4 => 0],
+                '2026-05-12' => [1 => 1, 2 => 0, 3 => 1, 4 => 0],
+            ],
+        ];
+
+        $totals = $this->service->buildMonthlyTotals($gridData);
+
+        $this->assertSame(3, $totals[1]); // 朝: 2+1
+        $this->assertSame(1, $totals[2]); // 昼: 1+0
+        $this->assertSame(1, $totals[3]); // 夕: 0+1
+        $this->assertSame(0, $totals[4]); // 弁: 0+0
+    }
+
+    public function testBuildMonthlyTotalsReturnsZeroForEmptyGrid(): void
+    {
+        $gridData = ['dailyTotals' => []];
+
+        $totals = $this->service->buildMonthlyTotals($gridData);
+
+        foreach (array_keys(\App\Service\MealCountGridService::MEALS) as $mealType) {
+            $this->assertSame(0, $totals[$mealType]);
+        }
+    }
+
+    /* =====================================================================
+     * getAdminOldestAllowedMonday
+     * ===================================================================== */
+
+    public function testGetAdminOldestAllowedMondayReturnsMonday(): void
+    {
+        $oldest = $this->service->getAdminOldestAllowedMonday($this->thisMonday);
+
+        $this->assertSame('1', $oldest->format('N'), '最古週が月曜日でない');
+    }
+
+    public function testGetAdminOldestAllowedMondayIsTwoMonthsBack(): void
+    {
+        $oldest = $this->service->getAdminOldestAllowedMonday($this->thisMonday);
+
+        $this->assertLessThan($this->thisMonday, $oldest);
+        // 2ヶ月以上前であること
+        $diff = $this->thisMonday->diff($oldest);
+        $this->assertGreaterThanOrEqual(1, $diff->m + ($diff->y * 12));
+    }
+
+    /* =====================================================================
+     * resolveWeekNavigation
+     * ===================================================================== */
+
+    public function testResolveWeekNavigationReturnsCurrentWeekWhenNoParam(): void
+    {
+        $result = $this->service->resolveWeekNavigation(null, false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationNormalizesWednesdayToMonday(): void
+    {
+        $wednesday = $this->thisMonday->modify('+2 days');
+
+        $result = $this->service->resolveWeekNavigation($wednesday->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationNonAdminCannotGoBeforeCurrentWeek(): void
+    {
+        $lastWeek = $this->thisMonday->modify('-7 days');
+
+        $result = $this->service->resolveWeekNavigation($lastWeek->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationAdminCanReachOldestAllowedMonday(): void
+    {
+        $oldest = $this->service->getAdminOldestAllowedMonday($this->thisMonday);
+
+        $result = $this->service->resolveWeekNavigation($oldest->format('Y-m-d'), true, $this->thisMonday);
+
+        $this->assertSame($oldest->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationClampsFarFutureToFourWeeks(): void
+    {
+        $farFuture   = $this->thisMonday->modify('+10 weeks');
+        $expectedMax = $this->thisMonday->modify('+4 weeks');
+
+        $result = $this->service->resolveWeekNavigation($farFuture->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertSame($expectedMax->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationCanGoNextFalseAtFutureLimit(): void
+    {
+        $fourWeeksOut = $this->thisMonday->modify('+4 weeks');
+
+        $result = $this->service->resolveWeekNavigation($fourWeeksOut->format('Y-m-d'), false, $this->thisMonday);
+
+        $this->assertFalse($result['canGoNext']);
+    }
+
+    public function testResolveWeekNavigationHandlesInvalidStringGracefully(): void
+    {
+        $result = $this->service->resolveWeekNavigation('not-a-date', false, $this->thisMonday);
+
+        $this->assertSame($this->thisMonday->format('Y-m-d'), $result['weekMondayStr']);
+    }
+
+    public function testResolveWeekNavigationPrevAndNextAreSurroundingWeeks(): void
+    {
+        $result = $this->service->resolveWeekNavigation(null, false, $this->thisMonday);
+
+        $this->assertSame(
+            $this->thisMonday->modify('-7 days')->format('Y-m-d'),
+            $result['prevMonday']->format('Y-m-d')
+        );
+        $this->assertSame(
+            $this->thisMonday->modify('+7 days')->format('Y-m-d'),
+            $result['nextMonday']->format('Y-m-d')
+        );
+    }
+
+    /* =====================================================================
+     * buildGrid
+     * ===================================================================== */
+
+    public function testBuildGridReturnsExpectedStructure(): void
+    {
+        $reservationTable = $this->getTableLocator()->get('TIndividualReservationInfo');
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $result = $this->service->buildGrid($reservationTable, [], [], $dates);
+
+        $this->assertArrayHasKey('dates', $result);
+        $this->assertArrayHasKey('meals', $result);
+        $this->assertArrayHasKey('rooms', $result);
+        $this->assertArrayHasKey('dailyTotals', $result);
+    }
+
+    public function testBuildGridWithNoRoomsReturnsEmptyRooms(): void
+    {
+        $reservationTable = $this->getTableLocator()->get('TIndividualReservationInfo');
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $result = $this->service->buildGrid($reservationTable, [], [], $dates);
+
+        $this->assertEmpty($result['rooms']);
+    }
+
+    public function testBuildGridDailyTotalsInitializedForAllDatesAndMeals(): void
+    {
+        $reservationTable = $this->getTableLocator()->get('TIndividualReservationInfo');
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $result = $this->service->buildGrid($reservationTable, [], [], $dates);
+
+        foreach ($dates as $d) {
+            $this->assertArrayHasKey($d, $result['dailyTotals']);
+            foreach (array_keys(MealCountGridService::MEALS) as $mealType) {
+                $this->assertArrayHasKey($mealType, $result['dailyTotals'][$d]);
+            }
+        }
+    }
+
+    public function testBuildGridReturnsDatesPassed(): void
+    {
+        $reservationTable = $this->getTableLocator()->get('TIndividualReservationInfo');
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $result = $this->service->buildGrid($reservationTable, [], [], $dates);
+
+        $this->assertSame($dates, $result['dates']);
+    }
+
+    public function testBuildGridReturnsMealConstants(): void
+    {
+        $reservationTable = $this->getTableLocator()->get('TIndividualReservationInfo');
+        $dates = $this->service->buildDateRange('2026-05-11');
+
+        $result = $this->service->buildGrid($reservationTable, [], [], $dates);
+
+        $this->assertSame(MealCountGridService::MEALS, $result['meals']);
+    }
+
+    /* =====================================================================
+     * getRoomUsers
+     * ===================================================================== */
+
+    public function testGetRoomUsersReturnsUsersInRoom(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $userInfoTable  = $this->getTableLocator()->get('MUserInfo');
+
+        // i_del_flag=0 のアクティブユーザーを追加
+        $userInfoTable->save($userInfoTable->newEntity([
+            'i_id_user'       => 2,
+            'c_login_account' => 'active_user',
+            'c_login_passwd'  => 'pass',
+            'c_user_name'     => 'ActiveUser',
+            'i_admin'         => 0,
+            'i_disp_no'       => 2,
+            'i_enable'        => 1,
+            'i_del_flag'      => 0,
+            'dt_create'       => '2024-01-01 00:00:00',
+            'c_create_user'   => 'test',
+            'dt_update'       => '2024-01-01 00:00:00',
+            'c_update_user'   => 'test',
+        ]));
+        $userGroupTable->save($userGroupTable->newEntity([
+            'i_id_user'     => 2,
+            'i_id_room'     => 1,
+            'active_flag'   => 0,
+            'dt_create'     => '2024-01-01 00:00:00',
+            'c_create_user' => 'test',
+            'dt_update'     => '2024-01-01 00:00:00',
+            'c_update_user' => 'test',
+        ]));
+
+        $result = $this->service->getRoomUsers($userGroupTable, $userInfoTable, 1);
+
+        $userIds = array_column($result, 'id');
+        $this->assertContains(2, $userIds);
+    }
+
+    public function testGetRoomUsersExcludesDeletedUsers(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $userInfoTable  = $this->getTableLocator()->get('MUserInfo');
+
+        // フィクスチャのユーザー1は i_del_flag=1（削除済み）なので結果に含まれない
+        $result = $this->service->getRoomUsers($userGroupTable, $userInfoTable, 1);
+
+        $userIds = array_column($result, 'id');
+        $this->assertNotContains(1, $userIds);
+    }
+
+    public function testGetRoomUsersReturnsEmptyForUnknownRoom(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $userInfoTable  = $this->getTableLocator()->get('MUserInfo');
+
+        $result = $this->service->getRoomUsers($userGroupTable, $userInfoTable, 9999);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testGetRoomUsersResultHasIdAndNameKeys(): void
+    {
+        $userGroupTable = $this->getTableLocator()->get('MUserGroup');
+        $userInfoTable  = $this->getTableLocator()->get('MUserInfo');
+
+        // アクティブユーザーを追加
+        $userInfoTable->save($userInfoTable->newEntity([
+            'i_id_user'       => 3,
+            'c_login_account' => 'user3',
+            'c_login_passwd'  => 'pass',
+            'c_user_name'     => 'User Three',
+            'i_admin'         => 0,
+            'i_disp_no'       => 3,
+            'i_enable'        => 1,
+            'i_del_flag'      => 0,
+            'dt_create'       => '2024-01-01 00:00:00',
+            'c_create_user'   => 'test',
+            'dt_update'       => '2024-01-01 00:00:00',
+            'c_update_user'   => 'test',
+        ]));
+        $userGroupTable->save($userGroupTable->newEntity([
+            'i_id_user'     => 3,
+            'i_id_room'     => 1,
+            'active_flag'   => 0,
+            'dt_create'     => '2024-01-01 00:00:00',
+            'c_create_user' => 'test',
+            'dt_update'     => '2024-01-01 00:00:00',
+            'c_update_user' => 'test',
+        ]));
+
+        $result = $this->service->getRoomUsers($userGroupTable, $userInfoTable, 1);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('id', $result[0]);
+        $this->assertArrayHasKey('name', $result[0]);
+    }
+}

--- a/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
@@ -1,0 +1,736 @@
+/* ===== 食数予約 Excel グリッド ===== */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+    margin: 0; padding: 0;
+    height: 100%;
+    font-family: 'Yu Gothic UI', 'Meiryo UI', 'Segoe UI', sans-serif;
+    font-size: 13px;
+    background: #d4d0c8;
+    color: #000;
+}
+
+/* =====================================================================
+ * Excel ライクなウィンドウ枠
+ * ===================================================================== */
+
+.excel-window {
+    position: fixed;
+    top: var(--mcg-nav-h, 66px);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    background: #f0f0f0;
+    z-index: 10;
+}
+
+/* =====================================================================
+ * ツールバー（フィルター + 期間ナビ）
+ * ===================================================================== */
+
+.mcg-toolbar {
+    background: #f8f8f8;
+    border-bottom: 1px solid #d0d0d0;
+    padding: 6px 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.mcg-toolbar-user-name {
+    font-size: 12px;
+    color: #333;
+    white-space: nowrap;
+    font-weight: 600;
+}
+
+.mcg-toolbar-label {
+    font-size: 11px;
+    color: #555;
+    white-space: nowrap;
+}
+
+.mcg-toolbar select {
+    font-size: 12px;
+    border: 1px solid #c0c0c0;
+    border-radius: 2px;
+    padding: 2px 20px 2px 6px;
+    background: #fff;
+    min-width: 100px;
+    height: 26px;
+    appearance: auto;
+}
+
+.mcg-toolbar-sep {
+    width: 1px;
+    height: 22px;
+    background: #c0c0c0;
+    flex-shrink: 0;
+}
+
+/* 凡例 */
+.mcg-legend {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+.mcg-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: #555;
+    white-space: nowrap;
+}
+.mcg-legend-item::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+.mcg-legend-last-minute::before { background: #fff8f0; border: 1px solid #fb8c00; }
+.mcg-legend-past::before        { background: #ebebeb; border: 1px solid #bbb; }
+
+/* ヘッダーセル（直前ウィンドウ）のホバーツールチップ */
+.mcg-grid thead th[data-tooltip] {
+    cursor: help;
+}
+
+/* JS で body に append するツールチップ要素 */
+.mcg-tooltip {
+    position: fixed;
+    background: #333;
+    color: #fff;
+    font-size: 11px;
+    line-height: 1.7;
+    white-space: pre;
+    padding: 6px 10px;
+    border-radius: 4px;
+    pointer-events: none;
+    z-index: 99999;
+    box-shadow: 0 2px 6px rgba(0,0,0,.35);
+    transition: opacity 0.12s;
+}
+
+/* 部屋ボタングループ */
+.mcg-room-btngroup {
+    display: flex;
+    gap: 3px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.mcg-room-btn {
+    background: #fff;
+    border: 1px solid #b0b0b0;
+    border-radius: 2px;
+    font-size: 12px;
+    padding: 2px 10px;
+    cursor: pointer;
+    height: 26px;
+    white-space: nowrap;
+    color: #333;
+    transition: background 0.1s, border-color 0.1s;
+    line-height: 1;
+}
+
+.mcg-room-btn:hover:not(:disabled) { background: #e8e8e8; }
+
+.mcg-room-btn.active {
+    background: #217346;
+    color: #fff;
+    border-color: #1a5c38;
+    font-weight: 600;
+}
+
+.mcg-room-btn:disabled {
+    color: #aaa;
+    cursor: default;
+    background: #f5f5f5;
+    border-color: #d5d5d5;
+}
+
+.mcg-period-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+}
+
+.mcg-period-label-text {
+    font-size: 12px;
+    color: #333;
+    white-space: nowrap;
+}
+
+.mcg-nav-btn {
+    background: #fff;
+    border: 1px solid #b0b0b0;
+    border-radius: 2px;
+    font-size: 12px;
+    padding: 2px 10px;
+    cursor: pointer;
+    height: 26px;
+    white-space: nowrap;
+    color: #333;
+    transition: background 0.1s;
+}
+
+.mcg-nav-btn:hover { background: #e8e8e8; }
+.mcg-nav-btn:disabled { color: #aaa; cursor: default; background: #f5f5f5; }
+.mcg-nav-btn.today { background: #217346; color: #fff; border-color: #1a5c38; }
+.mcg-nav-btn.today:hover { background: #1a5c38; }
+
+/* =====================================================================
+ * メインコンテンツエリア
+ * ===================================================================== */
+
+.excel-content {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.excel-body {
+    flex: 1;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+/* =====================================================================
+ * グリッドテーブル
+ * ===================================================================== */
+
+:root {
+    --col-row-w:  32px;
+    --col-room-w: 72px;
+    --col-name-w: 60px;
+    --cell-w:     24px;
+    --header-h:   40px;
+    --row-h:      22px;
+}
+
+.mcg-grid-wrap {
+    overflow-x: auto;
+    overflow-y: auto;
+    flex-shrink: 0;
+    background: #fff;
+    border-bottom: 1px solid #c0c0c0;
+}
+
+.mcg-grid {
+    border-collapse: collapse;
+    font-size: 12px;
+    table-layout: fixed;
+    width: max-content;
+    min-width: 100%;
+}
+
+/* ── 固定左列 ── */
+.mcg-grid .col-row {
+    width: var(--col-row-w);
+    min-width: var(--col-row-w);
+    position: sticky; left: 0; z-index: 3;
+    background: #d8e4bc;
+}
+
+.mcg-grid .col-room {
+    width: var(--col-room-w);
+    min-width: var(--col-room-w);
+    position: sticky; left: var(--col-row-w); z-index: 3;
+    background: #d8e4bc;
+}
+
+.mcg-grid .col-name {
+    width: var(--col-name-w);
+    min-width: var(--col-name-w);
+    position: sticky;
+    left: calc(var(--col-row-w) + var(--col-room-w));
+    z-index: 3;
+    background: #d8e4bc;
+    border-right: 2px solid #7f7f7f !important;
+}
+
+/* ── ヘッダー全体 ── */
+.mcg-grid thead th {
+    position: sticky; top: 0; z-index: 2;
+}
+
+.mcg-grid thead th.col-row,
+.mcg-grid thead th.col-room,
+.mcg-grid thead th.col-name {
+    z-index: 4;
+}
+
+/* ── 日付ヘッダー行 ── */
+.mcg-grid thead tr.header-dates th {
+    background: #d8e4bc;
+    text-align: center;
+    padding: 4px 1px 2px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #000;
+    border: 1px solid #aaa;
+    white-space: nowrap;
+    height: var(--header-h);
+    vertical-align: bottom;
+    line-height: 1.3;
+}
+
+.mcg-grid thead tr.header-dates th.date-group {
+    border-left: 2px solid #7f7f7f;
+}
+
+/* 今日 */
+.mcg-grid thead tr.header-dates th.is-today { background: #ffc000; color: #000; }
+/* 土曜 */
+.mcg-grid thead tr.header-dates th.is-saturday { background: #dce6f1; color: #0070c0; }
+/* 日曜 */
+.mcg-grid thead tr.header-dates th.is-sunday { background: #fde8e8; color: #c00000; }
+/* 祝日（日曜と同色） */
+.mcg-grid thead tr.header-dates th.is-holiday { background: #fde8e8; color: #c00000; }
+
+/* ── 食事種別ヘッダー行 ── */
+.mcg-grid thead tr.header-meals th {
+    background: #d8e4bc;
+    text-align: center;
+    padding: 1px 0;
+    font-size: 10px;
+    font-weight: 600;
+    color: #333;
+    border: 1px solid #aaa;
+    width: var(--cell-w);
+    height: 18px;
+    top: var(--header-h);
+}
+
+.mcg-grid thead tr.header-meals th.meal-first {
+    border-left: 2px solid #7f7f7f;
+}
+
+.mcg-grid thead tr.header-meals th.is-today    { background: #fce4d6; }
+.mcg-grid thead tr.header-meals th.is-saturday { background: #dce6f1; }
+.mcg-grid thead tr.header-meals th.is-sunday   { background: #fde8e8; }
+.mcg-grid thead tr.header-meals th.is-holiday  { background: #fde8e8; }
+
+/* ── データ行 ── */
+.mcg-grid tbody tr { height: var(--row-h); }
+
+.mcg-grid tbody td {
+    padding: 0;
+    text-align: center;
+    vertical-align: middle;
+    border: 1px solid #d9d9d9;
+    height: var(--row-h);
+    font-size: 12px;
+}
+
+.mcg-grid tbody td.col-row {
+    background: #d8e4bc;
+    font-size: 11px;
+    color: #555;
+    border-color: #aaa;
+}
+
+.mcg-grid tbody td.col-room {
+    background: #fff;
+    text-align: left;
+    padding: 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-color: #aaa;
+}
+
+.mcg-grid tbody td.col-name {
+    background: #fff;
+    text-align: left;
+    padding: 0 4px;
+    font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-color: #aaa;
+}
+
+/* 食事セル */
+.mcg-grid tbody td.cell-meal {
+    width: var(--cell-w);
+    cursor: pointer;
+    user-select: none;
+    background: #fff;
+    font-size: 12px;
+    font-weight: 500;
+    color: #000;
+}
+
+.mcg-grid tbody td.cell-meal:hover { background: #b8d0a8 !important; }
+
+.mcg-grid tbody td.meal-first { border-left: 2px solid #7f7f7f; }
+
+/* 今日列 */
+.mcg-grid tbody td.is-today { background: #fce4d6; }
+.mcg-grid tbody td.is-today.cell-meal:hover { background: #f4b183 !important; }
+
+/* 土曜列 */
+.mcg-grid tbody td.is-saturday { background: #dce6f1; }
+.mcg-grid tbody td.is-saturday.cell-meal:hover { background: #9dc3e6 !important; }
+
+/* 日曜列 */
+.mcg-grid tbody td.is-sunday { background: #fde8e8; }
+.mcg-grid tbody td.is-sunday.cell-meal:hover { background: #f4a0a0 !important; }
+
+/* 祝日（日曜と同色） */
+.mcg-grid tbody td.is-holiday { background: #fde8e8; }
+.mcg-grid tbody td.is-holiday.cell-meal:hover { background: #f4a0a0 !important; }
+
+/* 過去日: グレー・クリック不可 */
+.mcg-grid tbody td.cell-meal.is-past {
+    background: #ebebeb !important;
+    color: #bbb;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+/* 過去日ヘッダー: ツールチップ用カーソル */
+.mcg-grid thead th.is-past-header {
+    cursor: help;
+}
+
+/* 直前ウィンドウ（当日〜+14日）: 薄いオレンジティント */
+.mcg-grid tbody td.cell-meal.is-last-minute {
+    background: #fff8f0;
+}
+.mcg-grid tbody td.cell-meal.is-last-minute:hover {
+    background: #ffd8a8 !important;
+}
+.mcg-grid tbody td.cell-meal.is-last-minute[data-reserved="1"] {
+    background: #ffe0b2;
+}
+.mcg-grid tbody td.cell-meal.is-last-minute.mcg-pending-on {
+    background: #fb8c00 !important;
+    color: #fff;
+}
+
+/* ヘッダー: 直前ウィンドウのオレンジ下線 */
+.mcg-grid thead tr.header-dates th.is-last-minute {
+    border-bottom: 3px solid #fb8c00;
+}
+.mcg-grid thead tr.header-meals th.is-last-minute {
+    border-bottom: 3px solid #fb8c00;
+}
+
+/* 日計行 */
+.mcg-grid tr.row-daily-total td {
+    background: #d8e4bc;
+    color: #000;
+    font-size: 11px;
+    font-weight: 700;
+    border-color: #aaa;
+    border-top: 2px solid #7f7f7f;
+}
+
+.mcg-grid tr.row-daily-total td.col-row,
+.mcg-grid tr.row-daily-total td.col-room,
+.mcg-grid tr.row-daily-total td.col-name {
+    text-align: left;
+    padding-left: 4px;
+}
+
+/* セル選択状態 */
+.mcg-grid tbody td.mcg-selected {
+    outline: 2px solid #217346;
+    outline-offset: -2px;
+    z-index: 1;
+    position: relative;
+}
+
+/* =====================================================================
+ * 月計サマリーパネル
+ * ===================================================================== */
+
+.mcg-summary {
+    padding: 12px 16px;
+    background: #fff;
+    border: 1px solid #c0c0c0;
+    margin: 10px;
+    border-radius: 2px;
+    box-shadow: 1px 1px 4px rgba(0,0,0,.08);
+    display: inline-flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 280px;
+    max-width: 460px;
+}
+
+.mcg-summary-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: #375623;
+    margin-bottom: 4px;
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 4px;
+}
+
+.mcg-summary-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 20px;
+}
+
+.mcg-summary-label {
+    font-size: 12px;
+    color: #333;
+    width: 28px;
+    text-align: right;
+    flex-shrink: 0;
+}
+
+.mcg-summary-bar-wrap {
+    flex: 1;
+    background: #e0e0e0;
+    height: 14px;
+    border-radius: 1px;
+    overflow: hidden;
+}
+
+.mcg-summary-bar {
+    height: 100%;
+    background: #375623;
+    transition: width 0.3s ease;
+    min-width: 0;
+}
+
+.mcg-summary-val {
+    font-size: 12px;
+    font-weight: 700;
+    color: #000;
+    min-width: 24px;
+    text-align: right;
+}
+
+/* =====================================================================
+ * ステータスバー
+ * ===================================================================== */
+
+.excel-statusbar {
+    background: #217346;
+    color: rgba(255,255,255,.9);
+    font-size: 11px;
+    display: flex;
+    align-items: center;
+    padding: 2px 10px;
+    justify-content: space-between;
+    flex-shrink: 0;
+    min-height: 22px;
+}
+
+/* =====================================================================
+ * シートタブ
+ * ===================================================================== */
+
+.excel-sheettabs {
+    background: #d4d0c8;
+    border-top: 1px solid #7f7f7f;
+    display: flex;
+    align-items: flex-end;
+    padding: 0 4px;
+    gap: 2px;
+    flex-shrink: 0;
+    min-height: 24px;
+}
+
+.excel-sheettab {
+    background: #c8c4bc;
+    border: 1px solid #7f7f7f;
+    border-bottom: none;
+    border-radius: 3px 3px 0 0;
+    font-size: 11px;
+    padding: 3px 14px;
+    cursor: pointer;
+    color: #333;
+    text-decoration: none;
+    display: inline-block;
+    transition: background 0.1s;
+    white-space: nowrap;
+}
+
+.excel-sheettab:hover { background: #e0dcd4; color: #000; }
+.excel-sheettab.active {
+    background: #fff;
+    color: #000;
+    font-weight: 600;
+    border-bottom: 1px solid #fff;
+    z-index: 1;
+    position: relative;
+}
+
+.excel-sheettab-add {
+    background: none;
+    border: none;
+    font-size: 15px;
+    color: #555;
+    cursor: pointer;
+    padding: 0 6px;
+    align-self: center;
+}
+
+/* =====================================================================
+ * 登録ボタン
+ * ===================================================================== */
+
+#mcg-register-btn {
+    background: #bdbdbd;
+    color: #fff;
+    border: none;
+    border-radius: 2px;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 14px;
+    height: 28px;
+    cursor: not-allowed;
+    white-space: nowrap;
+    transition: background 0.15s;
+    letter-spacing: 0.03em;
+}
+
+#mcg-register-btn.has-changes {
+    background: #217346;
+    cursor: pointer;
+    animation: mcg-btn-pulse 1.8s ease-in-out infinite;
+}
+
+#mcg-register-btn.has-changes:hover { background: #1a5c38; animation: none; }
+
+@keyframes mcg-btn-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(33,115,70,.5); }
+    50%       { box-shadow: 0 0 0 5px rgba(33,115,70,0); }
+}
+
+/* =====================================================================
+ * Pending セル（未保存変更）
+ * ===================================================================== */
+
+/* pending ON: 緑 ● */
+.mcg-grid tbody td.mcg-pending-on {
+    background: #c6efce !important;
+    color: #375623 !important;
+    font-size: 13px !important;
+    font-weight: 900 !important;
+    cursor: pointer;
+}
+
+/* pending OFF: 赤 × */
+.mcg-grid tbody td.mcg-pending-off {
+    background: #ffc7ce !important;
+    color: #9c0006 !important;
+    font-size: 13px !important;
+    font-weight: 900 !important;
+    cursor: pointer;
+}
+
+/* =====================================================================
+ * 排他制御: 他部屋で予約済みセル
+ * ===================================================================== */
+
+.mcg-grid tbody td.mcg-cell-conflict {
+    background: repeating-linear-gradient(
+        45deg,
+        #e4e4e4,
+        #e4e4e4 4px,
+        #d0d0d0 4px,
+        #d0d0d0 8px
+    ) !important;
+    cursor: not-allowed !important;
+    color: transparent !important;
+    pointer-events: auto !important; /* hover 検知のため維持 */
+    position: relative;
+}
+
+/* コンフリクトツールチップ（JS で生成・配置） */
+.mcg-conflict-tip {
+    position: fixed;
+    z-index: 9999;
+    background: #c00000;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 3px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,.25);
+    display: none;
+}
+
+/* =====================================================================
+ * セルフラッシュアニメーション
+ * ===================================================================== */
+
+@keyframes mcg-flash-on {
+    0%   { background-color: inherit; }
+    25%  { background-color: #92d050; }
+    100% { background-color: inherit; }
+}
+
+@keyframes mcg-flash-off {
+    0%   { background-color: inherit; }
+    25%  { background-color: #ff7f7f; }
+    100% { background-color: inherit; }
+}
+
+.mcg-cell-flash-on  { animation: mcg-flash-on  0.5s ease; }
+.mcg-cell-flash-off { animation: mcg-flash-off 0.5s ease; }
+
+/* =====================================================================
+ * Toast
+ * ===================================================================== */
+
+.mcg-toast-wrap {
+    position: fixed;
+    bottom: 28px;
+    right: 20px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    pointer-events: none;
+}
+
+.mcg-toast {
+    padding: 8px 14px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0,0,0,.25);
+    pointer-events: auto;
+    max-width: 300px;
+    word-break: break-word;
+    animation: mcg-toast-in 0.15s ease;
+    transition: opacity 0.25s, transform 0.25s;
+}
+
+.mcg-toast--hiding { opacity: 0; transform: translateY(6px); }
+.mcg-toast--error   { background: #c00000; }
+.mcg-toast--success { background: #375623; }
+.mcg-toast--info    { background: #2f75b6; }
+
+@keyframes mcg-toast-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -1,0 +1,465 @@
+'use strict';
+
+/* ── 食事種別定数 ── */
+var MEAL = { BREAKFAST: 1, LUNCH: 2, DINNER: 3, BENTO: 4 };
+
+/* ── 部屋名マップ（PHP から注入） ── */
+var MCG_ROOM_NAMES = (window.MCG_CONFIG && window.MCG_CONFIG.rooms) ? window.MCG_CONFIG.rooms : {};
+var MCG_BASE = (window.MCG_CONFIG && window.MCG_CONFIG.basePath) ? window.MCG_CONFIG.basePath : '';
+
+/* ── 昼↔弁当 排他マップ ── */
+var MEAL_OPPONENT = {};
+MEAL_OPPONENT[MEAL.LUNCH] = MEAL.BENTO;
+MEAL_OPPONENT[MEAL.BENTO] = MEAL.LUNCH;
+
+/* ─────────────────────────────────────────────
+ * Pending（未保存変更）管理
+ *
+ * キー: "userId|roomId|date|meal"
+ * 値:   { td: HTMLElement, original: '0'|'1', desired: 0|1 }
+ *
+ * data-reserved は pending 状態を即反映する（排他制御・日計に使用）。
+ * original は登録失敗時のロールバック用に保存する。
+ * ─────────────────────────────────────────── */
+var _mcgPending = new Map();
+
+function _mcgKey(td) {
+    return td.dataset.userId + '|' + td.dataset.roomId + '|' + td.dataset.date + '|' + td.dataset.meal;
+}
+
+function mcgAddPending(td, newValue) {
+    var key = _mcgKey(td);
+    var existing = _mcgPending.get(key);
+    var original = existing ? existing.original : td.dataset.reserved;
+
+    _mcgPending.set(key, { td: td, original: original, desired: newValue });
+
+    /* data-reserved を pending 状態に合わせる（排他制御・日計が正確になる） */
+    td.dataset.reserved = newValue === 1 ? '1' : '0';
+    td.setAttribute('aria-checked', newValue === 1 ? 'true' : 'false');
+    td.classList.remove('mcg-pending-on', 'mcg-pending-off');
+    if (newValue === 1) {
+        td.classList.add('mcg-pending-on');
+        td.textContent = '●';
+    } else {
+        td.classList.add('mcg-pending-off');
+        td.textContent = '×';
+    }
+}
+
+function mcgRemovePending(td) {
+    var key = _mcgKey(td);
+    var entry = _mcgPending.get(key);
+    if (entry) {
+        /* data-reserved を元に戻す */
+        td.dataset.reserved = entry.original;
+        td.setAttribute('aria-checked', entry.original === '1' ? 'true' : 'false');
+        _mcgPending.delete(key);
+    }
+    td.classList.remove('mcg-pending-on', 'mcg-pending-off');
+    if (td.dataset.reserved === '1') {
+        td.textContent = '1';
+    } else {
+        td.textContent = '';
+    }
+}
+
+/* ─────────────────────────────────────────────
+ * 登録ボタン更新
+ * ─────────────────────────────────────────── */
+function mcgUpdateRegisterBtn() {
+    var btn = document.getElementById('mcg-register-btn');
+    if (!btn) return;
+    var count = _mcgPending.size;
+    if (count > 0) {
+        btn.disabled = false;
+        btn.textContent = '登録 (' + count + '件)';
+        btn.classList.add('has-changes');
+    } else {
+        btn.disabled = true;
+        btn.textContent = '登録';
+        btn.classList.remove('has-changes');
+    }
+}
+
+/* ─────────────────────────────────────────────
+ * 一括登録（Promise を返す）
+ * ─────────────────────────────────────────── */
+function mcgRegisterAll() {
+    if (_mcgPending.size === 0) return Promise.resolve();
+
+    var btn = document.getElementById('mcg-register-btn');
+    if (btn) { btn.disabled = true; btn.textContent = '保存中…'; btn.classList.remove('has-changes'); }
+
+    var csrfMeta  = document.querySelector('meta[name="csrfToken"]');
+    var csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : '';
+
+    var entries = Array.from(_mcgPending.entries());
+
+    return Promise.allSettled(entries.map(function (pair) {
+        var key = pair[0];
+        var entry = pair[1];
+        var parts  = key.split('|');
+        var userId = parts[0], roomId = parts[1], date = parts[2], meal = parts[3];
+
+        return fetch(MCG_BASE + '/TReservationInfo/toggle/' + roomId, {
+            method:  'POST',
+            headers: {
+                'Content-Type':     'application/json',
+                'X-CSRF-Token':     csrfToken,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept':           'application/json',
+            },
+            body: JSON.stringify({
+                userId: parseInt(userId, 10),
+                date:   date,
+                meal:   parseInt(meal, 10),
+                value:  entry.desired,
+            }),
+        }).then(function (res) {
+            return res.text().then(function (text) {
+                var data;
+                try { data = JSON.parse(text); } catch (e) { throw new Error('HTTP ' + res.status); }
+                if (data.ok === false) throw new Error(data.message || 'エラー');
+                return key;
+            });
+        });
+    })).then(function (results) {
+        var successKeys = [];
+        var failCount   = 0;
+
+        results.forEach(function (result, i) {
+            var key   = entries[i][0];
+            var entry = entries[i][1];
+            var parts = key.split('|');
+
+            if (result.status === 'fulfilled') {
+                successKeys.push(key);
+                _mcgPending.delete(key);
+                entry.td.classList.remove('mcg-pending-on', 'mcg-pending-off');
+                /* data-reserved は既に desired 値になっている */
+                if (entry.desired === 1) {
+                    entry.td.textContent = '1';
+                } else {
+                    entry.td.textContent = '';
+                }
+                mcgFlashCell(entry.td, entry.desired === 1);
+            } else {
+                failCount++;
+                /* ロールバック */
+                _mcgPending.delete(key);
+                entry.td.dataset.reserved = entry.original;
+                entry.td.classList.remove('mcg-pending-on', 'mcg-pending-off');
+                if (entry.original === '1') {
+                    entry.td.textContent = '1';
+                    entry.td.setAttribute('aria-checked', 'true');
+                } else {
+                    entry.td.textContent = '';
+                    entry.td.setAttribute('aria-checked', 'false');
+                }
+            }
+        });
+
+        /* 影響セルの日計・排他状態を再計算 */
+        var seen = Object.create(null);
+        results.forEach(function (result, i) {
+            var entry = entries[i][1];
+            var parts = entries[i][0].split('|');
+            var k = parts[2] + '|' + parts[3];
+            if (!seen[k]) {
+                seen[k] = true;
+                mcgUpdateDailyTotal(parts[2], parseInt(parts[3], 10));
+                mcgSyncConflicts(parts[0], parts[2], parts[3]);
+            }
+        });
+
+        if (successKeys.length > 0) {
+            mcgShowToast(successKeys.length + '件を登録しました', 'success');
+        }
+        if (failCount > 0) {
+            mcgShowToast(failCount + '件の登録に失敗しました', 'error');
+        }
+
+        mcgUpdateRegisterBtn();
+    });
+}
+
+/* ─────────────────────────────────────────────
+ * 排他制御（他部屋予約チェック）
+ * ─────────────────────────────────────────── */
+
+function mcgGetSiblingCells(userId, date, meal) {
+    return document.querySelectorAll(
+        '.mcg-toggleable[data-user-id="' + userId + '"]' +
+        '[data-date="' + date + '"]' +
+        '[data-meal="' + meal + '"]'
+    );
+}
+
+function mcgSyncConflicts(userId, date, meal) {
+    var cells = mcgGetSiblingCells(userId, date, meal);
+    if (cells.length <= 1) return;
+
+    var reservedRoomId = null;
+    cells.forEach(function (cell) {
+        if (cell.dataset.reserved === '1') reservedRoomId = cell.dataset.roomId;
+    });
+
+    cells.forEach(function (cell) {
+        if (reservedRoomId !== null && cell.dataset.roomId !== reservedRoomId) {
+            var roomName = MCG_ROOM_NAMES[reservedRoomId] || ('部屋' + reservedRoomId);
+            cell.classList.add('mcg-cell-conflict');
+            cell.dataset.conflictMsg = roomName + 'で予約済みのため選択できません';
+        } else {
+            cell.classList.remove('mcg-cell-conflict');
+            delete cell.dataset.conflictMsg;
+        }
+    });
+}
+
+function mcgInitConflicts() {
+    var seen = Object.create(null);
+    document.querySelectorAll('.mcg-toggleable').forEach(function (cell) {
+        var key = cell.dataset.userId + '|' + cell.dataset.date + '|' + cell.dataset.meal;
+        if (!seen[key]) {
+            seen[key] = true;
+            mcgSyncConflicts(cell.dataset.userId, cell.dataset.date, cell.dataset.meal);
+        }
+    });
+}
+
+/* ── コンフリクトツールチップ ── */
+
+var _mcgConflictTip = null;
+
+function mcgInitConflictTip() {
+    document.addEventListener('mouseover', function (e) {
+        var cell = e.target.closest('.mcg-cell-conflict');
+        if (cell && cell.dataset.conflictMsg) {
+            if (!_mcgConflictTip) {
+                _mcgConflictTip = document.createElement('div');
+                _mcgConflictTip.className = 'mcg-conflict-tip';
+                document.body.appendChild(_mcgConflictTip);
+            }
+            _mcgConflictTip.textContent = cell.dataset.conflictMsg;
+            _mcgConflictTip.style.display = 'block';
+            _mcgConflictTip.style.left = (e.clientX + 12) + 'px';
+            _mcgConflictTip.style.top  = (e.clientY - 36) + 'px';
+        } else if (_mcgConflictTip) {
+            _mcgConflictTip.style.display = 'none';
+        }
+    });
+    document.addEventListener('mousemove', function (e) {
+        if (_mcgConflictTip && _mcgConflictTip.style.display === 'block') {
+            _mcgConflictTip.style.left = (e.clientX + 12) + 'px';
+            _mcgConflictTip.style.top  = (e.clientY - 36) + 'px';
+        }
+    });
+    document.addEventListener('mouseleave', function () {
+        if (_mcgConflictTip) _mcgConflictTip.style.display = 'none';
+    }, true);
+}
+
+/* ─────────────────────────────────────────────
+ * Toast 通知
+ * ─────────────────────────────────────────── */
+function mcgShowToast(message, type) {
+    var wrap = document.getElementById('mcg-toast-wrap');
+    if (!wrap) {
+        wrap = document.createElement('div');
+        wrap.id        = 'mcg-toast-wrap';
+        wrap.className = 'mcg-toast-wrap';
+        document.body.appendChild(wrap);
+    }
+    var toast = document.createElement('div');
+    toast.className   = 'mcg-toast mcg-toast--' + (type || 'info');
+    toast.textContent = message;
+    wrap.appendChild(toast);
+    setTimeout(function () {
+        toast.classList.add('mcg-toast--hiding');
+        setTimeout(function () { if (toast.parentNode) toast.parentNode.removeChild(toast); }, 250);
+    }, 2700);
+}
+
+/* ─────────────────────────────────────────────
+ * セルアニメーション
+ * ─────────────────────────────────────────── */
+function mcgFlashCell(td, isOn) {
+    var cls = isOn ? 'mcg-cell-flash-on' : 'mcg-cell-flash-off';
+    td.classList.remove('mcg-cell-flash-on', 'mcg-cell-flash-off');
+    void td.offsetWidth;
+    td.classList.add(cls);
+    setTimeout(function () { td.classList.remove(cls); }, 500);
+}
+
+/* ─────────────────────────────────────────────
+ * 指定セルを検索
+ * ─────────────────────────────────────────── */
+function mcgFindCell(userId, roomId, date, meal) {
+    return document.querySelector(
+        '.mcg-toggleable[data-user-id="' + userId + '"]' +
+        '[data-room-id="' + roomId + '"]' +
+        '[data-date="' + date + '"]' +
+        '[data-meal="' + meal + '"]'
+    );
+}
+
+/* ─────────────────────────────────────────────
+ * 日計行を再集計
+ * ─────────────────────────────────────────── */
+function mcgUpdateDailyTotal(date, meal) {
+    var count = document.querySelectorAll(
+        '.mcg-toggleable[data-date="' + date + '"][data-meal="' + meal + '"][data-reserved="1"]'
+    ).length;
+    var cell = document.querySelector(
+        '.row-daily-total td[data-date="' + date + '"][data-meal="' + meal + '"]'
+    );
+    if (cell) cell.textContent = count > 0 ? String(count) : '';
+}
+
+/* ─────────────────────────────────────────────
+ * セルクリック（Pending モード）
+ * ─────────────────────────────────────────── */
+function mcgInitToggle() {
+    document.querySelectorAll('.mcg-toggleable').forEach(function (td) {
+        td.addEventListener('keydown', function (e) {
+            if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); td.click(); }
+        });
+
+        td.addEventListener('click', function () {
+            if (td.classList.contains('is-past')) return;
+            if (td.classList.contains('mcg-cell-conflict')) return;
+
+            var userId = td.dataset.userId;
+            var roomId = td.dataset.roomId;
+            var date   = td.dataset.date;
+            var meal   = parseInt(td.dataset.meal, 10);
+
+            /* 現在の有効な予約状態（pending 込み） */
+            var currentReserved = td.dataset.reserved === '1';
+            var newValue        = currentReserved ? 0 : 1;
+
+            /* 昼↔弁当 排他: 同部屋の対立セルを pending OFF にする */
+            if (newValue === 1 && Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
+                var opponentMeal = MEAL_OPPONENT[meal];
+                var opponentTd   = mcgFindCell(userId, roomId, date, opponentMeal);
+                if (opponentTd && opponentTd.dataset.reserved === '1') {
+                    var opponentKey     = _mcgKey(opponentTd);
+                    var opponentEntry   = _mcgPending.get(opponentKey);
+                    var opponentOriginal = opponentEntry ? opponentEntry.original : opponentTd.dataset.reserved;
+
+                    if (opponentOriginal === '0') {
+                        /* 元々 OFF だったものが pending ON になっていた → 単純に pending 解除 */
+                        mcgRemovePending(opponentTd);
+                    } else {
+                        /* 元々 ON → pending OFF */
+                        mcgAddPending(opponentTd, 0);
+                    }
+                    mcgUpdateDailyTotal(date, opponentMeal);
+                    mcgSyncConflicts(userId, date, String(opponentMeal));
+                }
+            }
+
+            /* 元の状態に戻るなら pending 解除、それ以外は pending 追加 */
+            var key      = _mcgKey(td);
+            var entry    = _mcgPending.get(key);
+            var original = entry ? entry.original : td.dataset.reserved;
+
+            if (String(newValue) === original) {
+                mcgRemovePending(td);
+            } else {
+                mcgAddPending(td, newValue);
+            }
+
+            mcgUpdateDailyTotal(date, meal);
+            mcgSyncConflicts(userId, date, td.dataset.meal);
+            mcgUpdateRegisterBtn();
+        });
+    });
+}
+
+/* ─────────────────────────────────────────────
+ * ページ離脱ガード（未保存あり）
+ * ─────────────────────────────────────────── */
+function mcgInitBeforeUnload() {
+    window.addEventListener('beforeunload', function (e) {
+        if (_mcgPending.size > 0) {
+            e.preventDefault();
+            e.returnValue = '登録されていない変更があります。ページを離れますか？';
+        }
+    });
+}
+
+/* ─────────────────────────────────────────────
+ * ナビリンク（前4週・翌4週・今日）クリック時の自動保存
+ * ─────────────────────────────────────────── */
+function mcgInitNavSave() {
+    document.querySelectorAll('a.mcg-nav-btn').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+            if (_mcgPending.size === 0) return;
+            e.preventDefault();
+            var href = this.href;
+            mcgRegisterAll().then(function () {
+                window.location.href = href;
+            });
+        });
+    });
+}
+
+function mcgInitHeaderTooltip() {
+    var tip = document.createElement('div');
+    tip.className = 'mcg-tooltip';
+    tip.style.opacity = '0';
+    document.body.appendChild(tip);
+
+    document.querySelectorAll('.mcg-grid thead th[data-tooltip]').forEach(function (th) {
+        th.addEventListener('mouseenter', function (e) {
+            tip.textContent = th.dataset.tooltip;
+            tip.style.opacity = '1';
+            _mcgPositionTooltip(tip, th);
+        });
+        th.addEventListener('mousemove', function () {
+            _mcgPositionTooltip(tip, th);
+        });
+        th.addEventListener('mouseleave', function () {
+            tip.style.opacity = '0';
+        });
+    });
+}
+
+function _mcgPositionTooltip(tip, anchor) {
+    var rect = anchor.getBoundingClientRect();
+    var left = rect.left + rect.width / 2 - tip.offsetWidth / 2;
+    // 画面右端からはみ出さないよう補正
+    left = Math.min(left, window.innerWidth - tip.offsetWidth - 8);
+    left = Math.max(left, 8);
+    tip.style.left = left + 'px';
+    tip.style.top  = (rect.bottom + 6) + 'px';
+}
+
+/* ─────────────────────────────────────────────
+ * 祝日セルに is-holiday クラスを付与
+ * ─────────────────────────────────────────── */
+function mcgApplyHolidays() {
+    if (!window.JapaneseHolidays) return;
+    document.querySelectorAll('[data-date]').forEach(function (el) {
+        var d = new Date(el.dataset.date + 'T00:00:00');
+        if (JapaneseHolidays.isHoliday(d)) {
+            el.classList.add('is-holiday');
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    mcgApplyHolidays();
+    mcgInitConflicts();
+    mcgInitConflictTip();
+    mcgInitToggle();
+    mcgInitBeforeUnload();
+    mcgInitNavSave();
+    mcgInitHeaderTooltip();
+    mcgUpdateRegisterBtn();
+
+    var btn = document.getElementById('mcg-register-btn');
+    if (btn) btn.addEventListener('click', mcgRegisterAll);
+});


### PR DESCRIPTION
## 原因

PR #276 (`investigation/approval-admin-random-count` → `develop`) のマージ時に、そのブランチに存在しなかった `feature/220-excel-grid` 由来のファイルが develop から全て削除されてしまいました。

## 復元内容

- `templates/TReservationInfo/meal_count_grid.php` — グリッド画面テンプレート（371行）
- `webroot/css/pages/meal_count_grid.css` — スタイルシート（736行）
- `webroot/js/pages/meal_count_grid.js` — フロントエンドロジック（465行）
- `tests/TestCase/Service/MealCountGridServiceTest.php` — テスト（405行）
- `config/routes.php` — `/TReservationInfo/meal-count-grid` ルート
- `templates/Pages/dashboard.php` — エクセル食数予約ボタンリンク