### PR TITLE
Resolve #346: 食数グリッドの登録済みセル制御と昼↔弁当排他制御

### DIFF
--- a/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
@@ -626,14 +626,18 @@ html, body {
  * ===================================================================== */
 
 /* =====================================================================
- * 保存済みセル（登録後無効化）
+ * 保存済みセル（波線で変更可能であることを示す）
  * ===================================================================== */
 
-/* 登録直後に無効化 — 誤操作防止。ホバー・クリック不可 */
+/* 登録済みを示すオレンジ波線。クリック時は確認ポップアップを表示 */
 .mcg-grid tbody td.mcg-cell-saved {
-    cursor: not-allowed !important;
-    pointer-events: none !important;
-    opacity: 0.55;
+    cursor: pointer !important;
+    pointer-events: auto !important;
+    opacity: 0.85;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='4'%3E%3Cpath d='M0,3Q2,1,4,3Q6,5,8,3' stroke='%23e65100' fill='none' stroke-width='1.5'/%3E%3C/svg%3E");
+    background-repeat: repeat-x;
+    background-position: bottom center;
+    background-size: 8px 4px;
 }
 
 /* pending ON: 緑 ● */
@@ -671,6 +675,68 @@ html, body {
     pointer-events: auto !important; /* hover 検知のため維持 */
     position: relative;
 }
+
+/* =====================================================================
+ * 登録済みセル変更確認ダイアログ
+ * ===================================================================== */
+
+.mcg-confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,.35);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mcg-confirm-dialog {
+    background: #fff;
+    border: 1px solid #b0b0b0;
+    border-radius: 3px;
+    padding: 20px 24px 16px;
+    min-width: 260px;
+    max-width: 340px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.25);
+}
+
+.mcg-confirm-msg {
+    font-size: 13px;
+    color: #333;
+    margin: 0 0 16px;
+    line-height: 1.6;
+}
+
+.mcg-confirm-btns {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.mcg-confirm-btn {
+    font-size: 12px;
+    font-weight: 600;
+    padding: 5px 16px;
+    border-radius: 2px;
+    border: 1px solid #b0b0b0;
+    cursor: pointer;
+    height: 28px;
+}
+
+.mcg-confirm-btn--ok {
+    background: #e65100;
+    color: #fff;
+    border-color: #bf360c;
+}
+
+.mcg-confirm-btn--ok:hover { background: #bf360c; }
+
+.mcg-confirm-btn--cancel {
+    background: #fff;
+    color: #333;
+}
+
+.mcg-confirm-btn--cancel:hover { background: #f0f0f0; }
 
 /* =====================================================================
  * 排他制御: 昼↔弁当 登録済み排他セル

--- a/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
@@ -743,17 +743,15 @@ html, body {
  * ===================================================================== */
 
 .mcg-grid tbody td.mcg-cell-excl {
-    background: repeating-linear-gradient(
-        45deg,
-        #fff8e1,
-        #fff8e1 4px,
-        #ffe082 4px,
-        #ffe082 8px
-    ) !important;
-    cursor: not-allowed !important;
-    color: transparent !important;
+    background: #fff8e1 !important;
+    border-bottom: 2px solid #ffa000 !important;
+    cursor: pointer !important;
     pointer-events: auto !important;
     position: relative;
+}
+
+.mcg-grid tbody td.mcg-cell-excl:hover {
+    background: #ffecb3 !important;
 }
 
 /* コンフリクトツールチップ（JS で生成・配置） */

--- a/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
@@ -625,6 +625,17 @@ html, body {
  * Pending セル（未保存変更）
  * ===================================================================== */
 
+/* =====================================================================
+ * 保存済みセル（登録後無効化）
+ * ===================================================================== */
+
+/* 登録直後に無効化 — 誤操作防止。ホバー・クリック不可 */
+.mcg-grid tbody td.mcg-cell-saved {
+    cursor: not-allowed !important;
+    pointer-events: none !important;
+    opacity: 0.55;
+}
+
 /* pending ON: 緑 ● */
 .mcg-grid tbody td.mcg-pending-on {
     background: #c6efce !important;

--- a/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/meal_count_grid.css
@@ -672,6 +672,24 @@ html, body {
     position: relative;
 }
 
+/* =====================================================================
+ * 排他制御: 昼↔弁当 登録済み排他セル
+ * ===================================================================== */
+
+.mcg-grid tbody td.mcg-cell-excl {
+    background: repeating-linear-gradient(
+        45deg,
+        #fff8e1,
+        #fff8e1 4px,
+        #ffe082 4px,
+        #ffe082 8px
+    ) !important;
+    cursor: not-allowed !important;
+    color: transparent !important;
+    pointer-events: auto !important;
+    position: relative;
+}
+
 /* コンフリクトツールチップ（JS で生成・配置） */
 .mcg-conflict-tip {
     position: fixed;

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -176,6 +176,19 @@ function mcgRegisterAll() {
             }
         });
 
+        var seenLB = Object.create(null);
+        results.forEach(function (result, i) {
+            var parts = entries[i][0].split('|');
+            var meal = parseInt(parts[3], 10);
+            if (Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
+                var lbKey = parts[0] + '|' + parts[1] + '|' + parts[2];
+                if (!seenLB[lbKey]) {
+                    seenLB[lbKey] = true;
+                    mcgSyncLunchBento(parts[0], parts[1], parts[2]);
+                }
+            }
+        });
+
         if (successKeys.length > 0) {
             mcgShowToast(successKeys.length + '件を登録しました', 'success');
         }
@@ -231,20 +244,60 @@ function mcgInitConflicts() {
     });
 }
 
+/* ─────────────────────────────────────────────
+ * 昼↔弁当 登録済み排他（同部屋・同日）
+ * 昼が登録済みなら弁当セルを無効化、逆も同様
+ * ─────────────────────────────────────────── */
+function mcgSyncLunchBento(userId, roomId, date) {
+    var lunchTd = mcgFindCell(userId, roomId, date, MEAL.LUNCH);
+    var bentoTd = mcgFindCell(userId, roomId, date, MEAL.BENTO);
+    if (!lunchTd || !bentoTd) return;
+
+    if (lunchTd.dataset.reserved === '1') {
+        bentoTd.classList.add('mcg-cell-excl');
+        bentoTd.dataset.exclMsg = 'お昼が登録済みのため選択できません';
+    } else {
+        bentoTd.classList.remove('mcg-cell-excl');
+        delete bentoTd.dataset.exclMsg;
+    }
+
+    if (bentoTd.dataset.reserved === '1') {
+        lunchTd.classList.add('mcg-cell-excl');
+        lunchTd.dataset.exclMsg = 'お弁当が登録済みのため選択できません';
+    } else {
+        lunchTd.classList.remove('mcg-cell-excl');
+        delete lunchTd.dataset.exclMsg;
+    }
+}
+
+function mcgInitLunchBentoExcl() {
+    var seen = Object.create(null);
+    document.querySelectorAll('.mcg-toggleable').forEach(function (td) {
+        var meal = parseInt(td.dataset.meal, 10);
+        if (meal !== MEAL.LUNCH && meal !== MEAL.BENTO) return;
+        var k = td.dataset.userId + '|' + td.dataset.roomId + '|' + td.dataset.date;
+        if (!seen[k]) {
+            seen[k] = true;
+            mcgSyncLunchBento(td.dataset.userId, td.dataset.roomId, td.dataset.date);
+        }
+    });
+}
+
 /* ── コンフリクトツールチップ ── */
 
 var _mcgConflictTip = null;
 
 function mcgInitConflictTip() {
     document.addEventListener('mouseover', function (e) {
-        var cell = e.target.closest('.mcg-cell-conflict');
-        if (cell && cell.dataset.conflictMsg) {
+        var cell = e.target.closest('.mcg-cell-conflict, .mcg-cell-excl');
+        var msg  = cell ? (cell.dataset.conflictMsg || cell.dataset.exclMsg) : null;
+        if (cell && msg) {
             if (!_mcgConflictTip) {
                 _mcgConflictTip = document.createElement('div');
                 _mcgConflictTip.className = 'mcg-conflict-tip';
                 document.body.appendChild(_mcgConflictTip);
             }
-            _mcgConflictTip.textContent = cell.dataset.conflictMsg;
+            _mcgConflictTip.textContent = msg;
             _mcgConflictTip.style.display = 'block';
             _mcgConflictTip.style.left = (e.clientX + 12) + 'px';
             _mcgConflictTip.style.top  = (e.clientY - 36) + 'px';
@@ -334,6 +387,7 @@ function mcgInitToggle() {
             if (td.classList.contains('is-past')) return;
             if (td.classList.contains('mcg-cell-conflict')) return;
             if (td.classList.contains('mcg-cell-saved')) return;
+            if (td.classList.contains('mcg-cell-excl')) return;
 
             var userId = td.dataset.userId;
             var roomId = td.dataset.roomId;
@@ -378,6 +432,9 @@ function mcgInitToggle() {
 
             mcgUpdateDailyTotal(date, meal);
             mcgSyncConflicts(userId, date, td.dataset.meal);
+            if (Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
+                mcgSyncLunchBento(userId, roomId, date);
+            }
             mcgUpdateRegisterBtn();
         });
     });
@@ -458,6 +515,7 @@ function mcgApplyHolidays() {
 document.addEventListener('DOMContentLoaded', function () {
     mcgApplyHolidays();
     mcgInitConflicts();
+    mcgInitLunchBentoExcl();
     mcgInitConflictTip();
     mcgInitToggle();
     mcgInitBeforeUnload();

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -255,7 +255,7 @@ function mcgSyncLunchBento(userId, roomId, date) {
 
     if (lunchTd.dataset.reserved === '1') {
         bentoTd.classList.add('mcg-cell-excl');
-        bentoTd.dataset.exclMsg = 'お昼が登録済みのため選択できません';
+        bentoTd.dataset.exclMsg = 'お昼が登録済みです（クリックで変更可能）';
     } else {
         bentoTd.classList.remove('mcg-cell-excl');
         delete bentoTd.dataset.exclMsg;
@@ -263,7 +263,7 @@ function mcgSyncLunchBento(userId, roomId, date) {
 
     if (bentoTd.dataset.reserved === '1') {
         lunchTd.classList.add('mcg-cell-excl');
-        lunchTd.dataset.exclMsg = 'お弁当が登録済みのため選択できません';
+        lunchTd.dataset.exclMsg = 'お弁当が登録済みです（クリックで変更可能）';
     } else {
         lunchTd.classList.remove('mcg-cell-excl');
         delete lunchTd.dataset.exclMsg;
@@ -479,9 +479,13 @@ function mcgInitToggle() {
             if (td.classList.contains('mcg-cell-excl')) {
                 var exclMeal = parseInt(td.dataset.meal, 10);
                 var exclConfirmMsg = exclMeal === MEAL.BENTO
-                    ? 'お昼がすでに予約されています。\nお弁当に変更しますか？'
-                    : 'お弁当がすでに予約されています。\nお昼に変更しますか？';
-                mcgShowConfirm(exclConfirmMsg, function () { doToggle(); });
+                    ? 'お昼が登録されています。\nお弁当を選択するとお昼がキャンセルされます。\n変更してもよろしいですか？'
+                    : 'お弁当が登録されています。\nお昼を選択するとお弁当がキャンセルされます。\n変更してもよろしいですか？';
+                mcgShowConfirm(exclConfirmMsg, function () {
+                    td.classList.remove('mcg-cell-saved');
+                    td.removeAttribute('aria-disabled');
+                    doToggle();
+                });
                 return;
             }
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -181,10 +181,10 @@ function mcgRegisterAll() {
             var parts = entries[i][0].split('|');
             var meal = parseInt(parts[3], 10);
             if (Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
-                var lbKey = parts[0] + '|' + parts[1] + '|' + parts[2];
+                var lbKey = parts[0] + '|' + parts[2];
                 if (!seenLB[lbKey]) {
                     seenLB[lbKey] = true;
-                    mcgSyncLunchBento(parts[0], parts[1], parts[2]);
+                    mcgSyncLunchBento(parts[0], parts[2]);
                 }
             }
         });
@@ -245,29 +245,42 @@ function mcgInitConflicts() {
 }
 
 /* ─────────────────────────────────────────────
- * 昼↔弁当 登録済み排他（同部屋・同日）
- * 昼が登録済みなら弁当セルを無効化、逆も同様
+ * 昼↔弁当 登録済み排他（全部屋・同日）
+ * 昼が登録済みなら同日の全弁当セルを無効化、逆も同様
  * ─────────────────────────────────────────── */
-function mcgSyncLunchBento(userId, roomId, date) {
-    var lunchTd = mcgFindCell(userId, roomId, date, MEAL.LUNCH);
-    var bentoTd = mcgFindCell(userId, roomId, date, MEAL.BENTO);
-    if (!lunchTd || !bentoTd) return;
+function mcgSyncLunchBento(userId, date) {
+    var allLunchCells = document.querySelectorAll(
+        '.mcg-toggleable[data-user-id="' + userId + '"][data-date="' + date + '"][data-meal="' + MEAL.LUNCH + '"]'
+    );
+    var allBentoCells = document.querySelectorAll(
+        '.mcg-toggleable[data-user-id="' + userId + '"][data-date="' + date + '"][data-meal="' + MEAL.BENTO + '"]'
+    );
 
-    if (lunchTd.dataset.reserved === '1') {
-        bentoTd.classList.add('mcg-cell-excl');
-        bentoTd.dataset.exclMsg = 'お昼が登録済みです（クリックで変更可能）';
-    } else {
-        bentoTd.classList.remove('mcg-cell-excl');
-        delete bentoTd.dataset.exclMsg;
-    }
+    var lunchReserved = false;
+    allLunchCells.forEach(function (td) { if (td.dataset.reserved === '1') lunchReserved = true; });
 
-    if (bentoTd.dataset.reserved === '1') {
-        lunchTd.classList.add('mcg-cell-excl');
-        lunchTd.dataset.exclMsg = 'お弁当が登録済みです（クリックで変更可能）';
-    } else {
-        lunchTd.classList.remove('mcg-cell-excl');
-        delete lunchTd.dataset.exclMsg;
-    }
+    var bentoReserved = false;
+    allBentoCells.forEach(function (td) { if (td.dataset.reserved === '1') bentoReserved = true; });
+
+    allBentoCells.forEach(function (td) {
+        if (lunchReserved) {
+            td.classList.add('mcg-cell-excl');
+            td.dataset.exclMsg = 'お昼が登録済みです（クリックで変更可能）';
+        } else {
+            td.classList.remove('mcg-cell-excl');
+            delete td.dataset.exclMsg;
+        }
+    });
+
+    allLunchCells.forEach(function (td) {
+        if (bentoReserved) {
+            td.classList.add('mcg-cell-excl');
+            td.dataset.exclMsg = 'お弁当が登録済みです（クリックで変更可能）';
+        } else {
+            td.classList.remove('mcg-cell-excl');
+            delete td.dataset.exclMsg;
+        }
+    });
 }
 
 function mcgInitLunchBentoExcl() {
@@ -275,10 +288,10 @@ function mcgInitLunchBentoExcl() {
     document.querySelectorAll('.mcg-toggleable').forEach(function (td) {
         var meal = parseInt(td.dataset.meal, 10);
         if (meal !== MEAL.LUNCH && meal !== MEAL.BENTO) return;
-        var k = td.dataset.userId + '|' + td.dataset.roomId + '|' + td.dataset.date;
+        var k = td.dataset.userId + '|' + td.dataset.date;
         if (!seen[k]) {
             seen[k] = true;
-            mcgSyncLunchBento(td.dataset.userId, td.dataset.roomId, td.dataset.date);
+            mcgSyncLunchBento(td.dataset.userId, td.dataset.date);
         }
     });
 }
@@ -432,11 +445,16 @@ function mcgInitToggle() {
             var currentReserved = td.dataset.reserved === '1';
             var newValue        = currentReserved ? 0 : 1;
 
-            /* 昼↔弁当 排他: 同部屋の対立セルを pending OFF にする */
+            /* 昼↔弁当 排他: 全部屋の対立セルを pending OFF にする */
             if (newValue === 1 && Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
-                var opponentMeal     = MEAL_OPPONENT[meal];
-                var opponentTd       = mcgFindCell(userId, roomId, date, opponentMeal);
-                if (opponentTd && opponentTd.dataset.reserved === '1') {
+                var opponentMeal = MEAL_OPPONENT[meal];
+                var allOpponents = document.querySelectorAll(
+                    '.mcg-toggleable[data-user-id="' + userId + '"]' +
+                    '[data-date="' + date + '"]' +
+                    '[data-meal="' + opponentMeal + '"]'
+                );
+                allOpponents.forEach(function (opponentTd) {
+                    if (opponentTd.dataset.reserved !== '1') return;
                     var opponentKey      = _mcgKey(opponentTd);
                     var opponentEntry    = _mcgPending.get(opponentKey);
                     var opponentOriginal = opponentEntry ? opponentEntry.original : opponentTd.dataset.reserved;
@@ -450,7 +468,7 @@ function mcgInitToggle() {
                     }
                     mcgUpdateDailyTotal(date, opponentMeal);
                     mcgSyncConflicts(userId, date, String(opponentMeal));
-                }
+                });
             }
 
             /* 元の状態に戻るなら pending 解除、それ以外は pending 追加 */
@@ -467,7 +485,7 @@ function mcgInitToggle() {
             mcgUpdateDailyTotal(date, meal);
             mcgSyncConflicts(userId, date, td.dataset.meal);
             if (Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
-                mcgSyncLunchBento(userId, roomId, date);
+                mcgSyncLunchBento(userId, date);
             }
             mcgUpdateRegisterBtn();
         }

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -317,6 +317,46 @@ function mcgInitConflictTip() {
 }
 
 /* ─────────────────────────────────────────────
+ * 登録済みセル変更確認ポップアップ
+ * ─────────────────────────────────────────── */
+function mcgShowConfirm(message, onOk) {
+    var overlay = document.createElement('div');
+    overlay.className = 'mcg-confirm-overlay';
+
+    var dialog = document.createElement('div');
+    dialog.className = 'mcg-confirm-dialog';
+
+    var msg = document.createElement('p');
+    msg.className = 'mcg-confirm-msg';
+    msg.textContent = message;
+
+    var btnWrap = document.createElement('div');
+    btnWrap.className = 'mcg-confirm-btns';
+
+    var okBtn = document.createElement('button');
+    okBtn.className = 'mcg-confirm-btn mcg-confirm-btn--ok';
+    okBtn.textContent = '変更する';
+
+    var cancelBtn = document.createElement('button');
+    cancelBtn.className = 'mcg-confirm-btn mcg-confirm-btn--cancel';
+    cancelBtn.textContent = 'キャンセル';
+
+    function close() { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }
+
+    okBtn.addEventListener('click', function () { close(); onOk(); });
+    cancelBtn.addEventListener('click', close);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
+
+    btnWrap.appendChild(cancelBtn);
+    btnWrap.appendChild(okBtn);
+    dialog.appendChild(msg);
+    dialog.appendChild(btnWrap);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+    okBtn.focus();
+}
+
+/* ─────────────────────────────────────────────
  * Toast 通知
  * ─────────────────────────────────────────── */
 function mcgShowToast(message, type) {
@@ -379,16 +419,10 @@ function mcgUpdateDailyTotal(date, meal) {
 function mcgInitToggle() {
     document.querySelectorAll('.mcg-toggleable').forEach(function (td) {
         td.addEventListener('keydown', function (e) {
-            if (td.classList.contains('mcg-cell-saved')) return;
             if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); td.click(); }
         });
 
-        td.addEventListener('click', function () {
-            if (td.classList.contains('is-past')) return;
-            if (td.classList.contains('mcg-cell-conflict')) return;
-            if (td.classList.contains('mcg-cell-saved')) return;
-            if (td.classList.contains('mcg-cell-excl')) return;
-
+        function doToggle() {
             var userId = td.dataset.userId;
             var roomId = td.dataset.roomId;
             var date   = td.dataset.date;
@@ -400,11 +434,11 @@ function mcgInitToggle() {
 
             /* 昼↔弁当 排他: 同部屋の対立セルを pending OFF にする */
             if (newValue === 1 && Object.prototype.hasOwnProperty.call(MEAL_OPPONENT, meal)) {
-                var opponentMeal = MEAL_OPPONENT[meal];
-                var opponentTd   = mcgFindCell(userId, roomId, date, opponentMeal);
+                var opponentMeal     = MEAL_OPPONENT[meal];
+                var opponentTd       = mcgFindCell(userId, roomId, date, opponentMeal);
                 if (opponentTd && opponentTd.dataset.reserved === '1') {
-                    var opponentKey     = _mcgKey(opponentTd);
-                    var opponentEntry   = _mcgPending.get(opponentKey);
+                    var opponentKey      = _mcgKey(opponentTd);
+                    var opponentEntry    = _mcgPending.get(opponentKey);
                     var opponentOriginal = opponentEntry ? opponentEntry.original : opponentTd.dataset.reserved;
 
                     if (opponentOriginal === '0') {
@@ -436,6 +470,23 @@ function mcgInitToggle() {
                 mcgSyncLunchBento(userId, roomId, date);
             }
             mcgUpdateRegisterBtn();
+        }
+
+        td.addEventListener('click', function () {
+            if (td.classList.contains('is-past')) return;
+            if (td.classList.contains('mcg-cell-conflict')) return;
+            if (td.classList.contains('mcg-cell-excl')) return;
+
+            if (td.classList.contains('mcg-cell-saved')) {
+                mcgShowConfirm('登録済みのデータを変更しますか？', function () {
+                    td.classList.remove('mcg-cell-saved');
+                    td.removeAttribute('aria-disabled');
+                    doToggle();
+                });
+                return;
+            }
+
+            doToggle();
         });
     });
 }

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -475,7 +475,15 @@ function mcgInitToggle() {
         td.addEventListener('click', function () {
             if (td.classList.contains('is-past')) return;
             if (td.classList.contains('mcg-cell-conflict')) return;
-            if (td.classList.contains('mcg-cell-excl')) return;
+
+            if (td.classList.contains('mcg-cell-excl')) {
+                var exclMeal = parseInt(td.dataset.meal, 10);
+                var exclConfirmMsg = exclMeal === MEAL.BENTO
+                    ? 'お昼がすでに予約されています。\nお弁当に変更しますか？'
+                    : 'お弁当がすでに予約されています。\nお昼に変更しますか？';
+                mcgShowConfirm(exclConfirmMsg, function () { doToggle(); });
+                return;
+            }
 
             if (td.classList.contains('mcg-cell-saved')) {
                 mcgShowConfirm('登録済みのデータを変更しますか？', function () {

--- a/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/meal_count_grid.js
@@ -143,6 +143,9 @@ function mcgRegisterAll() {
                 } else {
                     entry.td.textContent = '';
                 }
+                /* 保存済みセルを無効化して誤操作を防ぐ */
+                entry.td.classList.add('mcg-cell-saved');
+                entry.td.setAttribute('aria-disabled', 'true');
                 mcgFlashCell(entry.td, entry.desired === 1);
             } else {
                 failCount++;
@@ -323,12 +326,14 @@ function mcgUpdateDailyTotal(date, meal) {
 function mcgInitToggle() {
     document.querySelectorAll('.mcg-toggleable').forEach(function (td) {
         td.addEventListener('keydown', function (e) {
+            if (td.classList.contains('mcg-cell-saved')) return;
             if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); td.click(); }
         });
 
         td.addEventListener('click', function () {
             if (td.classList.contains('is-past')) return;
             if (td.classList.contains('mcg-cell-conflict')) return;
+            if (td.classList.contains('mcg-cell-saved')) return;
 
             var userId = td.dataset.userId;
             var roomId = td.dataset.roomId;


### PR DESCRIPTION
Closes #346

## 変更内容

### 登録後セルの制御（`meal_count_grid.js` / `meal_count_grid.css`）
- 登録成功後のセルに `mcg-cell-saved` クラスを付与し、オレンジ波線（SVGデータURI）で「登録済み」を視覚表示
- 登録済みセルをクリックすると確認ダイアログ（「登録済みのデータを変更しますか？」）を表示し、承認後に変更可能
- `mcgShowConfirm` 関数を追加（Bootstrap 非依存のカスタムオーバーレイモーダル）
- `mcgInitToggle` を `doToggle` 内部関数パターンにリファクタリングし、確認フローを整理

### 昼↔弁当 登録済み排他制御
- 昼が登録済みの場合、同日の**全部屋**の弁当セルに `mcg-cell-excl`（アンバー背景＋オレンジ下線）を適用（逆も同様）
- `mcgSyncLunchBento` の引数から `roomId` を廃止し、全部屋横断検索に変更
- 排他セルクリック時は確認ダイアログを表示：「お昼がキャンセルされます。変更してもよろしいですか？」
- 確認承認後、対立する全部屋の昼（または弁当）セルを一括 pending-off に設定
- `doToggle` 内の MEAL_OPPONENT キャンセル処理も全部屋対象（`querySelectorAll`）に変更
- ツールチップを「選択できません」→「クリックで変更可能」に更新

### CSS 追加
- `mcg-cell-saved`: 波線スタイル（pointer-events 維持、クリック可能）
- `mcg-cell-excl`: アンバー背景＋オレンジ下線（ホバー対応）
- 確認ダイアログのオーバーレイ・ダイアログ・ボタンスタイル