### PR TITLE
fix: 全ページのブラウザタブタイトルを日本語化

### DIFF
--- a/src_web/kamaho-shokusu/templates/Error/error400.php
+++ b/src_web/kamaho-shokusu/templates/Error/error400.php
@@ -10,6 +10,16 @@ use Cake\Error\Debugger;
 
 $this->layout = 'error';
 
+$messageMap = [
+    'Bad Request'           => '不正なリクエスト',
+    'Forbidden'             => 'アクセス権限がありません',
+    'Not Found'             => 'ページが見つかりません',
+    'Method Not Allowed'    => '許可されていないメソッドです',
+    'Gone'                  => 'このページは削除されました',
+    'Unauthorized'          => '認証が必要です',
+];
+$japaneseTitle = $messageMap[$message] ?? 'エラーが発生しました';
+
 if (Configure::read('debug')) :
     $this->layout = 'dev_error';
 
@@ -34,9 +44,11 @@ if (Configure::read('debug')) :
 
     $this->end();
 endif;
+
+$this->assign('title', $japaneseTitle);
 ?>
-<h2><?= h($message) ?></h2>
+<h2><?= h($japaneseTitle) ?></h2>
 <p class="error">
-    <strong><?= __d('cake', 'Error') ?>: </strong>
-    <?= __d('cake', 'The requested address {0} was not found on this server.', "<strong>'{$url}'</strong>") ?>
+    <strong>エラー: </strong>
+    <?= sprintf('リクエストされたアドレス <strong>\'%s\'</strong> はこのサーバーで見つかりませんでした。', h($url)) ?>
 </p>

--- a/src_web/kamaho-shokusu/templates/Error/error500.php
+++ b/src_web/kamaho-shokusu/templates/Error/error500.php
@@ -31,7 +31,7 @@ if (Configure::read('debug')) :
     <?php if ($error instanceof Error) : ?>
     <?php $file = $error->getFile() ?>
     <?php $line = $error->getLine() ?>
-    <strong>Error in: </strong>
+    <strong>エラー箇所: </strong>
     <?= $this->Html->link(sprintf('%s, line %s', Debugger::trimPath($file), $line), Debugger::editorUrl($file, $line)); ?>
 <?php endif; ?>
     <?php
@@ -39,9 +39,11 @@ if (Configure::read('debug')) :
 
     $this->end();
 endif;
+
+$this->assign('title', '内部エラーが発生しました');
 ?>
-<h2><?= __d('cake', 'An Internal Error Has Occurred.') ?></h2>
+<h2>内部エラーが発生しました。</h2>
 <p class="error">
-    <strong><?= __d('cake', 'Error') ?>: </strong>
+    <strong>エラー: </strong>
     <?= h($message) ?>
 </p>

--- a/src_web/kamaho-shokusu/templates/MUserInfo/admin_change_password.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/admin_change_password.php
@@ -1,3 +1,4 @@
+<?php $this->assign('title', '管理者：パスワード変更'); ?>
 <?= $this->Form->create(null, ['url' => ['action' => 'adminChangePassword'], 'class' => 'needs-validation']) ?>
 <fieldset>
     <legend class="mb-4">ユーザーのパスワード変更</legend>

--- a/src_web/kamaho-shokusu/templates/Notifications/index.php
+++ b/src_web/kamaho-shokusu/templates/Notifications/index.php
@@ -1,5 +1,6 @@
 <?php
 /** @var \App\View\AppView $this */
+$this->assign('title', '通知一覧');
 $notifications = $notifications ?? [];
 ?>
 

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -2,6 +2,7 @@
 /**
  * 直前編集ビュー
  */
+$this->assign('title', '直前編集');
 
 $selectedRoomId = null;
 $selectedRoomName = '';

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/edit.php
@@ -1,5 +1,6 @@
 <?php
-$loginUser = $this->request->getAttribute('identity'); // 認証済みユーザー情報
+$this->assign('title', '食数予約の編集');
+$loginUser = $this->request->getAttribute('identity');
 ?>
 
 <div class="row">

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/room_details.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/room_details.php
@@ -1,3 +1,4 @@
+<?php $this->assign('title', '部屋詳細'); ?>
 <div class="container">
     <h1>部屋詳細</h1>
     <h2>部屋名: <?= h($room->c_room_name) ?></h2> <!-- 部屋名 -->

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -3,7 +3,7 @@
 <head>
     <?= $this->Html->charset() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= $this->fetch('title') ?></title>
+    <title><?= $this->fetch('title') ?: '食数管理システム' ?></title>
     <?= $this->Html->css('bootstrap.min.css') ?>
     <?= $this->Html->meta('icon') ?>
     <?= $this->Html->meta('description', '食数管理システム') ?>

--- a/src_web/kamaho-shokusu/templates/layout/error.php
+++ b/src_web/kamaho-shokusu/templates/layout/error.php
@@ -15,7 +15,7 @@
  */
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
     <?= $this->Html->charset() ?>
     <title>
@@ -33,7 +33,7 @@
     <div class="error-container">
         <?= $this->Flash->render() ?>
         <?= $this->fetch('content') ?>
-        <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
+        <?= $this->Html->link('戻る', 'javascript:history.back()') ?>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## 変更内容

### レイアウト
- `layout/default.php`: タイトル未設定ページのフォールバックを「食数管理システム」に設定（空タブ防止）
- `layout/error.php`: `<html lang="ja">` 追加、「Back」リンクを「戻る」に変更

### エラーページ
- `Error/error400.php`: `Bad Request` / `Forbidden` / `Not Found` など英語メッセージを日本語にマッピング（不正なリクエスト / アクセス権限がありません / ページが見つかりません 等）
- `Error/error500.php`: 「An Internal Error Has Occurred.」→「内部エラーが発生しました。」

### タイトル未設定ページへの追加
- `TReservationInfo/change_edit.php`: 「直前編集」
- `TReservationInfo/edit.php`: 「食数予約の編集」
- `TReservationInfo/room_details.php`: 「部屋詳細」
- `Notifications/index.php`: 「通知一覧」
- `MUserInfo/admin_change_password.php`: 「管理者：パスワード変更」