### PR TITLE
feat: #352 部屋使用率に職員ごとの予約率を追加

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomUsageService.php
@@ -20,12 +20,12 @@ use Cake\ORM\TableRegistry;
 class RoomUsageService
 {
     /**
-     * 部屋ごとの使用率一覧を返す。
+     * 部屋ごとの使用率一覧を返す。職員（i_user_level=0）の個別使用率も含む。
      *
      * @param string|null $dateFrom 開始日 (Y-m-d)
      * @param string|null $dateTo   終了日 (Y-m-d)
      * @param int|null    $mealType 食種 (1=朝 2=昼 3=夕 4=弁当, null=全て)
-     * @return array{room_id:int, room_name:string, user_count:int, capacity:int, eat_count:int, usage_rate:float}[]
+     * @return array{room_id:int, room_name:string, user_count:int, capacity:int, eat_count:int, usage_rate:float, staff:array}[]
      */
     public function getRoomUsage(
         ?string $dateFrom = null,
@@ -39,7 +39,7 @@ class RoomUsageService
 
         $table = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $query = $table->find()
-            ->contain(['MRoomInfo'])
+            ->contain(['MRoomInfo', 'MUserInfo'])
             ->where([
                 'TIndividualReservationInfo.d_reservation_date >=' => $resolvedFrom,
                 'TIndividualReservationInfo.d_reservation_date <=' => $resolvedTo,
@@ -50,13 +50,17 @@ class RoomUsageService
         }
 
         // 部屋ごとに「期間中の DISTINCT ユーザー集合」と「食べる件数」を集計
-        $usersByRoom = [];
-        $eatCounts   = [];
-        $roomNames   = [];
+        $usersByRoom    = [];
+        $eatCounts      = [];
+        $roomNames      = [];
+        $staffByRoom    = [];
+        $staffEatCounts = [];
+        $staffNames     = [];
 
         foreach ($query->all()->toArray() as $row) {
-            $roomId = (int)$row->i_id_room;
-            $userId = (int)$row->i_id_user;
+            $roomId    = (int)$row->i_id_room;
+            $userId    = (int)$row->i_id_user;
+            $userLevel = (int)($row->m_user_info->i_user_level ?? -1);
 
             $usersByRoom[$roomId][$userId] = true;
             $roomNames[$roomId]            = $row->m_room_info->c_room_name ?? '';
@@ -67,6 +71,15 @@ class RoomUsageService
             if ($effectiveEat === 1) {
                 $eatCounts[$roomId] = ($eatCounts[$roomId] ?? 0) + 1;
             }
+
+            // 職員（i_user_level=0）のみ別途集計
+            if ($userLevel === 0) {
+                $staffByRoom[$roomId][$userId] = true;
+                $staffNames[$userId]           = $row->m_user_info->c_user_name ?? '';
+                if ($effectiveEat === 1) {
+                    $staffEatCounts[$roomId][$userId] = ($staffEatCounts[$roomId][$userId] ?? 0) + 1;
+                }
+            }
         }
 
         $result = [];
@@ -74,13 +87,29 @@ class RoomUsageService
             $userCount = count($users);
             $capacity  = $userCount * $days * $mealTypeCount;
             $eatCount  = $eatCounts[$roomId] ?? 0;
-            $result[]  = [
+
+            $staffList = [];
+            foreach (array_keys($staffByRoom[$roomId] ?? []) as $staffId) {
+                $staffCapacity = $days * $mealTypeCount;
+                $staffEatCount = $staffEatCounts[$roomId][$staffId] ?? 0;
+                $staffList[]   = [
+                    'user_id'    => $staffId,
+                    'user_name'  => $staffNames[$staffId],
+                    'capacity'   => $staffCapacity,
+                    'eat_count'  => $staffEatCount,
+                    'usage_rate' => $staffCapacity > 0 ? round($staffEatCount / $staffCapacity * 100, 1) : 0.0,
+                ];
+            }
+            usort($staffList, static fn(array $a, array $b): int => strcmp((string)$a['user_name'], (string)$b['user_name']));
+
+            $result[] = [
                 'room_id'    => $roomId,
                 'room_name'  => $roomNames[$roomId],
                 'user_count' => $userCount,
                 'capacity'   => $capacity,
                 'eat_count'  => $eatCount,
                 'usage_rate' => $capacity > 0 ? round($eatCount / $capacity * 100, 1) : 0.0,
+                'staff'      => $staffList,
             ];
         }
 

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -30,6 +30,12 @@ $basePath   = $this->request->getAttribute('base') ?? '';
         .usage-bar { height: 8px; border-radius: 4px; background: #e9ecef; overflow: hidden; }
         .usage-bar-fill { height: 100%; border-radius: 4px; transition: width .3s; }
         .low-badge { font-size: .7rem; padding: 2px 6px; }
+        .staff-row { background: #f8f9fa; }
+        .staff-row td { font-size: .85rem; padding-top: 4px !important; padding-bottom: 4px !important; }
+        .staff-toggle { cursor: pointer; user-select: none; }
+        .staff-toggle .toggle-icon { font-size: .75rem; transition: transform .2s; display: inline-block; }
+        .staff-toggle.collapsed .toggle-icon { transform: rotate(-90deg); }
+        .staff-indent { padding-left: 1.5rem !important; }
     </style>
 </head>
 <body>
@@ -130,10 +136,15 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                 </tr>
                 </thead>
                 <tbody>
-                <?php foreach ($rooms as $r): ?>
+                <?php foreach ($rooms as $idx => $r): ?>
                     <?php $isLow = $r['usage_rate'] <= $threshold && $r['capacity'] > 0; ?>
-                    <tr class="<?= $isLow ? 'table-warning' : '' ?>">
+                    <?php $hasStaff = !empty($r['staff']); ?>
+                    <tr class="<?= $isLow ? 'table-warning' : '' ?><?= $hasStaff ? ' staff-toggle' : '' ?>"
+                        <?= $hasStaff ? 'data-bs-toggle="collapse" data-bs-target="#staff-' . $idx . '" aria-expanded="true"' : '' ?>>
                         <td>
+                            <?php if ($hasStaff): ?>
+                                <span class="toggle-icon me-1">▾</span>
+                            <?php endif; ?>
                             <?= h($r['room_name']) ?>
                             <?php if ($isLow): ?>
                                 <span class="badge bg-warning text-dark low-badge ms-1">低</span>
@@ -157,6 +168,47 @@ $basePath   = $this->request->getAttribute('base') ?? '';
                             </div>
                         </td>
                     </tr>
+                    <?php if ($hasStaff): ?>
+                    <tr class="collapse show" id="staff-<?= $idx ?>">
+                        <td colspan="5" class="p-0">
+                            <table class="table table-sm mb-0">
+                                <thead class="table-secondary">
+                                <tr>
+                                    <th class="staff-indent">職員名</th>
+                                    <th class="text-end">総食数</th>
+                                    <th class="text-end">食べる</th>
+                                    <th class="text-end">食べない</th>
+                                    <th>使用率</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <?php foreach ($r['staff'] as $s): ?>
+                                    <?php
+                                        $sPct   = (float)$s['usage_rate'];
+                                        $sColor = $sPct >= 70 ? '#198754' : ($sPct >= 50 ? '#ffc107' : '#dc3545');
+                                    ?>
+                                    <tr class="staff-row">
+                                        <td class="staff-indent"><?= h($s['user_name']) ?></td>
+                                        <td class="text-end"><?= h($s['capacity']) ?></td>
+                                        <td class="text-end"><?= h($s['eat_count']) ?></td>
+                                        <td class="text-end"><?= h($s['capacity'] - $s['eat_count']) ?></td>
+                                        <td>
+                                            <div class="d-flex align-items-center gap-2">
+                                                <div class="usage-bar-wrap">
+                                                    <div class="usage-bar">
+                                                        <div class="usage-bar-fill" style="width:<?= h(min(100, $sPct)) ?>%;background:<?= h($sColor) ?>"></div>
+                                                    </div>
+                                                </div>
+                                                <span class="fw-semibold" style="color:<?= h($sColor) ?>"><?= h($sPct) ?>%</span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                    <?php endif; ?>
                 <?php endforeach; ?>
                 </tbody>
             </table>
@@ -165,5 +217,12 @@ $basePath   = $this->request->getAttribute('base') ?? '';
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.querySelectorAll('.staff-toggle').forEach(function(row) {
+    row.addEventListener('click', function() {
+        this.classList.toggle('collapsed');
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
Closes #352

## 変更内容

### RoomUsageService.php
- `getRoomUsage()` のクエリに `MUserInfo` を `contain` に追加し、各予約行のユーザー情報（`i_user_level`, `c_user_name`）を取得できるようにした
- ループ内で `i_user_level === 0`（職員）のユーザーを検出し、部屋 × 職員単位で `eat_count` を別途集計
- 戻り値の各部屋データに `staff` フィールドを追加
  - `staff` には `user_id`, `user_name`, `capacity`, `eat_count`, `usage_rate` を含む配列を返す
  - 職員名の昇順にソート

### templates/RoomUsage/index.php
- 職員がいる部屋の行を Bootstrap collapse でクリック展開できるよう変更（`▾` アイコン付き）
- 展開時に職員ごとのサブテーブル（職員名・総食数・食べる・食べない・使用率バー）を表示
- 職員が存在しない部屋は従来どおり1行表示のまま

### API への影響
- `/RoomUsage/roomUsage`（JSON）は `getRoomUsage()` の戻り値をそのまま返しているため、コントローラー変更なしで `staff` フィールドが自動的に含まれる