### PR TITLE
fix: #259 ReservationBulkServiceTest の過去日テスト修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
@@ -707,14 +707,8 @@ class ReservationBulkService
             if (!is_string($date) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
                 return '無効な日付が含まれています。';
             }
-            try {
-                $targetDate = new Date($date, 'Asia/Tokyo');
-                $today = Date::today('Asia/Tokyo');
-            } catch (\Throwable $e) {
-                return '無効な日付が含まれています。';
-            }
 
-            if ($targetDate < $today) {
+            if ($this->datePolicy->isPastDate($date)) {
                 return (string)Configure::read(
                     'App.messages.pastDateUnavailable',
                     '過去日の内容はこの画面では表示できません。修正が必要な場合は管理者にお問い合わせください。'

--- a/src_web/kamaho-shokusu/src/Service/ReservationDatePolicy.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationDatePolicy.php
@@ -151,6 +151,23 @@ class ReservationDatePolicy
     }
 
     /**
+     * 指定した日付文字列が今日より前(過去日)かどうかを返す。
+     *
+     * @param string $date 'Y-m-d' 形式の日付文字列
+     * @return bool true = 過去日 / false = 今日以降
+     */
+    public function isPastDate(string $date): bool
+    {
+        try {
+            $target = new Date($date, 'Asia/Tokyo');
+        } catch (\Throwable) {
+            return false;
+        }
+
+        return $target < $this->today();
+    }
+
+    /**
      * 予約日に応じて使用すべきDB列名を返す。
      *
      * - 直前編集ウィンドウ内(今日〜+14日): 'i_change_flag' 列を使う

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
@@ -40,9 +40,10 @@ class ReservationBulkServiceTest extends TestCase
     private function makeDatePolicyMock(): ReservationDatePolicy
     {
         $mock = $this->getMockBuilder(ReservationDatePolicy::class)
-            ->onlyMethods(['validateReservationDate'])
+            ->onlyMethods(['validateReservationDate', 'isPastDate'])
             ->getMock();
         $mock->method('validateReservationDate')->willReturn(true);
+        $mock->method('isPastDate')->willReturn(false);
         return $mock;
     }
 


### PR DESCRIPTION
## 変更内容

### 問題
`ReservationBulkServiceTest` の4テストが CI で失敗。
`validateNormalReservationDates` 内の過去日チェックが `ReservationDatePolicy` モックを通らず、
`Date::today()` と直接比較していたため、テストデータの日付（2026-06-01〜03）が今日より前になると失敗する。

### 修正
- `ReservationDatePolicy::isPastDate()` を新規追加
- `ReservationBulkService` の過去日比較を `datePolicy->isPastDate()` 経由に変更
- テストモックに `isPastDate → false` を追加し、日付に依存しないテストに改善