### PR TITLE
Resolve #352: システム管理者向け部屋使用率機能を実装

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
@@ -8,65 +8,86 @@ use Cake\ORM\TableRegistry;
 /**
  * 部屋使用率集計サービス
  *
- * t_individual_reservation_info を集計し、部屋ごとの使用率を算出する。
- * 使用率 = 食べる人数 / 総予約数 × 100
+ * 使用率の分母は m_user_group の有効所属人数（定員ベース）。
+ * 複数部屋所属ユーザーはそれぞれの部屋の定員に含まれ、
+ * 実際に食べた部屋のみ eat_count にカウントされる。
+ *
+ * 使用率 = 食べる件数 / (部屋の有効所属人数 × 日数 × 食種数) × 100
  */
 class RoomUsageService
 {
     /**
      * 部屋ごとの使用率一覧を返す。
      *
-     * @param string|null $dateFrom 開始日 (Y-m-d)
-     * @param string|null $dateTo   終了日 (Y-m-d)
-     * @param int|null    $mealType 食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
-     * @return array{room_id:int, room_name:string, total_reservations:int, eat_count:int, usage_rate:float}[]
+     * @param string|null $dateFrom   開始日 (Y-m-d)
+     * @param string|null $dateTo     終了日 (Y-m-d)
+     * @param int|null    $mealType   食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
+     * @return array{room_id:int, room_name:string, capacity:int, eat_count:int, usage_rate:float}[]
      */
     public function getRoomUsage(
         ?string $dateFrom = null,
         ?string $dateTo   = null,
         ?int    $mealType = null
     ): array {
-        $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
-        $query = $table->find()->contain(['MRoomInfo']);
+        $resolvedFrom = $dateFrom ?? date('Y-m-01');
+        $resolvedTo   = $dateTo   ?? date('Y-m-d');
 
-        if ($dateFrom !== null) {
-            $query->where(['TIndividualReservationInfo.d_reservation_date >=' => $dateFrom]);
+        // 日数・食種数から1部屋あたりのスロット乗数を算出
+        $days          = (int)(new \DateTimeImmutable($resolvedFrom))->diff(new \DateTimeImmutable($resolvedTo))->days + 1;
+        $mealTypeCount = $mealType !== null ? 1 : 4;
+        $slotMultiple  = $days * $mealTypeCount;
+
+        // m_user_group から有効所属人数を部屋別に集計
+        $groupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $groupRows  = $groupTable->find()
+            ->contain(['MRoomInfo'])
+            ->where(['active_flag' => 1])
+            ->all()
+            ->toArray();
+
+        $roomCapacity = [];
+        $roomNames    = [];
+        foreach ($groupRows as $row) {
+            $roomId = (int)$row->i_id_room;
+            $roomCapacity[$roomId] = ($roomCapacity[$roomId] ?? 0) + 1;
+            $roomNames[$roomId]    = $row->m_room_info->c_room_name ?? '';
         }
-        if ($dateTo !== null) {
-            $query->where(['TIndividualReservationInfo.d_reservation_date <=' => $dateTo]);
-        }
+
+        // t_individual_reservation_info から食べる件数を部屋別に集計
+        $resTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $query    = $resTable->find()
+            ->where([
+                'TIndividualReservationInfo.d_reservation_date >=' => $resolvedFrom,
+                'TIndividualReservationInfo.d_reservation_date <=' => $resolvedTo,
+            ]);
+
         if ($mealType !== null) {
             $query->where(['TIndividualReservationInfo.i_reservation_type' => $mealType]);
         }
 
-        $rows = $query->all()->toArray();
-
-        $grouped = [];
-        foreach ($rows as $row) {
-            $roomId = (int)$row->i_id_room;
-            if (!isset($grouped[$roomId])) {
-                $grouped[$roomId] = [
-                    'room_id'            => $roomId,
-                    'room_name'          => $row->m_room_info->c_room_name ?? '',
-                    'total_reservations' => 0,
-                    'eat_count'          => 0,
-                ];
-            }
-            $grouped[$roomId]['total_reservations']++;
+        $eatCounts = [];
+        foreach ($query->all()->toArray() as $row) {
+            $roomId       = (int)$row->i_id_room;
             $effectiveEat = $row->i_change_flag !== null
                 ? (int)$row->i_change_flag
                 : (int)($row->eat_flag ?? 0);
             if ($effectiveEat === 1) {
-                $grouped[$roomId]['eat_count']++;
+                $eatCounts[$roomId] = ($eatCounts[$roomId] ?? 0) + 1;
             }
         }
 
+        // 部屋ごとに使用率を算出
         $result = [];
-        foreach ($grouped as $data) {
-            $data['usage_rate'] = $data['total_reservations'] > 0
-                ? round($data['eat_count'] / $data['total_reservations'] * 100, 1)
-                : 0.0;
-            $result[] = $data;
+        foreach ($roomCapacity as $roomId => $userCount) {
+            $capacity = $userCount * $slotMultiple;
+            $eatCount = $eatCounts[$roomId] ?? 0;
+            $result[] = [
+                'room_id'    => $roomId,
+                'room_name'  => $roomNames[$roomId],
+                'capacity'   => $capacity,
+                'eat_count'  => $eatCount,
+                'usage_rate' => $capacity > 0 ? round($eatCount / $capacity * 100, 1) : 0.0,
+            ];
         }
 
         usort($result, static fn(array $a, array $b): int => strcmp((string)$a['room_name'], (string)$b['room_name']));
@@ -75,7 +96,7 @@ class RoomUsageService
     }
 
     /**
-     * 使用率が閾値を下回る部屋を返す。
+     * 使用率が閾値以下の部屋を返す。
      *
      * @param float       $threshold 使用率の閾値（%）。この値以下の部屋を返す。デフォルト 50.0
      * @param string|null $dateFrom

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -83,7 +83,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">総予約数</th>
+                    <th class="text-end">定員スロット数</th>
                     <th class="text-end">食べる</th>
                     <th>使用率</th>
                 </tr>
@@ -92,7 +92,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <?php foreach ($lowRooms as $r): ?>
                     <tr>
                         <td><?= h($r['room_name']) ?></td>
-                        <td class="text-end"><?= h($r['total_reservations']) ?></td>
+                        <td class="text-end"><?= h($r['capacity']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
@@ -123,15 +123,15 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">総予約数</th>
+                    <th class="text-end">定員スロット数</th>
                     <th class="text-end">食べる</th>
-                    <th class="text-end">食べない</th>
+                    <th class="text-end">食べない・未提出</th>
                     <th>使用率</th>
                 </tr>
                 </thead>
                 <tbody>
                 <?php foreach ($rooms as $r): ?>
-                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['total_reservations'] > 0; ?>
+                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['capacity'] > 0; ?>
                     <tr class="<?= $isLow ? 'table-warning' : '' ?>">
                         <td>
                             <?= h($r['room_name']) ?>
@@ -139,9 +139,9 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                                 <span class="badge bg-warning text-dark low-badge ms-1">低</span>
                             <?php endif; ?>
                         </td>
-                        <td class="text-end"><?= h($r['total_reservations']) ?></td>
+                        <td class="text-end"><?= h($r['capacity']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
-                        <td class="text-end"><?= h($r['total_reservations'] - $r['eat_count']) ?></td>
+                        <td class="text-end"><?= h($r['capacity'] - $r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
                                 <div class="usage-bar-wrap">


### PR DESCRIPTION
Closes #352

## 変更内容

### 新規ファイル

- **`src/Service/RoomUsageService.php`**
  - `getRoomUsage()` — 部屋ごとの使用率を集計。分母は `m_user_group` の有効所属人数 × 日数 × 食種数（定員ベース）
  - `getLowUsageRooms()` — 使用率が閾値以下の部屋をピックアップ
  - 複数部屋所属ユーザーは各部屋の定員に含まれ、実際に食べた部屋のみ `eat_count` に加算

- **`src/Policy/RoomUsagePolicy.php`**
  - `canIndex` / `canRoomUsage` / `canLowUsageRooms` をシステム管理者（`i_admin=3`）のみ許可

- **`src/Controller/RoomUsageController.php`**
  - `GET /RoomUsage` — 部屋使用率一覧 HTML ページ（日付・食種・閾値フィルタ付き）
  - `GET /RoomUsage/roomUsage` — 使用率一覧 JSON API
  - `GET /RoomUsage/lowUsageRooms` — 低使用率部屋ピックアップ JSON API
  - システム管理者以外: HTML → ダッシュボードへリダイレクト / API → HTTP 403

- **`templates/RoomUsage/index.php`**
  - 閾値以下の部屋を上部に警告表示
  - 全部屋の使用率をバー付きで一覧表示（70%以上=緑 / 50〜70%=黄 / 50%未満=赤）

### 変更

- **`config/routes.php`** — `/RoomUsage`・`/RoomUsage/roomUsage`・`/RoomUsage/lowUsageRooms` を追加
- **`src/Application.php`** — `MapResolver` に `RoomUsageController → RoomUsagePolicy` を登録
- **`templates/Pages/dashboard.php`** — システム管理セクションに「📈 部屋使用率」ボタンを追加（システム管理者のみ表示）
- **`tests/TestCase/Service/ApprovalServiceTest.php`** — `adminApprove` の直接承認テストを新仕様（成功）に更新

## 使用率の計算式

```
使用率 = 食べる件数 / (m_user_group 有効所属人数 × 日数 × 食種数) × 100
```

複数部屋所属ユーザーは各部屋の定員にそれぞれカウントされ、
実際に食べた部屋のみ eat_count に加算されるため、部屋ごとの実態を正確に反映する。