### PR TITLE
Resolve #295: 管理者の食数グリッド他ユーザー予約操作とロール判定の修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Domain\ValueObject\UserRole;
 use App\Service\ApiResponseService;
 use App\Service\UserBulkImportService;
 use App\Service\UserCreateService;
@@ -126,8 +127,8 @@ class MUserInfoController extends AppController
         }
 
         $user          = $this->request->getAttribute('identity');
-        $isAdmin       = in_array((int)$user->i_admin, [1, 3]);
-        $isSystemAdmin = (int)$user->i_admin === 3;
+        $isAdmin       = UserRole::isAdmin((int)$user->i_admin);
+        $isSystemAdmin = UserRole::isSystemAdmin((int)$user->i_admin);
         $currentUserId = $user->i_id_user;
         $showDeleted   = ($isAdmin || $isSystemAdmin) && $this->request->getQuery('show_deleted') === '1';
 
@@ -509,7 +510,7 @@ class MUserInfoController extends AppController
                 1
             );
 
-            if (in_array((int)$user->i_admin, [1, 3])) {
+            if (UserRole::isAdmin((int)$user->i_admin)) {
                 $defaultRedirect = ['controller' => 'TReservationInfo', 'action' => 'index'];
             } elseif ((int)$user->i_user_level === 1) {
                 $defaultRedirect = ['controller' => 'TReservationInfo', 'action' => 'index'];

--- a/src_web/kamaho-shokusu/src/Controller/PagesController.php
+++ b/src_web/kamaho-shokusu/src/Controller/PagesController.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace App\Controller;
 
+use App\Domain\ValueObject\UserRole;
 use App\Service\ApprovalService;
 use App\Service\DashboardService;
 use Cake\Core\Configure;
@@ -196,8 +197,8 @@ class PagesController extends AppController
                 ->select(['i_admin'])
                 ->where(['i_id_user' => $userId])
                 ->first();
-            $isAdmin = in_array((int)($currentUser?->i_admin ?? $user->get('i_admin') ?? 0), [1, 3]);
-            $isBlockLeader = (int)($currentUser?->i_admin ?? $user->get('i_admin') ?? 0) === 2;
+            $isAdmin = UserRole::isAdmin((int)($currentUser?->i_admin ?? $user->get('i_admin') ?? 0));
+            $isBlockLeader = UserRole::isBlockLeader((int)($currentUser?->i_admin ?? $user->get('i_admin') ?? 0));
 
             // ログインユーザー自身の本日の予約レコード有無で申告済みを判定する
             // 「食べる」「食べない」どちらの申告でもレコードが作成されるため、

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1921,13 +1921,14 @@ class TReservationInfoController extends AppController
             $users  = $gridService->getRoomUsers($this->MUserGroup, $this->MUserInfo, $roomId);
 
             if ($viewMode === 'individual') {
-                if ($hasStaffId) {
-                    // 職員IDを持つ場合: 自分 + 同部屋の子供ユーザー(i_user_level=1)を表示
+                if (!$canViewAll && $hasStaffId) {
+                    // 非管理者の職員: 自分 + 同部屋の子供ユーザー(i_user_level=1)を表示
                     $users = array_values(array_filter(
                         $users,
                         fn($u) => (int)$u['id'] === $loginUserId || (int)($u['i_user_level'] ?? 0) === 1
                     ));
                 } else {
+                    // 管理者または職員IDなしユーザー: 選択ユーザーのみ表示
                     $users = array_values(array_filter($users, fn($u) => (int)$u['id'] === $selectedUserId));
                 }
             }

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use App\Controller\Traits\ReservationBulkActionsTrait;
 use App\Controller\Traits\ReservationCopyActionsTrait;
 use App\Controller\Traits\ReservationReportActionsTrait;
+use App\Domain\ValueObject\UserRole;
 use Authorization\Exception\ForbiddenException;
 use App\Service\BulkReservationFormService;
 use Cake\Http\Exception\NotFoundException;
@@ -146,7 +147,7 @@ class TReservationInfoController extends AppController
         $userRoomId = $this->calendarService->getPrimaryRoomId($userRoomIds);
 
         /* ========== ここから: 部屋セレクト用の $rooms を必ず用意 ========== */
-        $isAdmin = in_array((int)($user->i_admin ?? 0), [1, 3]);
+        $isAdmin = UserRole::isAdmin((int)($user->i_admin ?? 0));
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, (int)$userId);
         $canViewAllRooms = $isAdmin || $isOfficeUser;
         $rooms = $this->calendarService->getRoomsForUser($this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser);
@@ -262,7 +263,7 @@ class TReservationInfoController extends AppController
             return $this->apiResponseService->error($this->response, 'Date range too large', 400);
         }
 
-        $isAdmin = in_array((int)($user->i_admin ?? 0), [1, 3]);
+        $isAdmin = UserRole::isAdmin((int)($user->i_admin ?? 0));
         $canViewAllRooms = $isAdmin || $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, (int)$userId);
 
         $userRoomIds = $this->calendarService->getUserRoomIds($this->MUserGroup, (int)$userId);
@@ -917,7 +918,7 @@ class TReservationInfoController extends AppController
         // 403 の理由をユーザーにわかりやすく伝えるため、ロール・所属別のメッセージを返す
         $loginUser = $this->request->getAttribute('identity');
         if ($loginUser !== null) {
-            $isAdmin  = in_array((int)($loginUser->get('i_admin') ?? 0), [1, 3]);
+            $isAdmin  = UserRole::isAdmin((int)($loginUser->get('i_admin') ?? 0));
             $isStaff  = (int)($loginUser->get('i_user_level') ?? -1) === 0;
             if (!$isAdmin && !$isStaff) {
                 // 職員・管理者でない場合は所属部屋があるか確認
@@ -1431,8 +1432,8 @@ class TReservationInfoController extends AppController
         }
 
         $userId  = (int)$authUser->get('i_id_user');
-        $isAdmin = in_array((int)($authUser->get('i_admin') ?? 0), [1, 3]);
-        $canProxyActualMeal = $isAdmin || (int)($authUser->get('i_admin') ?? 0) === 2;
+        $isAdmin = UserRole::isAdmin((int)($authUser->get('i_admin') ?? 0));
+        $canProxyActualMeal = $isAdmin || UserRole::isBlockLeader((int)($authUser->get('i_admin') ?? 0));
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $userId);
         $canViewAllRooms = $isAdmin || $isOfficeUser;
 
@@ -1547,8 +1548,8 @@ class TReservationInfoController extends AppController
         }
 
         $userId  = (int)$authUser->get('i_id_user');
-        $isAdmin = in_array((int)($authUser->get('i_admin') ?? 0), [1, 3]);
-        $isBlockLeader = (int)($authUser->get('i_admin') ?? 0) === 2;
+        $isAdmin = UserRole::isAdmin((int)($authUser->get('i_admin') ?? 0));
+        $isBlockLeader = UserRole::isBlockLeader((int)($authUser->get('i_admin') ?? 0));
         $canProxyActualMeal = $isAdmin || $isBlockLeader;
 
         // ユーザーの所属部屋
@@ -1784,8 +1785,8 @@ class TReservationInfoController extends AppController
     private function validateActualMealTarget($authUser, int $targetUid, int $roomId): ?string
     {
         $loginUid  = (int)($authUser?->get('i_id_user') ?? 0);
-        $isAdmin = in_array((int)($authUser?->get('i_admin') ?? 0), [1, 3]);
-        $isBlockLeader = (int)($authUser?->get('i_admin') ?? 0) === 2;
+        $isAdmin = UserRole::isAdmin((int)($authUser?->get('i_admin') ?? 0));
+        $isBlockLeader = UserRole::isBlockLeader((int)($authUser?->get('i_admin') ?? 0));
 
         if ($isAdmin) {
             return null;
@@ -1838,7 +1839,7 @@ class TReservationInfoController extends AppController
 
         $loginUserId  = (int)$authUser->get('i_id_user');
         $loginName    = (string)($authUser->get('c_user_name') ?? '');
-        $isAdmin      = in_array((int)($authUser->get('i_admin') ?? 0), [1, 3]);
+        $isAdmin      = UserRole::isAdmin((int)($authUser->get('i_admin') ?? 0));
         $loginStaffId = $authUser->get('i_id_staff');
         $hasStaffId   = $loginStaffId !== null && $loginStaffId !== '' && $loginStaffId !== 0;
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $loginUserId);

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1867,8 +1867,8 @@ class TReservationInfoController extends AppController
             $isOfficeUser
         );
 
-        // 各部屋・全部モードでは所属部屋のみ表示する（管理者でも自分が所属する部屋に限定）
-        if ($viewMode === 'room' || $viewMode === 'all') {
+        // 各部屋・全部モードでは非管理者のみ所属部屋に絞り込む（管理者は全部屋を表示）
+        if (!$isAdmin && ($viewMode === 'room' || $viewMode === 'all')) {
             $allRooms = array_intersect_key($allRooms, array_flip($userRoomIds));
         }
 

--- a/src_web/kamaho-shokusu/src/Controller/Traits/ReservationBulkActionsTrait.php
+++ b/src_web/kamaho-shokusu/src/Controller/Traits/ReservationBulkActionsTrait.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Controller\Traits;
 
+use App\Domain\ValueObject\UserRole;
+
 trait ReservationBulkActionsTrait
 {
     protected function runGetUsersByRoomForBulk($roomId)
@@ -76,7 +78,7 @@ trait ReservationBulkActionsTrait
         $selectedRoomId = $this->request->getQuery('room_id') ?? '';
         $baseWeekParam = $this->request->getQuery('base_week');
         $formData = $bulkFormService->buildBulkAddData((string)$selectedDate, $baseWeekParam);
-        $canGroup = (in_array((int)$this->request->getAttribute('identity')->get('i_admin'), [1, 3])
+        $canGroup = (UserRole::isAdmin((int)$this->request->getAttribute('identity')->get('i_admin'))
             || (int)$this->request->getAttribute('identity')->get('i_user_level') === 0);
 
         $this->set(compact(

--- a/src_web/kamaho-shokusu/src/Domain/ValueObject/UserRole.php
+++ b/src_web/kamaho-shokusu/src/Domain/ValueObject/UserRole.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Domain\ValueObject;
+
+/**
+ * ユーザーロール定数クラス。
+ *
+ * i_admin カラムの値とロール判定ロジックを一元管理する。
+ * マジックナンバーの散在を防ぎ、ロール追加時の修正箇所を最小化する。
+ */
+final class UserRole
+{
+    public const GENERAL      = 0;
+    public const ADMIN        = 1;
+    public const BLOCK_LEADER = 2;
+    public const SYSTEM_ADMIN = 3;
+
+    /** 管理者またはシステム管理者かどうかを返す。 */
+    public static function isAdmin(int $value): bool
+    {
+        return in_array($value, [self::ADMIN, self::SYSTEM_ADMIN], true);
+    }
+
+    /** ブロック長かどうかを返す。 */
+    public static function isBlockLeader(int $value): bool
+    {
+        return $value === self::BLOCK_LEADER;
+    }
+
+    /** システム管理者かどうかを返す。 */
+    public static function isSystemAdmin(int $value): bool
+    {
+        return $value === self::SYSTEM_ADMIN;
+    }
+
+    private function __construct() {}
+}

--- a/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Service\RoomAccessService;
 use Authorization\IdentityInterface;
 
@@ -74,15 +76,15 @@ class ApprovalPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;
@@ -96,15 +98,15 @@ class ApprovalPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_admin') === 2;
+            return UserRole::isBlockLeader((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return (int)($identity['i_admin'] ?? 0) === 2;
+            return UserRole::isBlockLeader((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_admin'] ?? 0) === 2;
+            return UserRole::isBlockLeader((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/AuditLogPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/AuditLogPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use Authorization\IdentityInterface;
 
 /**
@@ -33,13 +35,13 @@ class AuditLogPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_admin') === 3;
+            return UserRole::isSystemAdmin((int)$identity->get('i_admin'));
         }
         if (is_array($identity)) {
-            return (int)($identity['i_admin'] ?? 0) === 3;
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
         }
         if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_admin'] ?? 0) === 3;
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
         }
         return false;
     }

--- a/src_web/kamaho-shokusu/src/Policy/ContactsPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/ContactsPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use Authorization\IdentityInterface;
 
 /**
@@ -44,11 +46,11 @@ final class ContactsPolicy
         $identity = $user->getOriginalData();
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity) || $identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/MMealPriceInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MMealPriceInfoPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Model\Entity\MMealPriceInfo;
 use Authorization\IdentityInterface;
 
@@ -41,15 +43,15 @@ class MMealPriceInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/MRoomInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MRoomInfoPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Model\Entity\MRoomInfo;
 use Authorization\IdentityInterface;
 
@@ -41,15 +43,15 @@ class MRoomInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/MRoomTransferSchedulePolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MRoomTransferSchedulePolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use Authorization\IdentityInterface;
 
 class MRoomTransferSchedulePolicy
@@ -34,11 +36,11 @@ class MRoomTransferSchedulePolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/MUserInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MUserInfoPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Model\Entity\MUserInfo;
 use Authorization\IdentityInterface;
 
@@ -96,15 +98,15 @@ class MUserInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;
@@ -136,13 +138,13 @@ class MUserInfoPolicy
             return false;
         }
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_admin') === 3;
+            return UserRole::isSystemAdmin((int)$identity->get('i_admin'));
         }
         if (is_array($identity)) {
-            return (int)($identity['i_admin'] ?? 0) === 3;
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
         }
         if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_admin'] ?? 0) === 3;
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
         }
         return false;
     }

--- a/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Model\Entity\TContact;
 use Authorization\IdentityInterface;
 
@@ -51,15 +53,15 @@ class TContactPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\Policy;
 
+use App\Domain\ValueObject\UserRole;
+
 use App\Model\Entity\TReservationInfo;
 use App\Service\RoomAccessService;
 use Authorization\IdentityInterface;
@@ -214,15 +216,15 @@ class TReservationInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return in_array((int)$identity->get('i_admin'), [1, 3]);
+            return UserRole::isAdmin((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+            return UserRole::isAdmin((int)($identity['i_admin'] ?? 0));
         }
 
         return false;
@@ -258,15 +260,15 @@ class TReservationInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_admin') === 2;
+            return UserRole::isBlockLeader((int)$identity->get('i_admin'));
         }
 
         if (is_array($identity)) {
-            return (int)($identity['i_admin'] ?? 0) === 2;
+            return UserRole::isBlockLeader((int)($identity['i_admin'] ?? 0));
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_admin'] ?? 0) === 2;
+            return UserRole::isBlockLeader((int)($identity['i_admin'] ?? 0));
         }
 
         return false;

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -60,6 +60,8 @@ class TReservationInfoPolicy
             return true;
         }
 
+        $loginUserId = $this->getUserId($user);
+
         // 自分自身の予約操作は常に許可。
         if ($requestedUserId === $loginUserId) {
             return true;

--- a/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationChangeEditService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Domain\ValueObject\UserRole;
 use App\Exception\OptimisticLockConflictException;
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
@@ -149,7 +150,7 @@ class ReservationChangeEditService
     {
         // 管理者・職員・所属グループユーザーは部屋内の全ユーザーを編集できる
         $canEditAll = $isRoomManager || ($loginUser && (
-            (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
+            UserRole::isAdmin((int)($loginUser->get('i_admin') ?? 0)) ||
             (int)($loginUser->get('i_user_level') ?? -1) === 0
         ));
         $loginUid = $loginUser?->get('i_id_user');
@@ -191,7 +192,7 @@ class ReservationChangeEditService
             // ログインユーザーの編集権限を確定する（buildUsersForJson と同一ロジック）
             $loginUid    = $loginUser ? (int)$loginUser->get('i_id_user') : 0;
             $canEditAll  = $isRoomManager || ($loginUser && (
-                (int)($loginUser->get('i_admin')      ?? 0) === 1 ||
+                UserRole::isAdmin((int)($loginUser->get('i_admin') ?? 0)) ||
                 (int)($loginUser->get('i_user_level') ?? -1) === 0
             ));
 

--- a/src_web/kamaho-shokusu/src/Service/ReservationViewService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationViewService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Domain\ValueObject\UserRole;
 use Cake\I18n\Date;
 use Cake\ORM\Table;
 
@@ -52,7 +53,7 @@ class ReservationViewService
             if ($userRoomId !== null) {
                 $userRoomId = (int)$userRoomId;
             }
-            $isAdmin = in_array((int)$user->get('i_admin'), [1, 3]);
+            $isAdmin = UserRole::isAdmin((int)$user->get('i_admin'));
         }
 
         $date = $dateParam;

--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -10,6 +10,7 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 
 class ReservationWriteService
 {

--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Domain\ValueObject\UserRole;
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use Cake\Cache\Cache;
@@ -495,7 +496,7 @@ class ReservationWriteService
             ->select(['i_admin', 'i_user_level', 'i_id_staff'])
             ->where(['i_id_user' => $loginUserId])
             ->first();
-        $isAdmin    = $loginUser ? ((int)$loginUser->i_admin === 1) : false;
+        $isAdmin    = $loginUser ? UserRole::isAdmin((int)$loginUser->i_admin) : false;
         $loginStaff = $loginUser ? $loginUser->i_id_staff : null;
         $hasStaffId = $loginStaff !== null && $loginStaff !== '' && $loginStaff !== 0;
 

--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -577,7 +577,7 @@ class ReservationWriteService
             'i_reservation_type' => $meal,
         ]);
 
-        if ($isLastMinute && $targetUserLevel === 0 && $value === 0 && $exists) {
+        if (!$isAdmin && $isLastMinute && $targetUserLevel === 0 && $value === 0 && $exists) {
             return [
                 'status' => 403,
                 'body' => ['ok' => false, 'message' => '職員は直前編集でのキャンセルはできません。'],


### PR DESCRIPTION
Closes #295

## 変更内容

### 新規追加
- `Domain/ValueObject/UserRole.php` — `i_admin` カラムのロール判定を一元管理する定数クラスを新設。`isAdmin()`（1または3）、`isBlockLeader()`（2）、`isSystemAdmin()`（3）のメソッドを提供し、コード全体のマジックナンバーを排除。

### バグ修正
- **管理者が各部屋・全部モードで全部屋を閲覧できない問題**（`TReservationInfoController::mealCountGrid()`）  
  - `viewMode === 'room'` または `'all'` 時に管理者も所属部屋に限定されていたロジックを修正し、管理者は全部屋を表示・編集できるように変更。

- **管理者が職員の直前期間キャンセルを制限される問題**（`ReservationWriteService::processToggle()`）  
  - 職員の直前キャンセル禁止チェックに `!$isAdmin` 条件を追加し、管理者は常に操作可能に変更。

- **`canToggle` ポリシーの `$loginUserId` 未定義バグ**（`TReservationInfoPolicy::canToggle()`）  
  - `$loginUserId` の代入を `if ($requestedUserId <= 0)` の早期リターンより後（＝実際に使用する前）に移動し、PHP Warning を解消。

- **`ReservationWriteService` で `TableRegistry` が解決できないバグ**（`ReservationWriteService::processToggle()`）  
  - `use Cake\ORM\TableRegistry;` が欠落していたため `Class "App\Service\TableRegistry" not found` エラーが発生し、管理者が他ユーザーの予約をトグルできなかった問題を修正。

- **`mealCountGrid` 個人モードで管理者が職員IDを持つ場合に全ユーザーが表示される問題**  
  - 非管理者かつ職員IDありの場合のみ子供ユーザーを追加表示するよう条件を修正。

- **`isAdmin` 判定でシステム管理者（i_admin=3）が管理者として認識されない問題**（コントローラー・サービス・ポリシー全体）  
  - 各所に散在していた `in_array((int)$admin, [1, 3])` または `=== 1` を `UserRole::isAdmin()` に統一し、判定漏れを解消。

### その他
- 監査ログのIPアドレス取得を `$this->getClientIp()`（`X-Real-IP` / `X-Forwarded-For` 優先）に統一。
- セッション認証に `identify: true` を追加し、ロール変更をDB再取得で即時反映（再ログイン不要）。