### PR TITLE
feat: #184 差し戻し理由を実食入力画面トップに強調表示する

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1646,10 +1646,32 @@ class TReservationInfoController extends AppController
             $gridData = $service->buildWeekGrid($this->TIndividualReservationInfo, $selectedUsers, $weekMondayStr);
         }
 
+        // 表示週の差し戻し理由（最新1件）を取得してバナー表示に使う
+        $rejectionBanner = null;
+        $weekSundayStr = (new \DateTimeImmutable($weekMondayStr))->modify('+6 days')->format('Y-m-d');
+        $latestRejection = $this->fetchTable('TApprovalLog')->find()
+            ->contain(['Approvers'])
+            ->where([
+                'TApprovalLog.i_id_user'         => $selectedUserId,
+                'TApprovalLog.i_approval_status'  => 3,
+                'TApprovalLog.d_reservation_date >=' => $weekMondayStr,
+                'TApprovalLog.d_reservation_date <=' => $weekSundayStr,
+            ])
+            ->orderDesc('TApprovalLog.dt_create')
+            ->first();
+        if ($latestRejection !== null) {
+            $rejectionBanner = [
+                'reason'   => (string)($latestRejection->c_reject_reason ?: ''),
+                'approver' => (string)($latestRejection->approver->c_user_name ?? ''),
+                'date'     => $latestRejection->dt_create?->format('Y-m-d H:i') ?? '',
+            ];
+        }
+
         $this->set(compact(
             'rooms', 'selectedRoomId', 'gridData', 'targetUsers', 'selectedUserId', 'selectedTargetUser',
             'weekMondayStr', 'prevMonday', 'nextMonday',
-            'canGoPrev', 'canGoNext', 'isAdmin', 'isBlockLeader', 'canProxyActualMeal'
+            'canGoPrev', 'canGoNext', 'isAdmin', 'isBlockLeader', 'canProxyActualMeal',
+            'rejectionBanner'
         ));
         return null;
     }

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -1536,6 +1536,10 @@ class TReservationInfoController extends AppController
     /**
      * 個人向け実食入力画面（職員が自分の実食を入力する）。
      *
+     * 表示週に差し戻し（i_approval_status=3）がある場合、
+     * 差し戻し理由と差し戻し者をバナー表示する。
+     *
+     * @throws \Cake\Http\Exception\UnauthorizedException ログインしていない場合
      * @return Response|null
      */
     public function myActualMeal(): ?Response
@@ -1662,7 +1666,7 @@ class TReservationInfoController extends AppController
         if ($latestRejection !== null) {
             $rejectionBanner = [
                 'reason'   => (string)($latestRejection->c_reject_reason ?: ''),
-                'approver' => (string)($latestRejection->approver->c_user_name ?? ''),
+                'approver' => (string)($latestRejection->approver?->c_user_name ?? ''),
                 'date'     => $latestRejection->dt_create?->format('Y-m-d H:i') ?? '',
             ];
         }

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
@@ -65,6 +65,33 @@ if (!empty($dates)) {
     </div>
 </div>
 
+<?php if (!empty($rejectionBanner)): ?>
+<div class="alert alert-danger alert-dismissible d-flex gap-3 align-items-start mx-3 mt-3 mb-0" id="rejection-banner" role="alert">
+    <span style="font-size:1.3rem;line-height:1;">⚠️</span>
+    <div class="flex-grow-1">
+        <div class="fw-bold mb-1">この週の実食申請が差し戻されました</div>
+        <div class="mb-1">
+            <?php if (!empty($rejectionBanner['reason'])): ?>
+                <span class="fw-semibold">差し戻し理由：</span><?= h($rejectionBanner['reason']) ?>
+            <?php else: ?>
+                差し戻し理由は入力されていません。内容を確認して再提出してください。
+            <?php endif; ?>
+        </div>
+        <?php if (!empty($rejectionBanner['approver']) || !empty($rejectionBanner['date'])): ?>
+        <div class="small text-muted">
+            <?php if (!empty($rejectionBanner['approver'])): ?>
+                差し戻し者：<?= h($rejectionBanner['approver']) ?>
+            <?php endif; ?>
+            <?php if (!empty($rejectionBanner['date'])): ?>
+                ／ <?= h($rejectionBanner['date']) ?>
+            <?php endif; ?>
+        </div>
+        <?php endif; ?>
+    </div>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+</div>
+<?php endif; ?>
+
 <div class="page-shell">
     <div class="layout-grid">
         <aside class="sidebar-stack">
@@ -142,33 +169,6 @@ if (!empty($dates)) {
         </aside>
 
         <main class="content-stack">
-            <?php if (!empty($rejectionBanner)): ?>
-            <div class="alert alert-danger alert-dismissible d-flex gap-3 align-items-start mb-0" id="rejection-banner" role="alert">
-                <span style="font-size:1.3rem;line-height:1;">⚠️</span>
-                <div class="flex-grow-1">
-                    <div class="fw-bold mb-1">この週の実食申請が差し戻されました</div>
-                    <div class="mb-1">
-                        <?php if (!empty($rejectionBanner['reason'])): ?>
-                            <span class="fw-semibold">差し戻し理由：</span><?= h($rejectionBanner['reason']) ?>
-                        <?php else: ?>
-                            差し戻し理由は入力されていません。内容を確認して再提出してください。
-                        <?php endif; ?>
-                    </div>
-                    <?php if (!empty($rejectionBanner['approver']) || !empty($rejectionBanner['date'])): ?>
-                    <div class="small text-muted">
-                        <?php if (!empty($rejectionBanner['approver'])): ?>
-                            差し戻し者：<?= h($rejectionBanner['approver']) ?>
-                        <?php endif; ?>
-                        <?php if (!empty($rejectionBanner['date'])): ?>
-                            ／ <?= h($rejectionBanner['date']) ?>
-                        <?php endif; ?>
-                    </div>
-                    <?php endif; ?>
-                </div>
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
-            </div>
-            <?php endif; ?>
-
             <div class="week-nav-bar">
                 <?php if ($canGoPrev): ?>
                     <a class="btn btn-outline-secondary btn-sm"

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/my_actual_meal.php
@@ -142,6 +142,33 @@ if (!empty($dates)) {
         </aside>
 
         <main class="content-stack">
+            <?php if (!empty($rejectionBanner)): ?>
+            <div class="alert alert-danger alert-dismissible d-flex gap-3 align-items-start mb-0" id="rejection-banner" role="alert">
+                <span style="font-size:1.3rem;line-height:1;">⚠️</span>
+                <div class="flex-grow-1">
+                    <div class="fw-bold mb-1">この週の実食申請が差し戻されました</div>
+                    <div class="mb-1">
+                        <?php if (!empty($rejectionBanner['reason'])): ?>
+                            <span class="fw-semibold">差し戻し理由：</span><?= h($rejectionBanner['reason']) ?>
+                        <?php else: ?>
+                            差し戻し理由は入力されていません。内容を確認して再提出してください。
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!empty($rejectionBanner['approver']) || !empty($rejectionBanner['date'])): ?>
+                    <div class="small text-muted">
+                        <?php if (!empty($rejectionBanner['approver'])): ?>
+                            差し戻し者：<?= h($rejectionBanner['approver']) ?>
+                        <?php endif; ?>
+                        <?php if (!empty($rejectionBanner['date'])): ?>
+                            ／ <?= h($rejectionBanner['date']) ?>
+                        <?php endif; ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+            </div>
+            <?php endif; ?>
+
             <div class="week-nav-bar">
                 <?php if ($canGoPrev): ?>
                     <a class="btn btn-outline-secondary btn-sm"
@@ -379,7 +406,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         overlay.classList.remove('active');
         updateUI();
-        if (ok > 0) showResult(`${ok} 件保存しました。`, true);
+        if (ok > 0) {
+            showResult(`${ok} 件保存しました。`, true);
+            const banner = document.getElementById('rejection-banner');
+            if (banner) {
+                bootstrap.Alert.getOrCreateInstance(banner).close();
+            }
+        }
         if (ng.length > 0) showResult(ng[0], false);
     }
 


### PR DESCRIPTION
## 概要

差し戻された実食申請の理由が伝わらず同じミスが繰り返される問題を解消します。
`/TReservationInfo/my-actual-meal` の週表示時に、その週の最新の差し戻し理由をページ上部に赤いアラートバナーで強調表示します。

## 変更内容

### `TReservationInfoController::myActualMeal()`
- `t_approval_log` から表示週・対象ユーザーの最新差し戻しレコード（`i_approval_status = 3`）を取得
- 差し戻し理由・差し戻し者・日時を `$rejectionBanner` としてテンプレートに渡す

### `my_actual_meal.php`
- メインコンテンツ上部に差し戻し理由バナーを追加（Bootstrap `alert-danger alert-dismissible`）
- 表示内容：差し戻し理由 / 差し戻し者名 / 差し戻し日時
- `c_reject_reason` が空の場合はデフォルトメッセージ「差し戻し理由は入力されていません。内容を確認して再提出してください。」を表示
- 「確定して保存」成功後にバナーを自動で閉じる（`bootstrap.Alert.close()`）
- ×ボタンで手動閉じも可能

## 表示イメージ

```
┌─────────────────────────────────────────────────────────┐
│ ⚠️ この週の実食申請が差し戻されました                        [×] │
│    差し戻し理由：朝食の入力漏れがあります                          │
│    差し戻し者：山田 太郎 ／ 2026-06-17 10:23                   │
└─────────────────────────────────────────────────────────┘
```

## テスト項目

- [ ] 差し戻しありの週に遷移すると理由バナーが表示されること
- [ ] 差し戻しなしの週ではバナーが表示されないこと
- [ ] `c_reject_reason` が空の場合にデフォルトメッセージが表示されること
- [ ] 「確定して保存」後にバナーが自動で消えること
- [ ] ×ボタンで手動閉じができること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 「差し戻し（最新）」の理由を週表示（日曜までの月曜〜日曜）の内容に合わせて、警告バナーとして表示するようになりました（理由・差し戻し者・日時）。
  * 保存が正常に完了した場合、表示中の差し戻しアラートを自動で閉じるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->