### PR TITLE
Resolve #349: 承認管理の予約日表示改善と一括承認バグ修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -318,7 +318,7 @@ class ApprovalService
      */
     public function adminApprove(array $keys, int $approverId, string $actor, string $ipAddress = ''): bool
     {
-        $result = $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_BLOCK_LEADER]);
+        $result = $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_PENDING, self::STATUS_BLOCK_LEADER]);
         AuditLogService::record(
             'approval',
             'approval_admin',

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -465,10 +465,12 @@ class ApprovalService
 
         return $individualTable->getConnection()->transactional(
             function () use ($keys, $newStatus, $approverId, $actor, $reason, $allowedFromStatuses, $excludeUserId, $individualTable, $logTable, $now): bool {
+                $successKeys = [];
+
                 foreach ($keys as $k) {
-                    // 承認者自身の予約は自己承認を防止するためスキップ
+                    // 承認者自身の予約は自己承認防止のためスキップ
                     if ($excludeUserId !== null && (int)$k['i_id_user'] === $excludeUserId) {
-                        return false;
+                        continue;
                     }
                     $affected = $individualTable->updateAll(
                         ['i_approval_status' => $newStatus, 'dt_update' => $now, 'c_update_user' => $actor],
@@ -480,9 +482,12 @@ class ApprovalService
                             'i_approval_status IN' => $allowedFromStatuses,
                         ]
                     );
+                    // ステータス不一致（既に別の状態）のレコードはスキップ
                     if ($affected < 1) {
-                        return false;
+                        continue;
                     }
+
+                    $successKeys[] = $k;
 
                     $log = $logTable->newEntity([
                         'i_id_user'          => $k['i_id_user'],
@@ -497,8 +502,12 @@ class ApprovalService
                     $logTable->saveOrFail($log);
                 }
 
+                if (empty($successKeys)) {
+                    return false;
+                }
+
                 if ($newStatus === self::STATUS_REJECTED) {
-                    $this->notificationService->createRejectionNotifications($keys, $approverId, $reason, $now);
+                    $this->notificationService->createRejectionNotifications($successKeys, $approverId, $reason, $now);
                 }
 
                 return true;

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -8,6 +8,14 @@ $filterStatus = $filterStatus ?? '';
 $dateFrom     = $dateFrom ?? date('Y-m-d', strtotime('monday this week'));
 $dateTo       = $dateTo   ?? date('Y-m-d', strtotime('sunday this week'));
 
+$fmtDate = static function (\DateTime|string $d): string {
+    $dow = ['日', '月', '火', '水', '木', '金', '土'];
+    if (is_string($d)) {
+        $d = new \DateTime($d);
+    }
+    return $d->format('Y年n月j日') . '（' . $dow[(int)$d->format('w')] . '）';
+};
+
 $statusLabels = [
     0 => ['label' => '未承認',           'class' => 'bg-warning text-dark'],
     1 => ['label' => 'ブロック長承認済', 'class' => 'bg-info text-dark'],
@@ -141,7 +149,7 @@ foreach ($summary as $row) {
                 <tbody>
                 <?php foreach ($summary as $row): ?>
                     <tr>
-                        <td><?= h($row['reservation_date']) ?></td>
+                        <td><?= h($fmtDate($row['reservation_date'])) ?></td>
                         <td class="text-start"><?= h($row['room_name']) ?></td>
                         <td><?= $row['breakfast'] ?>名</td>
                         <td><?= $row['lunch'] ?>名</td>
@@ -204,7 +212,7 @@ foreach ($summary as $row) {
                     ?>
                     <tr>
                         <td><input type="checkbox" class="row-check" data-status="<?= h((string)$rec->i_approval_status) ?>" data-key='<?= h($dataKey) ?>'></td>
-                        <td><?= h($rec->d_reservation_date) ?></td>
+                        <td><?= h($fmtDate($rec->d_reservation_date)) ?></td>
                         <td><?= h($rec->m_room_info->c_room_name ?? '') ?></td>
                         <td><?= h($rec->m_user_info->c_user_name ?? '') ?></td>
                         <td><?= h($mealLabels[(int)$rec->i_reservation_type] ?? '') ?></td>

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -8,6 +8,14 @@ $filterStatus  = $filterStatus ?? '';
 $dateFrom      = $dateFrom ?? date('Y-m-d', strtotime('monday this week'));
 $dateTo        = $dateTo   ?? date('Y-m-d', strtotime('sunday this week'));
 
+$fmtDate = static function (\DateTime|string $d): string {
+    $dow = ['日', '月', '火', '水', '木', '金', '土'];
+    if (is_string($d)) {
+        $d = new \DateTime($d);
+    }
+    return $d->format('Y年n月j日') . '（' . $dow[(int)$d->format('w')] . '）';
+};
+
 $statusLabels = [
     0 => ['label' => '未承認',           'class' => 'bg-warning text-dark'],
     1 => ['label' => 'ブロック長承認済', 'class' => 'bg-info text-dark'],
@@ -145,7 +153,7 @@ foreach ($records as $record) {
                     <tr>
                         <td><input type="checkbox" class="row-check" data-key='<?= h($dataKey) ?>'></td>
                         <td>
-                            <span class="cell-primary"><?= h($rec->d_reservation_date) ?></span>
+                            <span class="cell-primary"><?= h($fmtDate($rec->d_reservation_date)) ?></span>
                         </td>
                         <td>
                             <span class="cell-primary"><?= h($rec->m_room_info->c_room_name ?? '') ?></span>


### PR DESCRIPTION
Closes #349

## 変更内容

### 予約日フォーマットの修正
- `admin_index.php` / `block_leader_index.php` の予約日表示を `4/19/26`（US形式）→ `2026年4月19日（土）`（日本語・曜日付き）に変更
- テンプレート内に `$fmtDate` クロージャを追加し、`\DateTime` オブジェクトと文字列（`Y-m-d`）の両方に対応

### 一括承認トランザクションのバグ修正
- `updateApprovalStatus` 内で1件でも `$affected < 1`（ステータス不一致）のレコードがあるとトランザクション全体がロールバックされる問題を修正
- `return false` → `continue` に変更し、成功したレコードのみ `$successKeys` で追跡
- 全件失敗した場合のみ `false` を返すよう変更
- 差し戻し通知も `$successKeys`（実際に更新されたレコード）のみ対象とするよう修正

### 管理者承認の許可ステータス拡張
- `adminApprove` の `allowedFromStatuses` を `[STATUS_BLOCK_LEADER]` → `[STATUS_PENDING, STATUS_BLOCK_LEADER]` に変更
- 管理者がブロック長承認ステップを経ていない「未承認（0）」のレコードも直接最終承認できるようにする