### PR TITLE
fix: #385 RoomUsageController の DI 違反を修正する

### DIFF
--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -16,6 +16,9 @@ use Authorization\Middleware\AuthorizationMiddleware;
 use Authorization\Policy\MapResolver;
 use Authorization\Policy\OrmResolver;
 use Authorization\Policy\ResolverCollection;
+use App\Controller\RoomUsageController;
+use App\Service\RoomUsageService;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Psr\Http\Message\ServerRequestInterface;
 use Cake\Core\Configure;
@@ -114,7 +117,10 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
 
     public function services(ContainerInterface $container): void
     {
-        // 必要に応じて DI サービスを登録
+        $container->add(RoomUsageService::class);
+        $container->add(RoomUsageController::class)
+            ->addArgument(RoomUsageService::class)
+            ->addArgument(ServerRequest::class);
     }
 
     public function getAuthorizationService(ServerRequestInterface $request): AuthorizationServiceInterface

--- a/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
+++ b/src_web/kamaho-shokusu/src/Controller/RoomUsageController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use App\Service\RoomUsageService;
 use Authorization\Exception\ForbiddenException;
 use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 
 /**
  * 部屋使用率コントローラー
@@ -14,12 +15,16 @@ use Cake\Http\Response;
  */
 class RoomUsageController extends AppController
 {
-    private RoomUsageService $roomUsageService;
+    public function __construct(
+        private RoomUsageService $roomUsageService,
+        ServerRequest $request
+    ) {
+        parent::__construct($request);
+    }
 
     public function initialize(): void
     {
         parent::initialize();
-        $this->roomUsageService = new RoomUsageService();
         $this->viewBuilder()->setLayout('default');
     }
 


### PR DESCRIPTION
## 概要

`RoomUsageController` が `new RoomUsageService()` で直接インスタンス化していた問題を修正し、CLAUDE.md のコンストラクタ DI 方針に準拠させます。

## 変更内容

### Application.php

`services()` に `RoomUsageService` と `RoomUsageController` を登録しました。CakePHP 5 の `ControllerFactory` はコンテナに登録されたコントローラーのみコンテナ経由で解決するため、両方の登録が必要です。

```php
public function services(ContainerInterface $container): void
{
    $container->add(RoomUsageService::class);
    $container->add(RoomUsageController::class)
        ->addArgument(RoomUsageService::class)
        ->addArgument(ServerRequest::class); // リクエストごとにコンテナへ追加済み
}
```

### RoomUsageController.php

`initialize()` の `new RoomUsageService()` を削除し、コンストラクタインジェクションに変更しました。

```php
public function __construct(
    private RoomUsageService $roomUsageService,
    ServerRequest $request
) {
    parent::__construct($request);
}
```

## 関連

- Closes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 依存性注入パターンをコンストラクタインジェクションに統一し、コードの保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->