### PR TITLE
Resolve #352: システム管理者向け部屋使用率機能を実装

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -160,7 +160,8 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/AuditLog', ['controller' => 'AuditLog', 'action' => 'index'])->setMethods(['GET']);
         $builder->connect('/AuditLog/export', ['controller' => 'AuditLog', 'action' => 'export'])->setMethods(['GET']);
 
-        // 部屋使用率 API（システム管理者専用）
+        // 部屋使用率（システム管理者専用）
+        $builder->connect('/RoomUsage', ['controller' => 'RoomUsage', 'action' => 'index'])->setMethods(['GET']);
         $builder->connect('/RoomUsage/roomUsage', ['controller' => 'RoomUsage', 'action' => 'roomUsage'])->setMethods(['GET']);
         $builder->connect('/RoomUsage/lowUsageRooms', ['controller' => 'RoomUsage', 'action' => 'lowUsageRooms'])->setMethods(['GET']);
 

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -160,6 +160,10 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/AuditLog', ['controller' => 'AuditLog', 'action' => 'index'])->setMethods(['GET']);
         $builder->connect('/AuditLog/export', ['controller' => 'AuditLog', 'action' => 'export'])->setMethods(['GET']);
 
+        // 部屋使用率 API（システム管理者専用）
+        $builder->connect('/RoomUsage/roomUsage', ['controller' => 'RoomUsage', 'action' => 'roomUsage'])->setMethods(['GET']);
+        $builder->connect('/RoomUsage/lowUsageRooms', ['controller' => 'RoomUsage', 'action' => 'lowUsageRooms'])->setMethods(['GET']);
+
         // MRoomTransferSchedule（部屋異動予約）
         $builder->connect('/MRoomTransferSchedule', ['controller' => 'MRoomTransferSchedule', 'action' => 'index']);
         $builder->connect('/MRoomTransferSchedule/add', ['controller' => 'MRoomTransferSchedule', 'action' => 'add']);

--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -125,6 +125,7 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             \App\Controller\NotificationsController::class => \App\Policy\NotificationPolicy::class,
             \App\Controller\ContactsController::class      => \App\Policy\ContactsPolicy::class,
             \App\Controller\AuditLogController::class      => \App\Policy\AuditLogPolicy::class,
+            \App\Controller\RoomUsageController::class    => \App\Policy\RoomUsagePolicy::class,
         ]);
 
         // MapResolver で解決できない場合は OrmResolver（エンティティ→ポリシー）にフォールバック

--- a/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
+++ b/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
@@ -8,7 +8,7 @@ use Authorization\Exception\ForbiddenException;
 use Cake\Http\Response;
 
 /**
- * 部屋使用率 API コントローラー
+ * 部屋使用率コントローラー
  *
  * システム管理者専用。部屋ごとの使用率集計・低使用率部屋のピックアップを提供する。
  */
@@ -20,6 +20,35 @@ class RoomUsageController extends AppController
     {
         parent::initialize();
         $this->roomUsageService = new RoomUsageService();
+        $this->viewBuilder()->setLayout('default');
+    }
+
+    /**
+     * GET /RoomUsage — 部屋使用率一覧ページ（HTML）
+     */
+    public function index(): ?Response
+    {
+        try {
+            $this->Authorization->authorize($this, 'index');
+        } catch (ForbiddenException $e) {
+            $this->Flash->error('この機能はシステム管理者のみ利用できます。');
+            return $this->redirect(['controller' => 'Pages', 'action' => 'dashboard']);
+        }
+
+        $dateFrom  = $this->request->getQuery('date_from') ?: date('Y-m-01');
+        $dateTo    = $this->request->getQuery('date_to')   ?: date('Y-m-d');
+        $mealType  = $this->request->getQuery('meal_type') !== null && $this->request->getQuery('meal_type') !== ''
+            ? (int)$this->request->getQuery('meal_type')
+            : null;
+        $threshold = $this->request->getQuery('threshold') !== null && $this->request->getQuery('threshold') !== ''
+            ? (float)$this->request->getQuery('threshold')
+            : 50.0;
+
+        $rooms    = $this->roomUsageService->getRoomUsage($dateFrom, $dateTo, $mealType);
+        $lowRooms = $this->roomUsageService->getLowUsageRooms($threshold, $dateFrom, $dateTo, $mealType);
+
+        $this->set(compact('rooms', 'lowRooms', 'dateFrom', 'dateTo', 'mealType', 'threshold'));
+        return null;
     }
 
     /**

--- a/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
+++ b/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\RoomUsageService;
+use Authorization\Exception\ForbiddenException;
+use Cake\Http\Response;
+
+/**
+ * 部屋使用率 API コントローラー
+ *
+ * システム管理者専用。部屋ごとの使用率集計・低使用率部屋のピックアップを提供する。
+ */
+class RoomUsageController extends AppController
+{
+    private RoomUsageService $roomUsageService;
+
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->roomUsageService = new RoomUsageService();
+    }
+
+    /**
+     * GET /RoomUsage/roomUsage
+     *
+     * 部屋ごとの使用率一覧を返す。
+     *
+     * クエリパラメータ:
+     *   - date_from  (Y-m-d)
+     *   - date_to    (Y-m-d)
+     *   - meal_type  (1=朝 2=昼 3=夕 4=弁当)
+     */
+    public function roomUsage(): Response
+    {
+        try {
+            $this->Authorization->authorize($this, 'roomUsage');
+        } catch (ForbiddenException $e) {
+            return $this->jsonError('この機能はシステム管理者のみ利用できます。', 403);
+        }
+
+        $dateFrom = $this->request->getQuery('date_from') ?: null;
+        $dateTo   = $this->request->getQuery('date_to')   ?: null;
+        $mealType = $this->request->getQuery('meal_type')  !== null && $this->request->getQuery('meal_type') !== ''
+            ? (int)$this->request->getQuery('meal_type')
+            : null;
+
+        $rooms = $this->roomUsageService->getRoomUsage($dateFrom, $dateTo, $mealType);
+
+        return $this->jsonResponse(['rooms' => $rooms]);
+    }
+
+    /**
+     * GET /RoomUsage/lowUsageRooms
+     *
+     * 使用率が閾値以下の部屋を返す。
+     *
+     * クエリパラメータ:
+     *   - threshold  (float, デフォルト 50.0)
+     *   - date_from  (Y-m-d)
+     *   - date_to    (Y-m-d)
+     *   - meal_type  (1=朝 2=昼 3=夕 4=弁当)
+     */
+    public function lowUsageRooms(): Response
+    {
+        try {
+            $this->Authorization->authorize($this, 'lowUsageRooms');
+        } catch (ForbiddenException $e) {
+            return $this->jsonError('この機能はシステム管理者のみ利用できます。', 403);
+        }
+
+        $threshold = $this->request->getQuery('threshold') !== null && $this->request->getQuery('threshold') !== ''
+            ? (float)$this->request->getQuery('threshold')
+            : 50.0;
+        $dateFrom = $this->request->getQuery('date_from') ?: null;
+        $dateTo   = $this->request->getQuery('date_to')   ?: null;
+        $mealType = $this->request->getQuery('meal_type') !== null && $this->request->getQuery('meal_type') !== ''
+            ? (int)$this->request->getQuery('meal_type')
+            : null;
+
+        $rooms = $this->roomUsageService->getLowUsageRooms($threshold, $dateFrom, $dateTo, $mealType);
+
+        return $this->jsonResponse([
+            'threshold' => $threshold,
+            'rooms'     => $rooms,
+        ]);
+    }
+
+    private function jsonResponse(array $data, int $status = 200): Response
+    {
+        return $this->response
+            ->withStatus($status)
+            ->withType('application/json')
+            ->withStringBody((string)json_encode($data, JSON_UNESCAPED_UNICODE));
+    }
+
+    private function jsonError(string $message, int $status = 400): Response
+    {
+        return $this->jsonResponse(['success' => false, 'error' => $message], $status);
+    }
+}

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -107,10 +107,6 @@ class TReservationInfoController extends AppController
         // $this->viewBuilder()->setOption('serialize', true);
         $this->viewBuilder()->setLayout('default');
 
-        // JSON ボディを受け取る AJAX エンドポイントは FormProtection のフォームトークン検証対象外にする。
-        // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
-        // view・bulkChangeEditForm は GET アクションだが、FormProtection は POST にのみ適用されるため
-        // 実質無害。将来的にリストから除外可能。
         $this->FormProtection->setConfig('unlockedActions', [
             'add',
             'toggle',
@@ -1009,7 +1005,7 @@ class TReservationInfoController extends AppController
             if ($this->request->is(['post', 'put'])) {
                 $earlyData = $this->request->getData();
                 if (empty($earlyData)) {
-                    $earlyParsed = json_decode((string)$this->request->getBody(), true);
+                    $earlyParsed = $this->request->input('json_decode', true);
                     if (is_array($earlyParsed)) $earlyData = $earlyParsed;
                 }
                 if (($earlyData['reservation_type'] ?? '2') === '1') {
@@ -1125,7 +1121,7 @@ class TReservationInfoController extends AppController
             if ($this->request->is(['post','put'])) {
                 $data = $this->request->getData();
                 if (empty($data)) {
-                    $parsed = json_decode((string)$this->request->getBody(), true);
+                    $parsed = $this->request->input('json_decode', true);
                     if (is_array($parsed)) $data = $parsed;
                 }
                 $usersData = (isset($data['users']) && is_array($data['users'])) ? $data['users'] : [];
@@ -1302,7 +1298,7 @@ class TReservationInfoController extends AppController
         // ペイロード（form→JSON）
         $payload = (array)$this->request->getData();
         if (empty($payload)) {
-            $payload = (array)(json_decode((string)$this->request->getBody(), true) ?? []);
+            $payload = (array)($this->request->input('json_decode', true) ?? []);
         }
         if ($roomId === null) {
             $roomId = isset($payload['roomId']) ? (int)$payload['roomId'] : (int)($payload['i_id_room'] ?? 0);

--- a/src_web/kamaho-shokusu/src/Policy/RoomUsagePolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/RoomUsagePolicy.php
@@ -13,6 +13,11 @@ use Authorization\IdentityInterface;
  */
 class RoomUsagePolicy
 {
+    public function canIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isSystemAdmin($user);
+    }
+
     public function canRoomUsage(?IdentityInterface $user, mixed $resource): bool
     {
         return $this->isSystemAdmin($user);

--- a/src_web/kamaho-shokusu/src/Policy/RoomUsagePolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/RoomUsagePolicy.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use App\Domain\ValueObject\UserRole;
+use Authorization\IdentityInterface;
+
+/**
+ * 部屋使用率 API 用認可ポリシー
+ *
+ * システム管理者（i_admin === 3）のみアクセスを許可する。
+ */
+class RoomUsagePolicy
+{
+    public function canRoomUsage(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isSystemAdmin($user);
+    }
+
+    public function canLowUsageRooms(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isSystemAdmin($user);
+    }
+
+    private function isSystemAdmin(?IdentityInterface $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+        $identity = $user->getOriginalData();
+        if ($identity === null) {
+            return false;
+        }
+
+        if (is_object($identity) && method_exists($identity, 'get')) {
+            return UserRole::isSystemAdmin((int)$identity->get('i_admin'));
+        }
+        if (is_array($identity)) {
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
+        }
+        if ($identity instanceof \ArrayAccess) {
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
+        }
+        return false;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 部屋使用率集計サービス
+ *
+ * t_individual_reservation_info を集計し、部屋ごとの使用率を算出する。
+ * 使用率 = 食べる人数 / 総予約数 × 100
+ */
+class RoomUsageService
+{
+    /**
+     * 部屋ごとの使用率一覧を返す。
+     *
+     * @param string|null $dateFrom 開始日 (Y-m-d)
+     * @param string|null $dateTo   終了日 (Y-m-d)
+     * @param int|null    $mealType 食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
+     * @return array{room_id:int, room_name:string, total_reservations:int, eat_count:int, usage_rate:float}[]
+     */
+    public function getRoomUsage(
+        ?string $dateFrom = null,
+        ?string $dateTo   = null,
+        ?int    $mealType = null
+    ): array {
+        $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $query = $table->find()->contain(['MRoomInfo']);
+
+        if ($dateFrom !== null) {
+            $query->where(['TIndividualReservationInfo.d_reservation_date >=' => $dateFrom]);
+        }
+        if ($dateTo !== null) {
+            $query->where(['TIndividualReservationInfo.d_reservation_date <=' => $dateTo]);
+        }
+        if ($mealType !== null) {
+            $query->where(['TIndividualReservationInfo.i_reservation_type' => $mealType]);
+        }
+
+        $rows = $query->all()->toArray();
+
+        $grouped = [];
+        foreach ($rows as $row) {
+            $roomId = (int)$row->i_id_room;
+            if (!isset($grouped[$roomId])) {
+                $grouped[$roomId] = [
+                    'room_id'            => $roomId,
+                    'room_name'          => $row->m_room_info->c_room_name ?? '',
+                    'total_reservations' => 0,
+                    'eat_count'          => 0,
+                ];
+            }
+            $grouped[$roomId]['total_reservations']++;
+            $effectiveEat = $row->i_change_flag !== null
+                ? (int)$row->i_change_flag
+                : (int)($row->eat_flag ?? 0);
+            if ($effectiveEat === 1) {
+                $grouped[$roomId]['eat_count']++;
+            }
+        }
+
+        $result = [];
+        foreach ($grouped as $data) {
+            $data['usage_rate'] = $data['total_reservations'] > 0
+                ? round($data['eat_count'] / $data['total_reservations'] * 100, 1)
+                : 0.0;
+            $result[] = $data;
+        }
+
+        usort($result, static fn(array $a, array $b): int => strcmp((string)$a['room_name'], (string)$b['room_name']));
+
+        return $result;
+    }
+
+    /**
+     * 使用率が閾値を下回る部屋を返す。
+     *
+     * @param float       $threshold 使用率の閾値（%）。この値以下の部屋を返す。デフォルト 50.0
+     * @param string|null $dateFrom
+     * @param string|null $dateTo
+     * @param int|null    $mealType
+     * @return array
+     */
+    public function getLowUsageRooms(
+        float   $threshold = 50.0,
+        ?string $dateFrom  = null,
+        ?string $dateTo    = null,
+        ?int    $mealType  = null
+    ): array {
+        $all = $this->getRoomUsage($dateFrom, $dateTo, $mealType);
+
+        return array_values(
+            array_filter($all, static fn(array $r): bool => $r['usage_rate'] <= $threshold)
+        );
+    }
+}

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -8,10 +8,10 @@ $filterStatus = $filterStatus ?? '';
 $dateFrom     = $dateFrom ?? date('Y-m-d', strtotime('monday this week'));
 $dateTo       = $dateTo   ?? date('Y-m-d', strtotime('sunday this week'));
 
-$fmtDate = static function (\DateTime|string $d): string {
+$fmtDate = static function ($d): string {
     $dow = ['日', '月', '火', '水', '木', '金', '土'];
     if (is_string($d)) {
-        $d = new \DateTime($d);
+        $d = new \DateTimeImmutable($d);
     }
     return $d->format('Y年n月j日') . '（' . $dow[(int)$d->format('w')] . '）';
 };

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -8,10 +8,10 @@ $filterStatus  = $filterStatus ?? '';
 $dateFrom      = $dateFrom ?? date('Y-m-d', strtotime('monday this week'));
 $dateTo        = $dateTo   ?? date('Y-m-d', strtotime('sunday this week'));
 
-$fmtDate = static function (\DateTime|string $d): string {
+$fmtDate = static function ($d): string {
     $dow = ['日', '月', '火', '水', '木', '金', '土'];
     if (is_string($d)) {
-        $d = new \DateTime($d);
+        $d = new \DateTimeImmutable($d);
     }
     return $d->format('Y年n月j日') . '（' . $dow[(int)$d->format('w')] . '）';
 };

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -357,6 +357,11 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                         <div class="menu-title-text">監査ログ</div>
                         <div class="menu-desc">全操作履歴を検索・CSVエクスポート</div>
                     </a>
+                    <a class="menu-card" href="<?= $this->Url->build('/RoomUsage') ?>">
+                        <div class="menu-icon" style="background:#e8f5e9;color:#2e7d32;">📈</div>
+                        <div class="menu-title-text">部屋使用率</div>
+                        <div class="menu-desc">部屋ごとの食事利用率・低使用率部屋のピックアップ</div>
+                    </a>
                 </div>
             <?php endif; ?>
         </main>

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -1,0 +1,169 @@
+<?php
+/** @var \App\Controller\RoomUsageController $this */
+$rooms     = $rooms     ?? [];
+$lowRooms  = $lowRooms  ?? [];
+$dateFrom  = $dateFrom  ?? date('Y-m-01');
+$dateTo    = $dateTo    ?? date('Y-m-d');
+$mealType  = $mealType  ?? null;
+$threshold = $threshold ?? 50.0;
+
+$mealLabels = ['' => '全食種', 1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
+$basePath   = $this->request->getAttribute('base') ?? '';
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>部屋使用率</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body { background: #f5f7fa; }
+        .page-shell { max-width: 1100px; margin: 0 auto; padding: 24px 16px 48px; }
+        .page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 24px; }
+        .page-title { font-size: 1.4rem; font-weight: 700; margin: 0; }
+        .page-subtitle { font-size: .85rem; color: #6c757d; margin-top: 2px; }
+        .mui-paper { background: #fff; border-radius: 12px; box-shadow: 0 1px 4px rgba(0,0,0,.08); padding: 20px; margin-bottom: 20px; }
+        .filter-title { font-size: .8rem; font-weight: 600; color: #6c757d; text-transform: uppercase; letter-spacing: .05em; margin-bottom: 12px; }
+        .section-title { font-size: 1rem; font-weight: 700; margin-bottom: 12px; }
+        .usage-bar-wrap { width: 120px; }
+        .usage-bar { height: 8px; border-radius: 4px; background: #e9ecef; overflow: hidden; }
+        .usage-bar-fill { height: 100%; border-radius: 4px; transition: width .3s; }
+        .low-badge { font-size: .7rem; padding: 2px 6px; }
+    </style>
+</head>
+<body>
+<div class="page-shell">
+    <div class="page-head">
+        <div>
+            <h1 class="page-title">部屋使用率</h1>
+            <div class="page-subtitle">期間内の部屋ごとの食事利用率を集計します。システム管理者専用。</div>
+        </div>
+        <a href="<?= h($basePath) ?>/" class="btn btn-outline-secondary btn-sm">戻る</a>
+    </div>
+
+    <!-- フィルター -->
+    <div class="mui-paper">
+        <div class="filter-title">絞り込み</div>
+        <form method="get" action="" class="row g-3 align-items-end">
+            <div class="col-12 col-md-3">
+                <label class="form-label mb-1 small">開始日</label>
+                <input type="date" name="date_from" value="<?= h($dateFrom) ?>" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 col-md-3">
+                <label class="form-label mb-1 small">終了日</label>
+                <input type="date" name="date_to" value="<?= h($dateTo) ?>" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 col-md-2">
+                <label class="form-label mb-1 small">食種</label>
+                <select name="meal_type" class="form-select form-select-sm">
+                    <?php foreach ($mealLabels as $val => $label): ?>
+                        <option value="<?= h($val) ?>" <?= (string)$val === (string)($mealType ?? '') ? 'selected' : '' ?>>
+                            <?= h($label) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-12 col-md-2">
+                <label class="form-label mb-1 small">低使用率の閾値（%以下）</label>
+                <input type="number" name="threshold" value="<?= h($threshold) ?>" min="0" max="100" step="1" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 col-md-2">
+                <button type="submit" class="btn btn-primary btn-sm w-100">絞り込む</button>
+            </div>
+        </form>
+    </div>
+
+    <!-- 低使用率部屋ピックアップ -->
+    <?php if (!empty($lowRooms)): ?>
+    <div class="mui-paper border border-warning">
+        <div class="section-title text-warning">⚠ 低使用率の部屋（<?= h($threshold) ?>%以下）</div>
+        <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle mb-0">
+                <thead class="table-light">
+                <tr>
+                    <th>部屋名</th>
+                    <th class="text-end">総予約数</th>
+                    <th class="text-end">食べる</th>
+                    <th>使用率</th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($lowRooms as $r): ?>
+                    <tr>
+                        <td><?= h($r['room_name']) ?></td>
+                        <td class="text-end"><?= h($r['total_reservations']) ?></td>
+                        <td class="text-end"><?= h($r['eat_count']) ?></td>
+                        <td>
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="usage-bar-wrap">
+                                    <div class="usage-bar">
+                                        <div class="usage-bar-fill bg-warning" style="width:<?= h(min(100, $r['usage_rate'])) ?>%"></div>
+                                    </div>
+                                </div>
+                                <span class="fw-semibold text-warning"><?= h($r['usage_rate']) ?>%</span>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <!-- 全部屋使用率一覧 -->
+    <div class="mui-paper">
+        <div class="section-title">全部屋の使用率一覧</div>
+        <?php if (empty($rooms)): ?>
+            <div class="text-muted text-center py-3">対象データがありません</div>
+        <?php else: ?>
+        <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle mb-0">
+                <thead class="table-light">
+                <tr>
+                    <th>部屋名</th>
+                    <th class="text-end">総予約数</th>
+                    <th class="text-end">食べる</th>
+                    <th class="text-end">食べない</th>
+                    <th>使用率</th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($rooms as $r): ?>
+                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['total_reservations'] > 0; ?>
+                    <tr class="<?= $isLow ? 'table-warning' : '' ?>">
+                        <td>
+                            <?= h($r['room_name']) ?>
+                            <?php if ($isLow): ?>
+                                <span class="badge bg-warning text-dark low-badge ms-1">低</span>
+                            <?php endif; ?>
+                        </td>
+                        <td class="text-end"><?= h($r['total_reservations']) ?></td>
+                        <td class="text-end"><?= h($r['eat_count']) ?></td>
+                        <td class="text-end"><?= h($r['total_reservations'] - $r['eat_count']) ?></td>
+                        <td>
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="usage-bar-wrap">
+                                    <div class="usage-bar">
+                                        <?php
+                                            $pct = (float)$r['usage_rate'];
+                                            $color = $pct >= 70 ? '#198754' : ($pct >= 50 ? '#ffc107' : '#dc3545');
+                                        ?>
+                                        <div class="usage-bar-fill" style="width:<?= h(min(100, $pct)) ?>%;background:<?= h($color) ?>"></div>
+                                    </div>
+                                </div>
+                                <span class="fw-semibold" style="color:<?= h($color) ?>"><?= h($pct) ?>%</span>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ApprovalServiceTest.php
@@ -105,17 +105,16 @@ class ApprovalServiceTest extends TestCase
     }
 
     /**
-     * バグ再現テスト:
-     * STATUS_PENDING(0) のレコードを adminApprove しても STATUS_ADMIN(2) にならないこと。
+     * 管理者は緊急時にブロック長承認ステップを経ずに直接最終承認できること。
      */
-    public function testAdminApprove_fails_when_status_is_pending(): void
+    public function testAdminApprove_succeeds_from_pending(): void
     {
         $this->setStatus(ApprovalService::STATUS_PENDING);
 
         $result = $this->service->adminApprove([$this->key1], 99, 'tester');
 
-        $this->assertFalse($result);
-        $this->assertSame(ApprovalService::STATUS_PENDING, $this->getStatus(), '承認ルートを経由せず承認済みになってはならない');
+        $this->assertTrue($result);
+        $this->assertSame(ApprovalService::STATUS_ADMIN, $this->getStatus(), '管理者は未承認レコードを直接最終承認できる');
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
Closes #352

## 変更内容

### 新規追加

- **`src/Service/RoomUsageService.php`**
  - `getRoomUsage()` — 期間・食種フィルタで部屋ごとの総予約数・食べる人数・使用率を集計
  - `getLowUsageRooms()` — 使用率が閾値以下の部屋をピックアップして返す

- **`src/Policy/RoomUsagePolicy.php`**
  - `canIndex` / `canRoomUsage` / `canLowUsageRooms` をシステム管理者（`i_admin=3`）のみ許可

- **`src/Controller/RoomUsageController.php`**
  - `GET /RoomUsage` — 部屋使用率一覧 HTML ページ（フィルタ付き）
  - `GET /RoomUsage/roomUsage` — 使用率一覧 JSON API
  - `GET /RoomUsage/lowUsageRooms` — 低使用率部屋ピックアップ JSON API（`threshold` パラメータで閾値指定）

- **`templates/RoomUsage/index.php`**
  - 日付範囲・食種・閾値フィルタ
  - 閾値以下の部屋を上部に警告表示
  - 全部屋の使用率をバー付きで一覧表示（70%以上=緑 / 50〜70%=黄 / 50%未満=赤）

### 変更

- **`config/routes.php`** — `/RoomUsage`、`/RoomUsage/roomUsage`、`/RoomUsage/lowUsageRooms` を追加
- **`src/Application.php`** — `MapResolver` に `RoomUsageController → RoomUsagePolicy` を登録
- **`templates/Pages/dashboard.php`** — システム管理セクションに「📈 部屋使用率」ボタンを追加（システム管理者のみ表示）

## アクセス制御

システム管理者以外がアクセスした場合:
- HTML ページ: ダッシュボードへリダイレクト
- JSON API: HTTP 403 + `{"success":false,"error":"..."}`