### PR TITLE
fix: #338 予約フォームJS のバグ・デッドコード整理

### DIFF
--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -151,18 +151,15 @@
                 }
                 formData.append('d_reservation_date', date);
 
-                // 集団予約の場合、部屋IDが正しく設定されているかチェック
                 if (reservationType === '2') {
                     const roomId = formData.get('i_id_room') || roomSelect?.value;
                     if (!roomId) {
                         toast('エラー: 部屋を選択してください。', 'danger');
                         return;
                     }
-                    // 部屋IDが明示的に設定されていない場合は追加
                     if (!formData.get('i_id_room') && roomSelect?.value) {
                         formData.append('i_id_room', roomSelect.value);
                     }
-                    console.log('集団予約 - 選択された部屋ID:', roomId);
                 }
                 
                 showLoading();

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1239,7 +1239,10 @@ function unlockForChildren(wrap){
                 clearHiddenInputs(isGroup);
 
                 var hint = scope.querySelector('#reserve-type-hint');
-                if (hint) hint.style.display = val ? 'none' : '';
+                if (hint) {
+                    if (val) hint.classList.add('d-none');
+                    else hint.classList.remove('d-none');
+                }
             }
 
             if (select) {

--- a/src_web/kamaho-shokusu/webroot/js/reservation.js
+++ b/src_web/kamaho-shokusu/webroot/js/reservation.js
@@ -1,11 +1,5 @@
 /* eslint-disable no-console */
 (function(){
-    function bindOnce(el, type, handler){
-        el.addEventListener(type, handler, { once: true });
-    }
-
-    const QDATE = typeof window.QUERY_DATE !== 'undefined' ? window.QUERY_DATE : null;
-
     function initReservationForm(){
         if (window.__reservationFormInited && document.getElementById('reservation-form')) return;
         if (!document.getElementById('reservation-form')) return;
@@ -25,7 +19,7 @@
 
         const csrfToken = document.querySelector('meta[name="csrfToken"]')?.getAttribute('content') ?? '';
         const dateInput = document.querySelector('input[name="d_reservation_date"]');
-        const date      = QDATE || (dateInput ? dateInput.value : null);
+        const date      = window.QUERY_DATE || (dateInput ? dateInput.value : null);
 
         const showLoading = () => {
             if (overlay) overlay.style.display = 'block';


### PR DESCRIPTION
Closes #338

## 変更内容

### `reservation.js`
- **`QDATE` タイミングバグ修正**: IIFE 先頭（`<head>` 実行時）に `window.QUERY_DATE` を取得していたため常に `null` になっていた問題を修正。`initReservationForm()` 内で `window.QUERY_DATE` を直接参照するよう変更
- **`bindOnce` 関数削除**: 定義されているが一度も呼ばれていない未使用関数を除去

### `add.js`
- **`console.log` 削除**: 集団予約フォーム送信時に部屋IDをコンソールに出力していたデバッグコードを除去

### `treservation_index.inline.js`
- **ヒント非表示バグ修正**: `applyMode` のヒント非表示ロジックを `style.display = 'none'` から `classList.add('d-none')` に変更。ヒント要素に `d-block` クラス（`display: block !important`）が付与されており `style.display` では上書きできていなかった