### PR TITLE
Resolve #331: 直前編集モーダルで予約タイプ切替時に部屋・利用者が表示されないバグを修正

### DIFF
--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -133,8 +133,9 @@
             showLoading();
             try{
                 const json = await fetchUsersByRoom(roomId, date);
-                const users = Array.isArray(json.usersByRoom) ? json.usersByRoom
-                    : (Array.isArray(json.users) ? json.users : []);
+                const payload = (json && json.data) ? json.data : json;
+                const users = Array.isArray(payload.usersByRoom) ? payload.usersByRoom
+                    : (Array.isArray(payload.users) ? payload.users : []);
                     
                 if (!userCheckboxesTbody) return;
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1216,7 +1216,8 @@ function unlockForChildren(wrap){
                                 }
                             })
                             .then(function(d){
-                                var users = d && d.usersByRoom;
+                                var payload = (d && d.data) ? d.data : d;
+                                var users = payload && payload.usersByRoom;
                                 if (!Array.isArray(users)) {
                                     throw new Error('usersByRoom が配列ではありません');
                                 }
@@ -1383,7 +1384,7 @@ function unlockForChildren(wrap){
                 }, 200);
             }
 
-            if (typeof window.initReservationForm === 'function') {
+            if (!addJsBooted && typeof window.initReservationForm === 'function') {
                 window.initReservationForm();
             }
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1283,7 +1283,13 @@ function unlockForChildren(wrap){
 
             function show(elList, on){
                 elList.forEach(function(el){
-                    el.style.display = on ? '' : 'none';
+                    if (on) {
+                        el.classList.remove('d-none');
+                        el.style.removeProperty('display');
+                    } else {
+                        el.classList.add('d-none');
+                        el.style.removeProperty('display');
+                    }
                 });
             }
 
@@ -1322,14 +1328,21 @@ function unlockForChildren(wrap){
 
             function applyMode(val){
                 var v = String(val || '').toLowerCase();
-                var isGroup = /group|collect| |^2$/.test(v);
+                if (!v) {
+                    show(personalBlocks, false);
+                    show(groupBlocks, false);
+                    var hint = scope.querySelector('#reserve-type-hint');
+                    if (hint) hint.style.display = '';
+                    return;
+                }
+                var isGroup = /^2$|group|collect/.test(v);
                 show(personalBlocks, !isGroup);
                 show(groupBlocks,    isGroup);
                 toggleTable(v);
                 clearHiddenInputs(isGroup);
 
                 var hint = scope.querySelector('#reserve-type-hint');
-                if (hint) hint.style.display = val ? 'none' : '';
+                if (hint) hint.style.display = 'none';
             }
 
             if (select) {
@@ -1348,13 +1361,12 @@ function unlockForChildren(wrap){
                         var roomId = roomSelect.value;
                         var tbody = document.getElementById('user-checkboxes');
                         if (tbody) tbody.innerHTML = '';
+                        var groupContainer = scope.querySelector('#user-selection-table');
                         if (!roomId) {
-                            var groupContainer = scope.querySelector('#user-selection-table');
-                            if (groupContainer) groupContainer.style.display = 'none';
+                            if (groupContainer) { groupContainer.classList.add('d-none'); groupContainer.style.removeProperty('display'); }
                             return;
                         }
-                        var groupContainer = scope.querySelector('#user-selection-table');
-                        if (groupContainer) groupContainer.style.display = '';
+                        if (groupContainer) { groupContainer.classList.remove('d-none'); groupContainer.style.removeProperty('display'); }
                         window.fetchUserData(roomId);
                     }
                     roomSelect.removeEventListener('change', roomSelect._handleRoomChange || (() => {}));
@@ -1990,10 +2002,10 @@ function unlockForChildren(wrap){
                     var tbody = scope.querySelector('#user-checkboxes');
                     if (tbody) tbody.innerHTML = '';
                     if (!roomId) {
-                        if (groupContainer) groupContainer.style.display = 'none';
+                        if (groupContainer) { groupContainer.classList.add('d-none'); groupContainer.style.removeProperty('display'); }
                         return;
                     }
-                    if (groupContainer) groupContainer.style.display = '';
+                    if (groupContainer) { groupContainer.classList.remove('d-none'); groupContainer.style.removeProperty('display'); }
                     window.fetchUserData(roomId);
                 }
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1345,38 +1345,43 @@ function unlockForChildren(wrap){
                 if (hint) hint.style.display = 'none';
             }
 
-            if (select) {
-                applyMode(select.value);
-                select.addEventListener('change', function(){ applyMode(select.value); });
-            }
+            var ceRoot = scope.querySelector('#ce-root') || scope;
+            var addJsBooted = !!(ceRoot && ceRoot.__ADD_FORM_BOOTED__);
 
-            setTimeout(function() {
-                roomSelect = scope.querySelector('#room-select') ||
-                    scope.querySelector('select[name*="room"]') ||
-                    scope.querySelector('#room_select') ||
-                    scope.querySelector('.room-select');
-
-                if (roomSelect) {
-                    function handleRoomChange() {
-                        var roomId = roomSelect.value;
-                        var tbody = document.getElementById('user-checkboxes');
-                        if (tbody) tbody.innerHTML = '';
-                        var groupContainer = scope.querySelector('#user-selection-table');
-                        if (!roomId) {
-                            if (groupContainer) { groupContainer.classList.add('d-none'); groupContainer.style.removeProperty('display'); }
-                            return;
-                        }
-                        if (groupContainer) { groupContainer.classList.remove('d-none'); groupContainer.style.removeProperty('display'); }
-                        window.fetchUserData(roomId);
-                    }
-                    roomSelect.removeEventListener('change', roomSelect._handleRoomChange || (() => {}));
-                    roomSelect._handleRoomChange = handleRoomChange;
-                    roomSelect.addEventListener('change', handleRoomChange);
-                    if (roomSelect.value) {
-                        setTimeout(function() { handleRoomChange(); }, 100);
-                    }
+            if (!addJsBooted) {
+                if (select) {
+                    applyMode(select.value);
+                    select.addEventListener('change', function(){ applyMode(select.value); });
                 }
-            }, 200);
+
+                setTimeout(function() {
+                    roomSelect = scope.querySelector('#room-select') ||
+                        scope.querySelector('select[name*="room"]') ||
+                        scope.querySelector('#room_select') ||
+                        scope.querySelector('.room-select');
+
+                    if (roomSelect) {
+                        function handleRoomChange() {
+                            var roomId = roomSelect.value;
+                            var tbody = document.getElementById('user-checkboxes');
+                            if (tbody) tbody.innerHTML = '';
+                            var groupContainer = scope.querySelector('#user-selection-table');
+                            if (!roomId) {
+                                if (groupContainer) { groupContainer.classList.add('d-none'); groupContainer.style.removeProperty('display'); }
+                                return;
+                            }
+                            if (groupContainer) { groupContainer.classList.remove('d-none'); groupContainer.style.removeProperty('display'); }
+                            window.fetchUserData(roomId);
+                        }
+                        roomSelect.removeEventListener('change', roomSelect._handleRoomChange || (() => {}));
+                        roomSelect._handleRoomChange = handleRoomChange;
+                        roomSelect.addEventListener('change', handleRoomChange);
+                        if (roomSelect.value) {
+                            setTimeout(function() { handleRoomChange(); }, 100);
+                        }
+                    }
+                }, 200);
+            }
 
             if (typeof window.initReservationForm === 'function') {
                 window.initReservationForm();
@@ -1992,6 +1997,9 @@ function unlockForChildren(wrap){
         window.ensureAddModalCompat = function(host){
             if (typeof _origEnsure === 'function') _origEnsure(host);
             var scope = host || document;
+
+            var ceRoot2 = scope.querySelector ? (scope.querySelector('#ce-root') || scope) : scope;
+            if (ceRoot2 && ceRoot2.__ADD_FORM_BOOTED__) return;
 
             setTimeout(function() {
                 var select = scope.querySelector('#room-select');

--- a/src_web/kamaho-shokusu/webroot/js/reservation.js
+++ b/src_web/kamaho-shokusu/webroot/js/reservation.js
@@ -126,8 +126,9 @@
     async function fetchUserData(roomId){
         try {
             const data = await fetchUsersByRoom(roomId, date);
-            const users = Array.isArray(data.usersByRoom) ? data.usersByRoom
-                : (Array.isArray(data.users) ? data.users : []);
+            const payload = (data && data.data) ? data.data : data;
+            const users = Array.isArray(payload.usersByRoom) ? payload.usersByRoom
+                : (Array.isArray(payload.users) ? payload.users : []);
             if (!Array.isArray(users)) throw new Error('データ形式が不正です');
             if (userCheckboxes) {
                 if (users.length === 0) {


### PR DESCRIPTION
Closes #331

## 変更内容

### 根本原因

直前編集モーダルおよび通常予約モーダルで以下の3つの問題が重なっていた。

1. **`display:none !important` vs `style.display` の競合**  
   Bootstrap `d-none` クラスが持つ `!important` をインラインスタイルで上書きできず、集団予約切替時に部屋セレクターや利用者テーブルが表示されなかった。

2. **`initReservationForm()` の二重呼び出しによる競合**  
   `ensureAddModalCompat` が `add.js` 初期化後にも `initReservationForm()` を呼び出してしまい、重複したイベントハンドラが登録されて挙動が不安定になっていた。

3. **APIレスポンスのデータ構造の読み違い**  
   `getUsersByRoom` が `{"ok":true,"data":{"usersByRoom":[...]}}` を返すのに対し、JS3ファイルが `d.usersByRoom`（最上位）を直接参照していたため、常に `undefined` → 空配列 → 「利用者がいません」と表示されていた。

---

### 修正内容

#### `treservation_index.inline.js`
- `show()` / `hide()` を `style.display` から `classList.remove/add('d-none')` に変更
- `applyMode()` の空値ロジック修正（未選択時は全セクション非表示）
- `__ADD_FORM_BOOTED__` フラグを確認し、`add.js` 初期化済みの場合は `initReservationForm()` を呼ばないガードを追加
- `window.fetchUserData` のレスポンス解析を `(d && d.data) ? d.data : d` パターンに修正

#### `add.js`
- `fetchAndRenderUsers` 内のレスポンス解析を `(json && json.data) ? json.data : json` パターンに修正

#### `reservation.js`
- `fetchUserData` 内のレスポンス解析を `(data && data.data) ? data.data : data` パターンに修正