### PR TITLE
fix: #248 json_decode 堅牢化・unlockedActions の意図を明確化

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -24,6 +24,9 @@ class ApprovalController extends AppController
         $this->approvalService   = new ApprovalService();
         $this->roomAccessService = new RoomAccessService();
 
+        // これらのアクションは JSON ボディを受け取る AJAX エンドポイントのため
+        // FormProtection のフォームトークン検証対象外にする。
+        // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
         $this->FormProtection->setConfig('unlockedActions', [
             'blockLeaderApprove',
             'blockLeaderReject',

--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -48,6 +48,9 @@ class MUserInfoController extends AppController
         $this->userRestoreService       = new UserRestoreService();
         $this->userRoomAssignmentService = new UserRoomAssignmentService();
 
+        // これらのアクションは JSON ボディを受け取る AJAX エンドポイントのため
+        // FormProtection のフォームトークン検証対象外にする。
+        // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
         $this->FormProtection->setConfig('unlockedActions', [
             'importJson',
             'updateAdminStatus',
@@ -96,7 +99,15 @@ class MUserInfoController extends AppController
 
         $payload = $this->request->getData();
         if (empty($payload)) {
-            $payload = json_decode((string)$this->request->getBody(), true) ?? [];
+            $raw = (string)$this->request->getBody();
+            if ($raw !== '') {
+                try {
+                    $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    throw new BadRequestException('リクエストボディが不正な JSON です。');
+                }
+            }
+            $payload = is_array($payload) ? $payload : [];
         }
         $records = $payload['records'] ?? null;
         if (!is_array($records)) {

--- a/src_web/kamaho-shokusu/src/Controller/NotificationsController.php
+++ b/src_web/kamaho-shokusu/src/Controller/NotificationsController.php
@@ -15,6 +15,8 @@ class NotificationsController extends AppController
         parent::initialize();
         $this->notificationService = new NotificationService();
 
+        // JSON ボディを受け取る AJAX エンドポイントのため FormProtection のフォームトークン検証対象外にする。
+        // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
         $this->FormProtection->setConfig('unlockedActions', [
             'markRead',
             'markAllRead',

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -107,6 +107,10 @@ class TReservationInfoController extends AppController
         // $this->viewBuilder()->setOption('serialize', true);
         $this->viewBuilder()->setLayout('default');
 
+        // JSON ボディを受け取る AJAX エンドポイントは FormProtection のフォームトークン検証対象外にする。
+        // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
+        // view・bulkChangeEditForm は GET アクションだが、FormProtection は POST にのみ適用されるため
+        // 実質無害。将来的にリストから除外可能。
         $this->FormProtection->setConfig('unlockedActions', [
             'add',
             'toggle',

--- a/src_web/kamaho-shokusu/src/Controller/Traits/ReservationCopyActionsTrait.php
+++ b/src_web/kamaho-shokusu/src/Controller/Traits/ReservationCopyActionsTrait.php
@@ -21,8 +21,8 @@ trait ReservationCopyActionsTrait
             try {
                 $raw = (string)$this->request->getBody();
                 if ($raw !== '') {
-                    $json = json_decode($raw, true);
-                    if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
+                    $json = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+                    if (is_array($json)) {
                         $data = $json;
                     }
                 }
@@ -101,8 +101,8 @@ trait ReservationCopyActionsTrait
             try {
                 $raw = (string)$this->request->getBody();
                 if ($raw !== '') {
-                    $json = json_decode($raw, true);
-                    if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
+                    $json = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+                    if (is_array($json)) {
                         $data = $json;
                     }
                 }


### PR DESCRIPTION
## 対応内容

Issue #248 の残作業のうち、高優先度の安全に対処できる項目を修正します。

---

## 変更内容

### `json_decode` に `JSON_THROW_ON_ERROR` を追加（3箇所）

**`MUserInfoController::importJson()`**
- 変更前: `json_decode(..., true) ?? []` のみで不正 JSON をサイレントに空配列として扱っていた
- 変更後: `JSON_THROW_ON_ERROR` を追加し、不正 JSON を `BadRequestException`（HTTP 400）として明示的に返却するよう変更

**`ReservationCopyActionsTrait::runCopy()` / `runCopyPreview()`（各1箇所）**
- 変更前: `json_decode($raw, true)` + `json_last_error() === JSON_ERROR_NONE` による手動チェック
- 変更後: `json_decode($raw, true, 512, JSON_THROW_ON_ERROR)` に統一。既存の `catch (\Throwable $e)` で捕捉されるため動作変更なし

### `unlockedActions` にコメントを追記（4コントローラー）

`ApprovalController` / `TReservationInfoController` / `MUserInfoController` / `NotificationsController` の `unlockedActions` 設定に、設定が正当である理由を明記しました。

- これらのアクションは JSON ボディを受け取る AJAX エンドポイントであり、CakePHP FormProtection のフォームトークン検証は不要
- **CSRF 保護は `CsrfProtectionMiddleware` がミドルウェア層で全エンドポイントに適用済み**（`Application.php` で確認済み）

---

## スコープ外（別 PR 推奨）

| 項目 | 理由 |
|---|---|
| Domain 層整備 / Repository パターン導入 | 全サービス・コントローラー横断の大規模リファクタリング |
| `skipAuthorization()` in login/logout/MMenuInfo | login・logout は認可前提にできない設計上の正当な使用。MMenuInfo は全認証ユーザー向け共通 API でコメント付き |