### PR TITLE
fix: ダッシュボードのナビバー表示とシステム管理者のグリッド操作を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1838,7 +1838,7 @@ class TReservationInfoController extends AppController
 
         $loginUserId  = (int)$authUser->get('i_id_user');
         $loginName    = (string)($authUser->get('c_user_name') ?? '');
-        $isAdmin      = (int)($authUser->get('i_admin') ?? 0) === 1;
+        $isAdmin      = in_array((int)($authUser->get('i_admin') ?? 0), [1, 3]);
         $loginStaffId = $authUser->get('i_id_staff');
         $hasStaffId   = $loginStaffId !== null && $loginStaffId !== '' && $loginStaffId !== 0;
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $loginUserId);

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -51,7 +51,6 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
 ?>
 
 <?= $this->Html->css('pages/home.pc.css') ?>
-<?= $this->Html->css('pages/home.mobile.css') ?>
 <?= $this->Html->css('pages/home_choice_modal.css') ?>
 
 <?php if (!$isLoggedIn): ?>

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -62,21 +62,12 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
     </div>
 <?php else: ?>
     <?php /* ログイン済み: ダッシュボード本体を表示する */ ?>
-    <div class="dash-shell mobile-sidebar-collapsed">
-        <?php /* サイドバー要素を読み込む。activeKey='dashboard' でダッシュボードメニューをハイライトする */ ?>
-        <?= $this->element('Pages/home_sidebar', [
-            'user'      => $user,
-            'isAdmin'   => $isAdmin,
-            'activeKey' => 'dashboard'
-        ]) ?>
-
+    <div class="dash-shell">
         <main class="dash-main">
             <?php /* ---- ヘッダー ---- */ ?>
             <div class="dash-header">
                 <div class="dash-title">ダッシュボード</div>
                 <div class="d-flex align-items-center gap-2">
-                    <?php /* モバイル向けサイドバー開閉ボタン */ ?>
-                    <button class="mobile-menu-btn" id="mobile-menu-btn" type="button">メニュー</button>
                     <?php /* 今日の日付ラベル(例: 2026年2月21日(土)) */ ?>
                     <div class="date-pill"><?= h($todayLabel) ?></div>
                     <a class="bell text-decoration-none position-relative" href="<?= $this->Url->build('/Notifications') ?>" aria-label="通知一覧">
@@ -253,8 +244,6 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
             <?php endif; ?>
         </main>
     </div>
-    <?php /* モバイルサイドバー表示中にメインコンテンツを暗くするオーバーレイ */ ?>
-    <div class="mobile-overlay" id="mobile-overlay"></div>
 
     <div id="actual-meal-choice-modal" class="choice-modal-backdrop" aria-hidden="true">
         <div class="choice-modal-card" role="dialog" aria-modal="true" aria-labelledby="actual-meal-choice-title">

--- a/src_web/kamaho-shokusu/webroot/css/pages/home.mobile.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/home.mobile.css
@@ -6,41 +6,4 @@
     .alert-actions { justify-content: flex-start; }
     .menu-card:hover { transform: none; }
     .menu-card:active { background: #e0e7ff; border-color: #a5b4fc; transform: none; }
-
-    .dash-shell.mobile-sidebar-collapsed .dash-sidebar {
-        transform: translateX(-100%);
-    }
-    .dash-sidebar {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 78%;
-        max-width: 320px;
-        height: 100vh;
-        z-index: 60;
-        background: #fff;
-        border-right: 1px solid #e8edf3;
-        transition: transform .2s ease;
-    }
-    .mobile-overlay {
-        display: none;
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, .35);
-        z-index: 50;
-    }
-    .dash-shell.mobile-sidebar-open + .mobile-overlay {
-        display: block;
-    }
-    .mobile-menu-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        padding: 8px 12px;
-        border-radius: 10px;
-        border: 1px solid #e8edf3;
-        background: #fff;
-        color: #475569;
-        font-weight: 700;
-    }
 }

--- a/src_web/kamaho-shokusu/webroot/css/pages/home.mobile.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/home.mobile.css
@@ -1,9 +1,0 @@
-@media (max-width: 992px) {
-    .dash-shell { grid-template-columns: 1fr; }
-    .dash-main { padding: 24px 20px 40px; }
-    .card-grid { grid-template-columns: 1fr; }
-    .alert-card { grid-template-columns: 1fr; }
-    .alert-actions { justify-content: flex-start; }
-    .menu-card:hover { transform: none; }
-    .menu-card:active { background: #e0e7ff; border-color: #a5b4fc; transform: none; }
-}

--- a/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
@@ -13,120 +13,6 @@ main.container { max-width: 100%; padding: 0; }
 .dash-sidebar {
     display: none;
 }
-    background: #ffffff;
-    border-right: 1px solid #e8edf3;
-    padding: 22px 18px;
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
-.brand {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-weight: 700;
-    font-size: 1.2rem;
-    margin-bottom: 18px;
-}
-.brand-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 12px;
-    background: #62cbbf;
-    display: grid;
-    place-items: center;
-    color: #fff;
-    font-size: 1.2rem;
-}
-.profile-card {
-    background: #f7fafc;
-    border: 1px solid #edf2f7;
-    border-radius: 16px;
-    padding: 14px;
-    display: grid;
-    grid-template-columns: 48px 1fr;
-    gap: 12px;
-    align-items: center;
-    margin-bottom: 18px;
-}
-.avatar {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: #e2e8f0;
-    display: grid;
-    place-items: center;
-    font-weight: 700;
-    color: #4a5568;
-}
-.profile-meta {
-    font-size: .85rem;
-    color: #718096;
-}
-.profile-name {
-    font-weight: 700;
-    margin-top: 2px;
-}
-.menu-title {
-    font-size: .85rem;
-    color: #9aa6b2;
-    letter-spacing: .08em;
-    margin: 14px 0 8px;
-}
-.menu-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    border-radius: 12px;
-    text-decoration: none;
-    color: #374151;
-    font-weight: 500;
-}
-.menu-item.active,
-.menu-item:hover {
-    background: #ecfeff;
-    color: #0f766e;
-    font-weight: 700;
-}
-.sidebar-bottom {
-    margin-top: auto;
-    padding-top: 16px;
-}
-.legacy-home-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 16px;
-    border-radius: 18px;
-    border: 2px solid #e5e7eb;
-    color: #1f2937;
-    text-decoration: none;
-    font-weight: 700;
-    background: #ffffff;
-    box-shadow: 0 2px 0 rgba(0,0,0,0.04);
-}
-.legacy-home-btn:hover {
-    background: #f9fafb;
-    color: #111827;
-}
-.legacy-home-icon {
-    width: 28px;
-    height: 28px;
-    border-radius: 10px;
-    background: #e6fffb;
-    color: #0ea5a3;
-    display: grid;
-    place-items: center;
-    font-weight: 700;
-    border: 2px solid #0ea5a3;
-}
-.legacy-home-arrow {
-    font-weight: 900;
-    margin-left: 2px;
-}
 
 .dash-main {
     padding: 26px 28px 40px;
@@ -265,7 +151,11 @@ main.container { max-width: 100%; padding: 0; }
 .menu-title-text { font-weight: 800; font-size: 1rem; }
 .menu-desc { color: #5f6b78; font-size: .95rem; }
 
-@media (min-width: 993px) {
-    .mobile-menu-btn { display: none; }
-    .mobile-overlay { display: none !important; }
+@media (max-width: 992px) {
+    .dash-main { padding: 24px 20px 40px; }
+    .card-grid { grid-template-columns: 1fr; }
+    .alert-card { grid-template-columns: 1fr; }
+    .alert-actions { justify-content: flex-start; }
+    .menu-card:hover { transform: none; }
+    .menu-card:active { background: #e0e7ff; border-color: #a5b4fc; transform: none; }
 }

--- a/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
@@ -1,17 +1,18 @@
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap');
 
-#mainNav { display: none !important; }
-body { padding-top: 0 !important; background: #f6f8fb; }
+body { background: #f6f8fb; }
 main.container { max-width: 100%; padding: 0; }
 
 .dash-shell {
     display: grid;
-    grid-template-columns: 260px 1fr;
+    grid-template-columns: 1fr;
     min-height: 100vh;
     font-family: "M PLUS Rounded 1c", "Noto Sans JP", sans-serif;
     color: #223;
 }
 .dash-sidebar {
+    display: none;
+}
     background: #ffffff;
     border-right: 1px solid #e8edf3;
     padding: 22px 18px;


### PR DESCRIPTION
## 変更内容

### 1. ダッシュボードのレイアウト変更（ナビバー表示・サイドバー非表示）

- `home.pc.css`: `#mainNav { display: none !important; }` を削除し、ナビゲーションバーを表示するように修正
- `home.pc.css`: `body { padding-top: 0 !important; }` を削除し、ナビバー高さ分のパディングを JS が自動付与できるよう修正
- `home.pc.css`: `.dash-shell` のグリッドを `260px 1fr` → `1fr` に変更し、`.dash-sidebar { display: none; }` を追加してサイドバーを非表示化
- `home.mobile.css`: サイドバー・モバイルメニューボタン・オーバーレイ関連の不要スタイルを削除
- `dashboard.php`: サイドバー要素の `element()` 呼び出し・モバイルメニューボタン・オーバーレイ `div` を除去

### 2. mealCountGrid のシステム管理者（i_admin=3）判定漏れを修正

- `TReservationInfoController.php`: `mealCountGrid()` 内の `$isAdmin` 判定を `=== 1` から `in_array([1, 3])` に変更
- システム管理者（i_admin=3）が通常管理者（i_admin=1）と同様に `$canViewAll = true` と判定されるようになり、個人モード以外の部屋・全体モードや過去日ナビゲーションが正しく動作するようになった