### PR TITLE
fix: FormProtection の unlockedFields を beforeFilter に移動

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MNoticeController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MNoticeController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use Authorization\Exception\ForbiddenException;
+use Cake\Event\EventInterface;
 use Cake\Http\Response;
 
 /**
@@ -18,6 +19,16 @@ class MNoticeController extends AppController
     {
         parent::initialize();
         $this->viewBuilder()->setLayout('default');
+    }
+
+    /**
+     * FormProtection::startup() より前に実行されるため、ここで unlockedFields を設定する。
+     * i_importance はプレーン HTML の radio で生成するため Form ヘルパーが追跡しない。
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+        $this->FormProtection->setConfig('unlockedFields', ['i_importance']);
     }
 
     /**
@@ -49,7 +60,6 @@ class MNoticeController extends AppController
     public function add(): ?Response
     {
         $this->request->allowMethod(['get', 'post']);
-        $this->FormProtection->setConfig('unlockedFields', ['i_importance']);
 
         $table    = $this->fetchTable('MNotice');
         $resource = $table->newEmptyEntity();
@@ -98,7 +108,6 @@ class MNoticeController extends AppController
     public function edit(int $id): ?Response
     {
         $this->request->allowMethod(['get', 'post']);
-        $this->FormProtection->setConfig('unlockedFields', ['i_importance']);
 
         $table    = $this->fetchTable('MNotice');
         $resource = $table->newEmptyEntity();


### PR DESCRIPTION
## 変更内容

- `MNoticeController` の `unlockedFields` 設定を `add()` / `edit()` アクション内から `beforeFilter()` に移動

### 修正理由

CakePHP のイベント実行順は以下の通り:

```
beforeFilter()  ← ここで設定が必要
FormProtection::startup()  ← formTokenData に unlockedFields を書き込む
アクション実行  ← 前回の修正はここに書いていたため startup() に間に合わず
ビュー描画
```

アクション内で `setConfig('unlockedFields', ...)` を呼んでも、`startup()` が既にトークンを生成した後のため無効だった。
`beforeFilter()` に移動することで `startup()` 実行前に設定が反映され、`i_importance` フィールドが正しくトークンの除外リストに含まれるようになった。