### PR TITLE
fix: #383 CLAUDE.md 規約違反を修正する（else 禁止・mixed 型禁止）

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -516,17 +516,12 @@ class ReservationWriteService
         }
         $targetUserLevel = (int)$targetUser->i_user_level;
 
-        if ($targetUserId !== $loginUserId) {
-            if ($isAdmin) {
-                // 管理者は全員を編集可能
-            } elseif (($isStaffUser || $isBlockLeader) && $targetUserLevel === 1) {
-                // 職員レベルユーザー・ブロック長は子供（i_user_level=1）のみ編集可能
-            } else {
-                return [
-                    'status' => 403,
-                    'body' => ['ok' => false, 'message' => '他ユーザーの予約を更新する権限がありません。'],
-                ];
-            }
+        $canEditOther = $isAdmin || (($isStaffUser || $isBlockLeader) && $targetUserLevel === 1);
+        if ($targetUserId !== $loginUserId && !$canEditOther) {
+            return [
+                'status' => 403,
+                'body' => ['ok' => false, 'message' => '他ユーザーの予約を更新する権限がありません。'],
+            ];
         }
 
         // 対象ユーザーが指定部屋に所属しているか確認（他部屋への不正書き込みを防ぐ）

--- a/src_web/kamaho-shokusu/src/Service/UserCreateService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserCreateService.php
@@ -46,7 +46,7 @@ class UserCreateService
      * @param string $ipAddress  操作元IPアドレス
      * @return bool
      */
-    public function saveWithRooms(mixed $entity, array $groupData, string $createdBy, int $actorId = 0, string $ipAddress = ''): bool
+    public function saveWithRooms(\Cake\ORM\Entity $entity, array $groupData, string $createdBy, int $actorId = 0, string $ipAddress = ''): bool
     {
         $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
         $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');


### PR DESCRIPTION
## 概要

CLAUDE.md で定めたコーディング規約に違反していた2箇所を修正します。

## 変更内容

### 1. `else` 禁止違反を修正（ReservationWriteService.php）

`processToggle` 内の空 if/elseif/else ブロックを `$canEditOther` フラグ + 早期リターンに置き換えました。

```php
// Before: 12行・空ブロック
if ($targetUserId !== $loginUserId) {
    if ($isAdmin) {
        // 管理者は全員を編集可能
    } elseif (...) {
        // 職員レベルユーザー・ブロック長は子供のみ編集可能
    } else {
        return ['status' => 403, ...];
    }
}

// After: 5行・明快
$canEditOther = $isAdmin || (($isStaffUser || $isBlockLeader) && $targetUserLevel === 1);
if ($targetUserId !== $loginUserId && !$canEditOther) {
    return ['status' => 403, ...];
}
```

### 2. `mixed` 型禁止違反を修正（UserCreateService.php）

```php
// Before
public function saveWithRooms(mixed $entity, ...): bool

// After
public function saveWithRooms(\Cake\ORM\Entity $entity, ...): bool
```

## 関連

- Closes #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **コード品質向上**
  * 内部の権限判定ロジックを最適化し、コード構造を改善しました
  * 型安全性を強化し、コード品質を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->