### PR TITLE
Resolve #352: 使用率分母をDISTINCTユーザー数×日数×食種数に変更

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
@@ -8,21 +8,22 @@ use Cake\ORM\TableRegistry;
 /**
  * 部屋使用率集計サービス
  *
- * 使用率の分母は m_user_group の有効所属人数（定員ベース）。
- * 複数部屋所属ユーザーはそれぞれの部屋の定員に含まれ、
- * 実際に食べた部屋のみ eat_count にカウントされる。
+ * 分母: 対象期間に実際に存在する予約レコード数（食べる＋食べない）
+ * 分子: そのうち effective_eat_flag = 1 のレコード数
  *
- * 使用率 = 食べる件数 / (部屋の有効所属人数 × 日数 × 食種数) × 100
+ * m_user_group の active_flag ではなく実レコードを分母にすることで
+ * 「期間中に退出したユーザーの記録が eat_count に含まれる」問題を防ぎ、
+ * 複数部屋所属ユーザーも部屋ごとに正しく集計できる。
  */
 class RoomUsageService
 {
     /**
      * 部屋ごとの使用率一覧を返す。
      *
-     * @param string|null $dateFrom   開始日 (Y-m-d)
-     * @param string|null $dateTo     終了日 (Y-m-d)
-     * @param int|null    $mealType   食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
-     * @return array{room_id:int, room_name:string, capacity:int, eat_count:int, usage_rate:float}[]
+     * @param string|null $dateFrom 開始日 (Y-m-d)
+     * @param string|null $dateTo   終了日 (Y-m-d)
+     * @param int|null    $mealType 食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
+     * @return array{room_id:int, room_name:string, total_slots:int, eat_count:int, usage_rate:float}[]
      */
     public function getRoomUsage(
         ?string $dateFrom = null,
@@ -32,30 +33,9 @@ class RoomUsageService
         $resolvedFrom = $dateFrom ?? date('Y-m-01');
         $resolvedTo   = $dateTo   ?? date('Y-m-d');
 
-        // 日数・食種数から1部屋あたりのスロット乗数を算出
-        $days          = (int)(new \DateTimeImmutable($resolvedFrom))->diff(new \DateTimeImmutable($resolvedTo))->days + 1;
-        $mealTypeCount = $mealType !== null ? 1 : 4;
-        $slotMultiple  = $days * $mealTypeCount;
-
-        // m_user_group から有効所属人数を部屋別に集計
-        $groupTable = TableRegistry::getTableLocator()->get('MUserGroup');
-        $groupRows  = $groupTable->find()
+        $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $query = $table->find()
             ->contain(['MRoomInfo'])
-            ->where(['active_flag' => 1])
-            ->all()
-            ->toArray();
-
-        $roomCapacity = [];
-        $roomNames    = [];
-        foreach ($groupRows as $row) {
-            $roomId = (int)$row->i_id_room;
-            $roomCapacity[$roomId] = ($roomCapacity[$roomId] ?? 0) + 1;
-            $roomNames[$roomId]    = $row->m_room_info->c_room_name ?? '';
-        }
-
-        // t_individual_reservation_info から食べる件数を部屋別に集計
-        $resTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
-        $query    = $resTable->find()
             ->where([
                 'TIndividualReservationInfo.d_reservation_date >=' => $resolvedFrom,
                 'TIndividualReservationInfo.d_reservation_date <=' => $resolvedTo,
@@ -65,29 +45,32 @@ class RoomUsageService
             $query->where(['TIndividualReservationInfo.i_reservation_type' => $mealType]);
         }
 
-        $eatCounts = [];
+        $grouped = [];
         foreach ($query->all()->toArray() as $row) {
-            $roomId       = (int)$row->i_id_room;
+            $roomId = (int)$row->i_id_room;
+            if (!isset($grouped[$roomId])) {
+                $grouped[$roomId] = [
+                    'room_id'     => $roomId,
+                    'room_name'   => $row->m_room_info->c_room_name ?? '',
+                    'total_slots' => 0,
+                    'eat_count'   => 0,
+                ];
+            }
+            $grouped[$roomId]['total_slots']++;
             $effectiveEat = $row->i_change_flag !== null
                 ? (int)$row->i_change_flag
                 : (int)($row->eat_flag ?? 0);
             if ($effectiveEat === 1) {
-                $eatCounts[$roomId] = ($eatCounts[$roomId] ?? 0) + 1;
+                $grouped[$roomId]['eat_count']++;
             }
         }
 
-        // 部屋ごとに使用率を算出
         $result = [];
-        foreach ($roomCapacity as $roomId => $userCount) {
-            $capacity = $userCount * $slotMultiple;
-            $eatCount = $eatCounts[$roomId] ?? 0;
-            $result[] = [
-                'room_id'    => $roomId,
-                'room_name'  => $roomNames[$roomId],
-                'capacity'   => $capacity,
-                'eat_count'  => $eatCount,
-                'usage_rate' => $capacity > 0 ? round($eatCount / $capacity * 100, 1) : 0.0,
-            ];
+        foreach ($grouped as $data) {
+            $data['usage_rate'] = $data['total_slots'] > 0
+                ? round($data['eat_count'] / $data['total_slots'] * 100, 1)
+                : 0.0;
+            $result[] = $data;
         }
 
         usort($result, static fn(array $a, array $b): int => strcmp((string)$a['room_name'], (string)$b['room_name']));

--- a/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
@@ -8,12 +8,14 @@ use Cake\ORM\TableRegistry;
 /**
  * 部屋使用率集計サービス
  *
- * 分母: 対象期間に実際に存在する予約レコード数（食べる＋食べない）
- * 分子: そのうち effective_eat_flag = 1 のレコード数
+ * 使用率 = 食べる件数 / (期間中に部屋に存在したユーザー数 × 日数 × 食種数) × 100
  *
- * m_user_group の active_flag ではなく実レコードを分母にすることで
- * 「期間中に退出したユーザーの記録が eat_count に含まれる」問題を防ぎ、
- * 複数部屋所属ユーザーも部屋ごとに正しく集計できる。
+ * 分母の「ユーザー数」は t_individual_reservation_info の DISTINCT ユーザー数を使う。
+ * - m_user_group の active_flag（現在状態）ではなく実績ベースのため
+ *   退出済みユーザーの eat_count が capacity を超える問題が発生しない。
+ * - 複数部屋所属ユーザーは各部屋の DISTINCT ユーザー集合に独立して含まれる。
+ * - 未提出の日がある場合も「1件でも記録がある = その部屋の利用者」とみなし、
+ *   提出漏れ分は食べない扱いとして分母に算入する。
  */
 class RoomUsageService
 {
@@ -23,15 +25,17 @@ class RoomUsageService
      * @param string|null $dateFrom 開始日 (Y-m-d)
      * @param string|null $dateTo   終了日 (Y-m-d)
      * @param int|null    $mealType 食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
-     * @return array{room_id:int, room_name:string, total_slots:int, eat_count:int, usage_rate:float}[]
+     * @return array{room_id:int, room_name:string, user_count:int, capacity:int, eat_count:int, usage_rate:float}[]
      */
     public function getRoomUsage(
         ?string $dateFrom = null,
         ?string $dateTo   = null,
         ?int    $mealType = null
     ): array {
-        $resolvedFrom = $dateFrom ?? date('Y-m-01');
-        $resolvedTo   = $dateTo   ?? date('Y-m-d');
+        $resolvedFrom  = $dateFrom ?? date('Y-m-01');
+        $resolvedTo    = $dateTo   ?? date('Y-m-d');
+        $days          = (int)(new \DateTimeImmutable($resolvedFrom))->diff(new \DateTimeImmutable($resolvedTo))->days + 1;
+        $mealTypeCount = $mealType !== null ? 1 : 4;
 
         $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $query = $table->find()
@@ -45,32 +49,39 @@ class RoomUsageService
             $query->where(['TIndividualReservationInfo.i_reservation_type' => $mealType]);
         }
 
-        $grouped = [];
+        // 部屋ごとに「期間中の DISTINCT ユーザー集合」と「食べる件数」を集計
+        $usersByRoom = [];
+        $eatCounts   = [];
+        $roomNames   = [];
+
         foreach ($query->all()->toArray() as $row) {
             $roomId = (int)$row->i_id_room;
-            if (!isset($grouped[$roomId])) {
-                $grouped[$roomId] = [
-                    'room_id'     => $roomId,
-                    'room_name'   => $row->m_room_info->c_room_name ?? '',
-                    'total_slots' => 0,
-                    'eat_count'   => 0,
-                ];
-            }
-            $grouped[$roomId]['total_slots']++;
+            $userId = (int)$row->i_id_user;
+
+            $usersByRoom[$roomId][$userId] = true;
+            $roomNames[$roomId]            = $row->m_room_info->c_room_name ?? '';
+
             $effectiveEat = $row->i_change_flag !== null
                 ? (int)$row->i_change_flag
                 : (int)($row->eat_flag ?? 0);
             if ($effectiveEat === 1) {
-                $grouped[$roomId]['eat_count']++;
+                $eatCounts[$roomId] = ($eatCounts[$roomId] ?? 0) + 1;
             }
         }
 
         $result = [];
-        foreach ($grouped as $data) {
-            $data['usage_rate'] = $data['total_slots'] > 0
-                ? round($data['eat_count'] / $data['total_slots'] * 100, 1)
-                : 0.0;
-            $result[] = $data;
+        foreach ($usersByRoom as $roomId => $users) {
+            $userCount = count($users);
+            $capacity  = $userCount * $days * $mealTypeCount;
+            $eatCount  = $eatCounts[$roomId] ?? 0;
+            $result[]  = [
+                'room_id'    => $roomId,
+                'room_name'  => $roomNames[$roomId],
+                'user_count' => $userCount,
+                'capacity'   => $capacity,
+                'eat_count'  => $eatCount,
+                'usage_rate' => $capacity > 0 ? round($eatCount / $capacity * 100, 1) : 0.0,
+            ];
         }
 
         usort($result, static fn(array $a, array $b): int => strcmp((string)$a['room_name'], (string)$b['room_name']));

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -83,7 +83,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">定員数</th>
+                    <th class="text-end">総食数</th>
                     <th class="text-end">食べる</th>
                     <th>使用率</th>
                 </tr>
@@ -123,7 +123,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">定員数</th>
+                    <th class="text-end">総食数</th>
                     <th class="text-end">食べる</th>
                     <th class="text-end">食べない</th>
                     <th>使用率</th>

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -83,7 +83,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">定員スロット数</th>
+                    <th class="text-end">提出数</th>
                     <th class="text-end">食べる</th>
                     <th>使用率</th>
                 </tr>
@@ -92,7 +92,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <?php foreach ($lowRooms as $r): ?>
                     <tr>
                         <td><?= h($r['room_name']) ?></td>
-                        <td class="text-end"><?= h($r['capacity']) ?></td>
+                        <td class="text-end"><?= h($r['total_slots']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
@@ -123,15 +123,15 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">定員スロット数</th>
+                    <th class="text-end">提出数</th>
                     <th class="text-end">食べる</th>
-                    <th class="text-end">食べない・未提出</th>
+                    <th class="text-end">食べない</th>
                     <th>使用率</th>
                 </tr>
                 </thead>
                 <tbody>
                 <?php foreach ($rooms as $r): ?>
-                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['capacity'] > 0; ?>
+                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['total_slots'] > 0; ?>
                     <tr class="<?= $isLow ? 'table-warning' : '' ?>">
                         <td>
                             <?= h($r['room_name']) ?>
@@ -139,9 +139,9 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                                 <span class="badge bg-warning text-dark low-badge ms-1">低</span>
                             <?php endif; ?>
                         </td>
-                        <td class="text-end"><?= h($r['capacity']) ?></td>
+                        <td class="text-end"><?= h($r['total_slots']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
-                        <td class="text-end"><?= h($r['capacity'] - $r['eat_count']) ?></td>
+                        <td class="text-end"><?= h($r['total_slots'] - $r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
                                 <div class="usage-bar-wrap">

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -83,7 +83,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">提出数</th>
+                    <th class="text-end">定員数</th>
                     <th class="text-end">食べる</th>
                     <th>使用率</th>
                 </tr>
@@ -92,7 +92,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <?php foreach ($lowRooms as $r): ?>
                     <tr>
                         <td><?= h($r['room_name']) ?></td>
-                        <td class="text-end"><?= h($r['total_slots']) ?></td>
+                        <td class="text-end"><?= h($r['capacity']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
@@ -123,7 +123,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 <thead class="table-light">
                 <tr>
                     <th>部屋名</th>
-                    <th class="text-end">提出数</th>
+                    <th class="text-end">定員数</th>
                     <th class="text-end">食べる</th>
                     <th class="text-end">食べない</th>
                     <th>使用率</th>
@@ -131,7 +131,7 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 </thead>
                 <tbody>
                 <?php foreach ($rooms as $r): ?>
-                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['total_slots'] > 0; ?>
+                    <?php $isLow = $r['usage_rate'] <= $threshold && $r['capacity'] > 0; ?>
                     <tr class="<?= $isLow ? 'table-warning' : '' ?>">
                         <td>
                             <?= h($r['room_name']) ?>
@@ -139,9 +139,9 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                                 <span class="badge bg-warning text-dark low-badge ms-1">低</span>
                             <?php endif; ?>
                         </td>
-                        <td class="text-end"><?= h($r['total_slots']) ?></td>
+                        <td class="text-end"><?= h($r['capacity']) ?></td>
                         <td class="text-end"><?= h($r['eat_count']) ?></td>
-                        <td class="text-end"><?= h($r['total_slots'] - $r['eat_count']) ?></td>
+                        <td class="text-end"><?= h($r['capacity'] - $r['eat_count']) ?></td>
                         <td>
                             <div class="d-flex align-items-center gap-2">
                                 <div class="usage-bar-wrap">


### PR DESCRIPTION
Closes #352

## 変更内容

### RoomUsageService.php — 使用率の分母アルゴリズムを改善
- 分母を `m_user_group.active_flag=1` の人数ベースから **実績データの DISTINCTユーザー数 × 日数 × 食種数** に変更
- 退出済みユーザーが期間中に eat_count を持つと `eat_count > capacity` になる問題を解消
- 複数部屋所属ユーザーは各部屋の DISTINCT ユーザー集合に独立して含まれるため二重計上なし
- 未提出日があっても「1件でも記録がある = その部屋の利用者」とみなして分母に算入

### templates/RoomUsage/index.php — 表示列の修正
- `total_slots` キーを `capacity` に統一（サービスの返り値に合わせる）
- 列ヘッダー「提出数」→「定員数」→「総食数」に変更（ユーザー数 × 日数 × 食種数 の意味を正確に表現）
- 低使用率テーブル・全部屋テーブルの両方で列名を統一