### PR TITLE
fix: セキュリティ指摘事項の対応 #372 #373 #374

### DIFF
--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -134,6 +134,10 @@ class TReservationInfoPolicy
         return $this->isStaffOrAdmin($user) && $this->canAccessRoom($user, $resource);
     }
 
+    /**
+     * ログインユーザー自身の予約データ取得のみ許可。
+     * コントローラーはリクエストから userId を受け取らず、identity から強制取得するため IDOR 不可。
+     */
     public function canGetPersonalReservation(?IdentityInterface $user, TReservationInfo $resource): bool
     {
         return $this->isAuthenticated($user);
@@ -154,11 +158,19 @@ class TReservationInfoPolicy
         return $this->isStaffOrAdmin($user);
     }
 
+    /**
+     * 実食なし報告はログインユーザー自身にのみ作用する。
+     * Trait 実装が identity から userId を強制取得するため IDOR 不可。
+     */
     public function canReportNoMeal(?IdentityInterface $user, TReservationInfo $resource): bool
     {
         return $this->isAuthenticated($user);
     }
 
+    /**
+     * 実食あり報告はログインユーザー自身にのみ作用する。
+     * Trait 実装が identity から userId を強制取得するため IDOR 不可。
+     */
     public function canReportEat(?IdentityInterface $user, TReservationInfo $resource): bool
     {
         return $this->isAuthenticated($user);

--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -198,8 +198,6 @@
                         const emitDate = payload.date || date || '';
                         
                         if (modalEl) {
-                            console.log('Modal found, attempting to close:', modalEl.id);
-                            
                             // 複数の方法でモーダルを閉じる試行
                             // 1. reservation:savedイベントを発火（既存の仕組み）
                             modalEl.dispatchEvent(new CustomEvent('reservation:saved', { detail: { date: emitDate } }));

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -53,7 +53,7 @@ window.__BASE_PATH = window.__TRESP.basePath;
                         instance?.show();
                         toastEl.addEventListener('hidden.bs.toast', function(){ toastEl.remove(); });
                     } catch (e) {
-                        console.log('[pageToast]', message);
+                        console.error('[pageToast]', e);
                     }
                 }
 
@@ -67,7 +67,7 @@ function notifyUser(message, type) {
         window.pageToast(message, tone);
         return;
     }
-    try { console.log('[notify]', message); } catch (_) {}
+    alert(message);
 }
 
 (function(){
@@ -1073,21 +1073,11 @@ function unlockForChildren(wrap){
 
         // 複数部屋所属の場合の情報表示
         document.addEventListener('DOMContentLoaded', function() {
-            if (window.__USER_INFO) {
-                console.log('ユーザー情報:', window.__USER_INFO);
-                if (window.__USER_INFO.roomCount > 1) {
-                    console.log('複数部屋所属:', window.__USER_INFO.roomIds);
-                    console.log('表示される食数は', window.__USER_INFO.roomCount, '部屋の合計です');
-                    // 必要に応じて、複数部屋所属の旨をユーザーに表示
-                    if (typeof window.pageToast === 'function') {
-                        setTimeout(function() {
-                            window.pageToast('複数部屋(' + window.__USER_INFO.roomCount + '部屋)の合計数を表示中', 'info');
-                        }, 1000);
-                    }
-                } else if (window.__USER_INFO.roomCount === 1) {
-                    console.log('単一部屋所属:', window.__USER_INFO.roomIds);
-                } else {
-                    console.log('部屋所属なし');
+            if (window.__USER_INFO && window.__USER_INFO.roomCount > 1) {
+                if (typeof window.pageToast === 'function') {
+                    setTimeout(function() {
+                        window.pageToast('複数部屋(' + window.__USER_INFO.roomCount + '部屋)の合計数を表示中', 'info');
+                    }, 1000);
                 }
             }
         });
@@ -1448,7 +1438,6 @@ function unlockForChildren(wrap){
                 // add.js の初期化関数を明示的に呼び出すことで、表示崩れを解消する
                 if (window.ADD_RESERVATION && typeof window.ADD_RESERVATION.init === 'function') {
                     try {
-                        console.log('[loadInto] Explicitly calling ADD_RESERVATION.init()');
                         window.ADD_RESERVATION.init(host);
                     } catch (e) {
                         console.error('Error during ADD_RESERVATION.init():', e);
@@ -2964,8 +2953,6 @@ function isWithin14(dateStr){
             })
                 .then(response => response.json())
                 .then(data => {
-                    // 成功時の処理
-                    console.log('コピー完了', data);
                     // 必要ならリロードやUI更新
                 })
                 .catch(error => {
@@ -3106,9 +3093,6 @@ function isWithin14(dateStr){
             
             // 直前編集モーダル（change_edit.php）: data-reservation-type属性を使用
             var changeEditRows = root.querySelectorAll('#ce-tbody tr[data-user-id], tbody tr[data-user-id]');
-            if (changeEditRows.length > 0) {
-                console.log('[applyLunchBentoExclusion] 直前編集モーダルの排他制御を適用します。対象行数:', changeEditRows.length);
-            }
             changeEditRows.forEach(function(tr){
                 var lunchCb = tr.querySelector('input.meal-checkbox[data-reservation-type="2"]');
                 var bentoCb = tr.querySelector('input.meal-checkbox[data-reservation-type="4"]');


### PR DESCRIPTION
## 概要

Issue #372 / #373 / #374 のセキュリティ指摘事項に対応します。

## 変更内容

### #372 `canReportNoMeal` / `canReportEat` の IDOR 調査

調査の結果、`ReservationReportActionsTrait` の実装が `$userId` を **identity から強制取得** しており、リクエストパラメータからの注入は不可能であることを確認。IDOR は発生しないため Policy の変更は不要。
意図を明文化するため PHPDoc コメントを追加。

### #373 本番 JS の `console.log` 削除

- `treservation_index.inline.js`: `console.log` 9件を削除
  - catch ブロックのログ → `console.error` に置換
  - pageToast 非利用時の通知フォールバック → `alert` に変更
  - ユーザー情報（`window.__USER_INFO`）のデバッグ出力を削除
  - 内部処理トレースログを削除
- `add.js`: `console.log` 1件を削除

### #374 `canGetPersonalReservation` の認可ロジック調査

調査の結果、コントローラーはリクエストからユーザーIDを受け取らず、**identity から強制取得** していることを確認。IDOR は発生しないため Policy の変更は不要。
意図を明文化するため PHPDoc コメントを追加。

## テスト

- [ ] 予約一覧画面が正常に表示されること
- [ ] 実食なし・実食あり報告が正常に動作すること
- [ ] 通知（pageToast）が表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 予約データへのアクセス制御とセキュリティに関する説明を追加しました

* **Chores**
  * 予約関連画面のデバッグログを削除し、内部の情報出力を整理しました
  * エラーハンドリングとユーザー通知の表示方式を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->