### PR TITLE
feat: #185 差し戻し通知から入力画面へのディープリンクを実装

### DIFF
--- a/src_web/kamaho-shokusu/config/Migrations/20260617000000_UpdateRejectionNotificationLink.php
+++ b/src_web/kamaho-shokusu/config/Migrations/20260617000000_UpdateRejectionNotificationLink.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class UpdateRejectionNotificationLink extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->execute(
+            "UPDATE t_notification
+             SET c_link = '/TReservationInfo/my-actual-meal'
+             WHERE c_notification_type = 'approval_rejected'
+               AND c_link = '/TReservationInfo'"
+        );
+    }
+
+    public function down(): void
+    {
+        $this->execute(
+            "UPDATE t_notification
+             SET c_link = '/TReservationInfo'
+             WHERE c_notification_type = 'approval_rejected'
+               AND c_link = '/TReservationInfo/my-actual-meal'"
+        );
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/NotificationService.php
+++ b/src_web/kamaho-shokusu/src/Service/NotificationService.php
@@ -84,9 +84,11 @@ class NotificationService
                 $message .= ' / 理由: ' . trim($reason);
             }
 
-            $deepLink = !empty($group['earliest_date'])
-                ? '/TReservationInfo/bulk-change-edit-form?date=' . $group['earliest_date']
-                : '/TReservationInfo';
+            $deepLink = '/TReservationInfo/my-actual-meal';
+            if (!empty($group['earliest_date'])) {
+                $monday = (new \DateTimeImmutable($group['earliest_date']))->modify('monday this week')->format('Y-m-d');
+                $deepLink .= '?week=' . $monday;
+            }
 
             $notification = $notificationTable->newEntity([
                 'i_id_user' => $userId,

--- a/src_web/kamaho-shokusu/src/Service/NotificationService.php
+++ b/src_web/kamaho-shokusu/src/Service/NotificationService.php
@@ -58,6 +58,13 @@ class NotificationService
             $userId = (int)$row->i_id_user;
             $grouped[$userId]['user_name'] = (string)($row->m_user_info->c_user_name ?? '');
             $grouped[$userId]['items'][] = $this->formatItemSummary($row);
+
+            $dateStr = method_exists($row->d_reservation_date, 'format')
+                ? $row->d_reservation_date->format('Y-m-d')
+                : (string)$row->d_reservation_date;
+            if (empty($grouped[$userId]['earliest_date']) || $dateStr < $grouped[$userId]['earliest_date']) {
+                $grouped[$userId]['earliest_date'] = $dateStr;
+            }
         }
 
         foreach ($grouped as $userId => $group) {
@@ -77,12 +84,16 @@ class NotificationService
                 $message .= ' / 理由: ' . trim($reason);
             }
 
+            $deepLink = !empty($group['earliest_date'])
+                ? '/TReservationInfo/bulk-change-edit-form?date=' . $group['earliest_date']
+                : '/TReservationInfo';
+
             $notification = $notificationTable->newEntity([
                 'i_id_user' => $userId,
                 'c_notification_type' => self::TYPE_APPROVAL_REJECTED,
                 'c_title' => '予約が差し戻されました',
                 'c_message' => mb_strimwidth($message, 0, 255, '...'),
-                'c_link' => '/TReservationInfo',
+                'c_link' => $deepLink,
                 'i_is_read' => 0,
                 'dt_create' => $createdAt,
             ]);


### PR DESCRIPTION
## 概要

差し戻し通知（`approval_rejected`）の「開く」ボタンが `/TReservationInfo`（一覧トップ）にしかリンクしていなかった問題を修正します。

## 変更内容

`NotificationService::createRejectionNotifications` の `c_link` を、差し戻された予約の**最古の日付**を使った直前編集フォームへのディープリンクに変更しました。

**変更前:**
```
c_link: /TReservationInfo
```

**変更後:**
```
c_link: /TReservationInfo/bulk-change-edit-form?date=YYYY-MM-DD
```

- 複数の予約が差し戻された場合は**最古の日付**のページにリンクします
- 万が一日付が取得できない場合は従来通り `/TReservationInfo` にフォールバックします

## 動作イメージ

1. 承認者が予約を差し戻す
2. 対象ユーザーに「予約が差し戻されました」通知が届く
3. 通知の「開く」ボタンを押すと、差し戻された最古の予約日付を含む **直前編集フォームに直接遷移**
4. 該当日付の週が表示された状態で入力・修正が可能

## テスト項目

- [ ] 予約を差し戻したとき、通知の `c_link` が `/TReservationInfo/bulk-change-edit-form?date=YYYY-MM-DD` 形式になっていること
- [ ] 通知の「開く」ボタンから直前編集フォームに遷移できること
- [ ] 複数予約差し戻し時は最古の日付のページに遷移すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 却下通知で、日付フォーマットが想定外の型でも扱えるようにし、表示の安定性を向上しました。
  * 通知の遷移先を「実際の食事」画面へ変更し、対象週（最早日の属する週の開始日）をクエリパラメータで引き渡すようにしました。
  * 過去の却下通知リンクもあわせて更新するマイグレーションを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->