### PR TITLE
fix: お知らせ作成画面のラジオボタン表示崩れを修正

### DIFF
--- a/src_web/kamaho-shokusu/templates/MNotice/add.php
+++ b/src_web/kamaho-shokusu/templates/MNotice/add.php
@@ -62,14 +62,12 @@ $this->assign('title', 'お知らせ作成');
         <label class="form-label fw-bold">重要度</label>
         <div class="d-flex gap-3">
             <div class="form-check">
-                <?= $this->Form->radio('i_importance', [
-                    0 => '通常',
-                    1 => '重要',
-                ], [
-                    'class'   => 'form-check-input',
-                    'value'   => 0,
-                    'escape'  => false,
-                ]) ?>
+                <input class="form-check-input" type="radio" name="i_importance" id="imp_normal" value="0" checked>
+                <label class="form-check-label" for="imp_normal">通常</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="i_importance" id="imp_high" value="1">
+                <label class="form-check-label" for="imp_high">重要</label>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 変更内容

- `templates/MNotice/add.php` の重要度ラジオボタンを修正
  - `$this->Form->radio()` ヘルパーが値（`0` / `1`）とラベルテキスト（「通常」「重要」）を同一要素内に出力し、文字が重なって表示されていた
  - `edit.php` と同じ手書きの `<input type="radio">` + `<label>` に統一し、「通常」をデフォルト選択状態に設定

## 関連
- #299（お知らせ掲示機能）の UI 修正