### PR TITLE
feat: #389 ログインセッション保持時間を半日（12時間）に延長する

### DIFF
--- a/src_web/kamaho-shokusu/config/app.php
+++ b/src_web/kamaho-shokusu/config/app.php
@@ -420,6 +420,9 @@ return [
      */
     'Session' => [
         'defaults' => 'php',
-        'timeout' => 60, // 60分でセッションを失効させる
+        'timeout' => 720, // 720分（12時間）
+        'ini' => [
+            'session.gc_maxlifetime' => 43200, // 43200秒（12時間）: timeout と整合させる
+        ],
     ],
 ];


### PR DESCRIPTION
## 概要

セッションタイムアウトを 60分 → 720分（12時間）に延長します。

## 変更内容

`config/app.php`

```php
'Session' => [
    'defaults' => 'php',
    'timeout' => 720, // 720分（12時間）
    'ini' => [
        'session.gc_maxlifetime' => 43200, // 43200秒（12時間）
    ],
],
```

`timeout`（分）と `session.gc_maxlifetime`（秒）を同じ12時間に揃えています。
`ini` キーで上書きすることで `php.ini` を直接変更せずアプリ側で完結させています。

## 関連

- Closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **メンテナンス**
  * ユーザーセッションの有効期限を60分から12時間に延長しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->