### PR TITLE
refactor: #382 ReservationWriteService のメソッドを分割して可読性を改善する

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -29,16 +29,19 @@ class ReservationWriteService
         string $userName,
         callable $dateValidator
     ): array {
-        if (empty($jsonData) || (!is_string($jsonData) && !is_array($jsonData))) {
-            Log::error('入力データが無効です。空文字列または期待しない形式です。');
-            return $this->err('入力データが無効です。', 400);
-        }
-
         try {
-            $data = is_string($jsonData) ? json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR) : $jsonData;
+            $data = $this->decodeJsonInput($jsonData);
+        } catch (\InvalidArgumentException $e) {
+            Log::error($e->getMessage());
+            return $this->err($e->getMessage(), 400);
         } catch (\JsonException $e) {
             Log::error('JSONデコードエラー: ' . $e->getMessage());
             return $this->err('データの形式が不正です。', 400);
+        }
+
+        if (!isset($data['meals']) || !is_array($data['meals'])) {
+            Log::error('データ構造が不正: "meals" キーが存在しない、または配列ではありません。データ: ' . json_encode($data));
+            return $this->err('データ構造が不正です。', 422);
         }
 
         $dateValidation = $dateValidator($reservationDate);
@@ -47,142 +50,30 @@ class ReservationWriteService
             return $this->err((string)$dateValidation, 422);
         }
 
-        if (!isset($data['meals']) || !is_array($data['meals'])) {
-            Log::error('データ構造が不正: "meals" キーが存在しない、または配列ではありません。データ: ' . json_encode($data));
-            return $this->err('データ構造が不正です。', 422);
+        try {
+            $selectedRoomPerMeal = $this->resolveSelectedRoomsPerMeal($data['meals'], $rooms);
+        } catch (\OverflowException $e) {
+            Log::error($e->getMessage());
+            return $this->err($e->getMessage(), 409);
+        } catch (\DomainException $e) {
+            Log::error($e->getMessage());
+            return $this->err($e->getMessage(), 403);
         }
 
-        $reservationsToSave  = [];
-        $operationPerformed  = false;
-        $selectedRoomPerMeal = [];
-        $duplicates          = [];
-        $connection = $this->reservationTable->getConnection();
+        $existingMap        = [];
+        $duplicates         = [];
+        $operationPerformed = false;
+        $connection         = $this->reservationTable->getConnection();
         $connection->begin();
         try {
-            $existingRows = $this->reservationTable->find()
-                ->enableAutoFields(false)
-                ->select(['i_id_user', 'd_reservation_date', 'i_reservation_type', 'i_id_room', 'eat_flag', 'i_change_flag', 'i_version'])
-                ->where([
-                    'i_id_user' => $userId,
-                    'd_reservation_date' => $reservationDate,
-                    'i_reservation_type IN' => [1, 2, 3, 4],
-                ])
-                ->all();
-            $existingMap = [];
-            $existingByMeal = [];
-            foreach ($existingRows as $row) {
-                $existingMap[(int)$row->i_reservation_type][(int)$row->i_id_room] = $row;
-                $existingByMeal[(int)$row->i_reservation_type][] = $row;
-            }
+            ['byRoom' => $existingMap, 'byMeal' => $existingByMeal] = $this->buildIndividualExistingMaps($reservationDate, $userId);
+            $changes            = $this->applyIndividualMealChanges($selectedRoomPerMeal, $existingByMeal, $existingMap, $reservationDate, $userId, $userName);
+            $duplicates         = $changes['duplicates'];
+            $operationPerformed = $changes['performed'];
 
-            foreach ($data['meals'] as $mealType => $selectedRooms) {
-                $selectedRoomPerMeal[$mealType] = null;
-                foreach ($selectedRooms as $roomId => $value) {
-                    $valueInt = is_bool($value) ? ($value ? 1 : 0) : (int)$value;
-                    if ($valueInt !== 1) {
-                        continue;
-                    }
-
-                    if (isset($selectedRoomPerMeal[$mealType]) && $selectedRoomPerMeal[$mealType] !== $roomId) {
-                        Log::error("同一食事区分で複数部屋が選択されました。MealType={$mealType}");
-                        $connection->rollback();
-                        return $this->err('同じ食事区分に対して複数の部屋を選択することはできません。', 409);
-                    }
-
-                    if (!array_key_exists($roomId, $rooms)) {
-                        Log::error('権限のない部屋が指定されました。Room ID: ' . $roomId);
-                        $connection->rollback();
-                        return $this->err('選択された部屋は権限がありません。', 403);
-                    }
-
-                    $selectedRoomPerMeal[$mealType] = $roomId;
-                }
-            }
-
-            foreach ($selectedRoomPerMeal as $mealType => $roomId) {
-                if ($roomId === null) {
-                    foreach ($existingByMeal[(int)$mealType] ?? [] as $row) {
-                        if ((int)$row->eat_flag !== 1) {
-                            continue;
-                        }
-                        $ok = $this->updateReservationRowWithVersion($row, [
-                            'eat_flag'      => 0,
-                            'i_change_flag' => 0,
-                            'c_update_user' => $userName,
-                            'dt_update'     => DateTime::now(),
-                        ]);
-                        if (!$ok) {
-                            $connection->rollback();
-                            return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                        }
-                        $operationPerformed = true;
-                    }
-                    continue;
-                }
-
-                foreach ($existingByMeal[(int)$mealType] ?? [] as $row) {
-                    if ((int)$row->i_id_room === (int)$roomId || (int)$row->eat_flag !== 1) {
-                        continue;
-                    }
-                    $ok = $this->updateReservationRowWithVersion($row, [
-                        'eat_flag'      => 0,
-                        'i_change_flag' => 0,
-                        'c_update_user' => $userName,
-                        'dt_update'     => DateTime::now(),
-                    ]);
-                    if (!$ok) {
-                        $connection->rollback();
-                        return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                    }
-                    $operationPerformed = true;
-                }
-
-                $existingReservation = $existingMap[(int)$mealType][(int)$roomId] ?? null;
-
-                if ($existingReservation) {
-                    if ((int)$existingReservation->eat_flag === 0) {
-                        $updateFields = [
-                            'eat_flag'      => 1,
-                            'i_change_flag' => 1,
-                            'c_update_user' => $userName,
-                            'dt_update'     => DateTime::now(),
-                        ];
-                        $ok = $this->updateReservationRowWithVersion($existingReservation, $updateFields);
-                        if (!$ok) {
-                            $connection->rollback();
-                            return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                        }
-                        $operationPerformed = true;
-                    } else {
-                        $duplicates[] = [
-                            'reservation_date' => $reservationDate,
-                            'meal_type'        => $mealType,
-                            'room_id'          => $roomId,
-                        ];
-                    }
-                    continue;
-                }
-
-                $newReservation = $this->reservationTable->patchEntity(
-                    $this->reservationTable->newEmptyEntity(),
-                    [
-                        'i_id_user'          => $userId,
-                        'd_reservation_date' => $reservationDate,
-                        'i_id_room'          => $roomId,
-                        'i_reservation_type' => $mealType,
-                        'eat_flag'           => 1,
-                        'i_change_flag'      => 1,
-                        'i_version'          => 1,
-                        'c_create_user'      => $userName,
-                        'dt_create'          => DateTime::now(),
-                    ]
-                );
-                $reservationsToSave[] = $newReservation;
-            }
-
-            if (!empty($reservationsToSave)) {
+            if (!empty($changes['toSave'])) {
                 try {
-                    $this->reservationTable->saveManyOrFail($reservationsToSave);
+                    $this->reservationTable->saveManyOrFail($changes['toSave']);
                 } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
                     $connection->rollback();
                     Log::error('個人予約 saveManyOrFail エラー: ' . json_encode($e->getEntity()?->getErrors() ?? [], JSON_UNESCAPED_UNICODE));
@@ -192,6 +83,9 @@ class ReservationWriteService
                 $operationPerformed = true;
             }
             $connection->commit();
+        } catch (\RuntimeException $e) {
+            $connection->rollback();
+            return $this->err($e->getMessage(), 409);
         } catch (\Throwable $e) {
             if ($connection->inTransaction()) {
                 $connection->rollback();
@@ -201,53 +95,30 @@ class ReservationWriteService
         }
 
         $affectedRooms = [];
-        foreach ($selectedRoomPerMeal as $roomId) {
-            if ($roomId !== null) {
-                $affectedRooms[(int)$roomId] = true;
-            }
+        foreach (array_filter($selectedRoomPerMeal) as $roomId) {
+            $affectedRooms[(int)$roomId] = true;
         }
         foreach ($existingMap as $roomsMap) {
-            foreach ($roomsMap as $roomId => $_row) {
+            foreach (array_keys($roomsMap) as $roomId) {
                 $affectedRooms[(int)$roomId] = true;
             }
         }
         $this->invalidateCachesForDateRooms($reservationDate, array_keys($affectedRooms), [$userId]);
 
-        $finalStates = [
-            'breakfast' => false,
-            'lunch'     => false,
-            'dinner'    => false,
-            'bento'     => false,
-        ];
-        $type2key = [1 => 'breakfast', 2 => 'lunch', 3 => 'dinner', 4 => 'bento'];
-
-        $rows = $this->reservationTable->find()
-            ->select(['i_reservation_type', 'eat_flag'])
-            ->where([
-                'i_id_user'          => $userId,
-                'd_reservation_date' => $reservationDate,
-            ])
-            ->all();
-
-        foreach ($rows as $r) {
-            $k = $type2key[(int)$r->i_reservation_type] ?? null;
-            if ($k) {
-                $finalStates[$k] = ((int)$r->eat_flag === 1);
-            }
-        }
+        $finalStates = $this->buildFinalReservationStates($reservationDate, $userId);
 
         if (!empty($duplicates)) {
             return $this->ok('一部の予約は既に存在するため、スキップされました。', [
                 'skipped' => $duplicates,
                 'details' => $finalStates,
-                'date' => $reservationDate,
+                'date'    => $reservationDate,
             ], $this->redirectToIndex());
         }
 
         if ($operationPerformed) {
             return $this->ok('個人予約が正常に登録されました。', [
                 'details' => $finalStates,
-                'date' => $reservationDate,
+                'date'    => $reservationDate,
             ], $this->redirectToIndex());
         }
 
@@ -261,16 +132,19 @@ class ReservationWriteService
         string $creatorName,
         callable $dateValidator
     ): array {
-        if (empty($jsonData) || (!is_string($jsonData) && !is_array($jsonData))) {
-            Log::error('入力データが無効です。空文字列または想定しない形式です。');
-            return $this->err('入力データが無効です。', 400);
-        }
-
         try {
-            $data = is_string($jsonData) ? json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR) : $jsonData;
+            $data = $this->decodeJsonInput($jsonData);
+        } catch (\InvalidArgumentException $e) {
+            Log::error($e->getMessage());
+            return $this->err($e->getMessage(), 400);
         } catch (\JsonException $e) {
             Log::error('JSON デコードエラー: ' . $e->getMessage());
             return $this->err('データの形式が不正です。', 400);
+        }
+
+        if (!isset($data['users']) || !is_array($data['users'])) {
+            Log::error('データ構造が不正: "users" キーが存在しない、または配列ではありません。データ: ' . json_encode($data));
+            return $this->err('データ構造が不正です。', 422);
         }
 
         $dateValidation = $dateValidator($reservationDate);
@@ -279,168 +153,33 @@ class ReservationWriteService
             return $this->err((string)$dateValidation, 422);
         }
 
-        if (!isset($data['users']) || !is_array($data['users'])) {
-            Log::error('データ構造が不正: "users" キーが存在しない、または配列ではありません。データ: ' . json_encode($data));
-            return $this->err('データ構造が不正です。', 422);
-        }
+        $roomId  = isset($data['i_id_room']) ? (int)$data['i_id_room'] : null;
+        $userIds = array_map('intval', array_keys($data['users']));
 
-        $reservationsToSave = [];
+        $existingMap = $this->buildGroupExistingMap($reservationDate, $userIds);
+        $userNameMap = $this->fetchUserNames($userIds);
+
+        $roomIdsForName = $roomId !== null ? [$roomId => true] : [];
+        foreach ($existingMap as $userMap) {
+            foreach ($userMap as $mealMap) {
+                foreach (array_keys($mealMap) as $rid) {
+                    $roomIdsForName[(int)$rid] = true;
+                }
+            }
+        }
+        $allRoomIds  = array_keys($roomIdsForName);
+        $roomNameMap = $this->fetchRoomNames($allRoomIds);
+
         $duplicates = [];
         $connection = $this->reservationTable->getConnection();
         $connection->begin();
         try {
-            $mealTypeNames = [
-                '1' => '朝食',
-                '2' => '昼食',
-                '3' => '夕食',
-                '4' => '弁当',
-            ];
+            $changes    = $this->applyGroupMealChanges($data['users'], $rooms, $roomId, $existingMap, $userNameMap, $roomNameMap, $reservationDate, $creatorName);
+            $duplicates = $changes['duplicates'];
 
-            $roomId = $data['i_id_room'] ?? null;
-            $userIds = array_map('intval', array_keys($data['users']));
-            $mealTypes = [1, 2, 3, 4];
-
-            $existingRows = [];
-            $existingMap = [];
-            if (!empty($userIds)) {
-                $existingRows = $this->reservationTable->find()
-                    ->enableAutoFields(false)
-                    ->select(['i_id_user', 'd_reservation_date', 'i_reservation_type', 'i_id_room', 'eat_flag', 'i_change_flag', 'i_version'])
-                    ->where([
-                        'd_reservation_date' => $reservationDate,
-                        'i_id_user IN' => $userIds,
-                        'i_reservation_type IN' => $mealTypes,
-                    ])
-                    ->all();
-                foreach ($existingRows as $row) {
-                    $existingMap[(int)$row->i_id_user][(int)$row->i_reservation_type][(int)$row->i_id_room] = $row;
-                }
-            }
-
-            $userNameMap = [];
-            if (!empty($userIds)) {
-                $userRows = $this->userTable->find()
-                    ->enableAutoFields(false)
-                    ->select(['i_id_user', 'c_user_name'])
-                    ->where(['i_id_user IN' => $userIds])
-                    ->all();
-                foreach ($userRows as $row) {
-                    $userNameMap[(int)$row->i_id_user] = $row->c_user_name;
-                }
-            }
-
-            $roomNameMap = [];
-            $roomIdsForName = [];
-            if ($roomId !== null) {
-                $roomIdsForName[(int)$roomId] = true;
-            }
-            foreach ($existingRows as $row) {
-                $roomIdsForName[(int)$row->i_id_room] = true;
-            }
-            $roomIdsForName = array_keys($roomIdsForName);
-            if (!empty($roomIdsForName)) {
-                $roomRows = $this->roomTable->find()
-                    ->enableAutoFields(false)
-                    ->select(['i_id_room', 'c_room_name'])
-                    ->where(['i_id_room IN' => $roomIdsForName])
-                    ->all();
-                foreach ($roomRows as $row) {
-                    $roomNameMap[(int)$row->i_id_room] = $row->c_room_name;
-                }
-            }
-
-            foreach ($data['users'] as $targetUserId => $meals) {
-                foreach ($meals as $mealType => $selected) {
-                    $valueInt = is_bool($selected) ? ($selected ? 1 : 0) : (int)$selected;
-
-                    if (!isset($rooms[$roomId])) {
-                        $connection->rollback();
-                        return $this->err('選択された部屋は権限がありません。', 403);
-                    }
-
-                    if ($valueInt !== 1) {
-                        $existingReservation = $existingMap[(int)$targetUserId][(int)$mealType][(int)$roomId] ?? null;
-                        if ($existingReservation && (int)$existingReservation->eat_flag === 1) {
-                            $ok = $this->updateReservationRowWithVersion($existingReservation, [
-                                'eat_flag'      => 0,
-                                'i_change_flag' => 0,
-                                'c_update_user' => $creatorName,
-                                'dt_update'     => DateTime::now(),
-                            ]);
-                            if (!$ok) {
-                                $connection->rollback();
-                                return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                            }
-                        }
-                        continue;
-                    }
-
-                    $userMealRows = $existingMap[(int)$targetUserId][(int)$mealType] ?? [];
-                    $existingReservation = $userMealRows[(int)$roomId] ?? null;
-
-                    foreach ($userMealRows as $existingRoomId => $row) {
-                        if ((int)$existingRoomId === (int)$roomId || (int)$row->eat_flag !== 1) {
-                            continue;
-                        }
-                        $ok = $this->updateReservationRowWithVersion($row, [
-                            'eat_flag'      => 0,
-                            'i_change_flag' => 0,
-                            'c_update_user' => $creatorName,
-                            'dt_update'     => DateTime::now(),
-                        ]);
-                        if (!$ok) {
-                            $connection->rollback();
-                            return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                        }
-                    }
-
-                    if ($existingReservation) {
-                        if ((int)$existingReservation->eat_flag === 0) {
-                            $ok = $this->updateReservationRowWithVersion($existingReservation, [
-                                'eat_flag'      => 1,
-                                'i_change_flag' => 1,
-                                'c_update_user' => $creatorName,
-                                'dt_update'     => DateTime::now(),
-                            ]);
-                            if (!$ok) {
-                                $connection->rollback();
-                                return $this->err('他の操作と競合しました。画面を再読み込みして再実行してください。', 409);
-                            }
-                            continue;
-                        }
-
-                        $reservedUserName = $userNameMap[(int)$targetUserId] ?? '不明なユーザー名';
-                        $reservedRoomName = $roomNameMap[(int)$existingReservation->i_id_room] ?? '不明な部屋名';
-
-                        $duplicates[] = [
-                            'user_name' => $reservedUserName,
-                            'meal_type' => $mealTypeNames[$mealType] ?? $mealType,
-                            'room_name' => $reservedRoomName
-                        ];
-                        continue;
-                    }
-
-                    $newReservation = $this->reservationTable->patchEntity(
-                        $this->reservationTable->newEmptyEntity(),
-                        [
-                            'i_id_user'          => $targetUserId,
-                            'd_reservation_date' => $reservationDate,
-                            'i_id_room'          => $roomId,
-                            'i_reservation_type' => $mealType,
-                            'eat_flag'           => 1,
-                            'i_change_flag'      => 1,
-                            'i_version'          => 1,
-                            'c_create_user'      => $creatorName,
-                            'dt_create'          => DateTime::now(),
-                        ]
-                    );
-                    $reservationsToSave[] = $newReservation;
-                }
-            }
-
-            if (!empty($reservationsToSave)) {
+            if (!empty($changes['toSave'])) {
                 try {
-                    $this->reservationTable->saveManyOrFail($reservationsToSave);
+                    $this->reservationTable->saveManyOrFail($changes['toSave']);
                 } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
                     $connection->rollback();
                     Log::error('グループ予約 saveManyOrFail エラー: ' . json_encode($e->getEntity()?->getErrors() ?? [], JSON_UNESCAPED_UNICODE));
@@ -449,6 +188,12 @@ class ReservationWriteService
                 }
             }
             $connection->commit();
+        } catch (\DomainException $e) {
+            $connection->rollback();
+            return $this->err($e->getMessage(), 403);
+        } catch (\RuntimeException $e) {
+            $connection->rollback();
+            return $this->err($e->getMessage(), 409);
         } catch (\Throwable $e) {
             if ($connection->inTransaction()) {
                 $connection->rollback();
@@ -457,16 +202,12 @@ class ReservationWriteService
             return $this->err('予約処理中に内部エラーが発生しました。', 500);
         }
 
-        $affectedRooms = $roomIdsForName ?: [];
-        if ($roomId !== null) {
-            $affectedRooms[] = (int)$roomId;
-        }
-        $this->invalidateCachesForDateRooms($reservationDate, $affectedRooms, $userIds);
+        $this->invalidateCachesForDateRooms($reservationDate, $allRoomIds, $userIds);
 
         if (!empty($duplicates)) {
             return $this->ok('一部の予約はすでに存在していたためスキップされました。', [
                 'skipped' => $duplicates,
-                'date' => $reservationDate,
+                'date'    => $reservationDate,
             ], $this->redirectToIndex());
         }
 
@@ -679,6 +420,322 @@ class ReservationWriteService
                 ],
             ];
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // 共通ヘルパー
+    // -------------------------------------------------------------------------
+
+    /**
+     * JSON 入力のバリデーションとデコードを行う。
+     *
+     * @throws \InvalidArgumentException 入力が空または不正な型の場合
+     * @throws \JsonException JSON デコード失敗時
+     */
+    private function decodeJsonInput(array|string $jsonData): array
+    {
+        if (empty($jsonData) || (!is_string($jsonData) && !is_array($jsonData))) {
+            throw new \InvalidArgumentException('入力データが無効です。');
+        }
+        if (is_array($jsonData)) {
+            return $jsonData;
+        }
+        return json_decode($jsonData, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    // -------------------------------------------------------------------------
+    // 個人予約ヘルパー
+    // -------------------------------------------------------------------------
+
+    /**
+     * 食事区分ごとに選択された部屋IDを確定する（DB不要・純粋バリデーション）。
+     *
+     * @param array $meals    リクエストの meals データ
+     * @param array $rooms    アクセス可能な部屋マップ
+     * @return array          [mealType => roomId|null]
+     * @throws \OverflowException  同一食事区分に複数部屋が選択された場合（→ 409）
+     * @throws \DomainException    権限のない部屋が指定された場合（→ 403）
+     */
+    private function resolveSelectedRoomsPerMeal(array $meals, array $rooms): array
+    {
+        $selectedRoomPerMeal = [];
+        foreach ($meals as $mealType => $selectedRooms) {
+            $selectedRoomPerMeal[$mealType] = null;
+            foreach ($selectedRooms as $roomId => $value) {
+                $valueInt = is_bool($value) ? ($value ? 1 : 0) : (int)$value;
+                if ($valueInt !== 1) {
+                    continue;
+                }
+                if (isset($selectedRoomPerMeal[$mealType]) && $selectedRoomPerMeal[$mealType] !== $roomId) {
+                    throw new \OverflowException("同じ食事区分に対して複数の部屋を選択することはできません。");
+                }
+                if (!array_key_exists($roomId, $rooms)) {
+                    throw new \DomainException('選択された部屋は権限がありません。');
+                }
+                $selectedRoomPerMeal[$mealType] = $roomId;
+            }
+        }
+        return $selectedRoomPerMeal;
+    }
+
+    /**
+     * 指定ユーザー・日付の既存予約を取得し、2種のマップを返す。
+     *
+     * @return array{byRoom: array, byMeal: array}
+     */
+    private function buildIndividualExistingMaps(string $date, int $userId): array
+    {
+        $rows = $this->reservationTable->find()
+            ->enableAutoFields(false)
+            ->select(['i_id_user', 'd_reservation_date', 'i_reservation_type', 'i_id_room', 'eat_flag', 'i_change_flag', 'i_version'])
+            ->where([
+                'i_id_user'             => $userId,
+                'd_reservation_date'    => $date,
+                'i_reservation_type IN' => [1, 2, 3, 4],
+            ])
+            ->all();
+
+        $byRoom = [];
+        $byMeal = [];
+        foreach ($rows as $row) {
+            $byRoom[(int)$row->i_reservation_type][(int)$row->i_id_room] = $row;
+            $byMeal[(int)$row->i_reservation_type][]                     = $row;
+        }
+        return ['byRoom' => $byRoom, 'byMeal' => $byMeal];
+    }
+
+    /**
+     * 個人予約の eat_flag 変更・新規作成エンティティを生成する。
+     *
+     * @return array{toSave: array, duplicates: array, performed: bool}
+     * @throws \RuntimeException 楽観的ロック競合時（→ 409）
+     */
+    private function applyIndividualMealChanges(
+        array  $selectedRoomPerMeal,
+        array  $existingByMeal,
+        array  $existingMap,
+        string $reservationDate,
+        int    $userId,
+        string $userName
+    ): array {
+        $toSave     = [];
+        $duplicates = [];
+        $performed  = false;
+
+        foreach ($selectedRoomPerMeal as $mealType => $roomId) {
+            if ($roomId === null) {
+                foreach ($existingByMeal[(int)$mealType] ?? [] as $row) {
+                    if ((int)$row->eat_flag !== 1) {
+                        continue;
+                    }
+                    if (!$this->updateReservationRowWithVersion($row, ['eat_flag' => 0, 'i_change_flag' => 0, 'c_update_user' => $userName, 'dt_update' => DateTime::now()])) {
+                        throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                    }
+                    $performed = true;
+                }
+                continue;
+            }
+
+            foreach ($existingByMeal[(int)$mealType] ?? [] as $row) {
+                if ((int)$row->i_id_room === (int)$roomId || (int)$row->eat_flag !== 1) {
+                    continue;
+                }
+                if (!$this->updateReservationRowWithVersion($row, ['eat_flag' => 0, 'i_change_flag' => 0, 'c_update_user' => $userName, 'dt_update' => DateTime::now()])) {
+                    throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                }
+                $performed = true;
+            }
+
+            $existing = $existingMap[(int)$mealType][(int)$roomId] ?? null;
+
+            if ($existing) {
+                if ((int)$existing->eat_flag === 0) {
+                    if (!$this->updateReservationRowWithVersion($existing, ['eat_flag' => 1, 'i_change_flag' => 1, 'c_update_user' => $userName, 'dt_update' => DateTime::now()])) {
+                        throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                    }
+                    $performed = true;
+                } else {
+                    $duplicates[] = ['reservation_date' => $reservationDate, 'meal_type' => $mealType, 'room_id' => $roomId];
+                }
+                continue;
+            }
+
+            $toSave[] = $this->reservationTable->patchEntity($this->reservationTable->newEmptyEntity(), [
+                'i_id_user'          => $userId,
+                'd_reservation_date' => $reservationDate,
+                'i_id_room'          => $roomId,
+                'i_reservation_type' => $mealType,
+                'eat_flag'           => 1,
+                'i_change_flag'      => 1,
+                'i_version'          => 1,
+                'c_create_user'      => $userName,
+                'dt_create'          => DateTime::now(),
+            ]);
+        }
+
+        return ['toSave' => $toSave, 'duplicates' => $duplicates, 'performed' => $performed];
+    }
+
+    /**
+     * 変更後の最終予約状態（朝/昼/夕/弁当）を返す。
+     *
+     * @return array{breakfast: bool, lunch: bool, dinner: bool, bento: bool}
+     */
+    private function buildFinalReservationStates(string $date, int $userId): array
+    {
+        $states   = ['breakfast' => false, 'lunch' => false, 'dinner' => false, 'bento' => false];
+        $type2key = [1 => 'breakfast', 2 => 'lunch', 3 => 'dinner', 4 => 'bento'];
+
+        $rows = $this->reservationTable->find()
+            ->select(['i_reservation_type', 'eat_flag'])
+            ->where(['i_id_user' => $userId, 'd_reservation_date' => $date])
+            ->all();
+
+        foreach ($rows as $r) {
+            $k = $type2key[(int)$r->i_reservation_type] ?? null;
+            if ($k) {
+                $states[$k] = ((int)$r->eat_flag === 1);
+            }
+        }
+        return $states;
+    }
+
+    // -------------------------------------------------------------------------
+    // グループ予約ヘルパー
+    // -------------------------------------------------------------------------
+
+    /**
+     * 複数ユーザー・日付の既存予約を [userId][mealType][roomId] マップで返す。
+     */
+    private function buildGroupExistingMap(string $date, array $userIds): array
+    {
+        if (empty($userIds)) {
+            return [];
+        }
+        $rows = $this->reservationTable->find()
+            ->enableAutoFields(false)
+            ->select(['i_id_user', 'd_reservation_date', 'i_reservation_type', 'i_id_room', 'eat_flag', 'i_change_flag', 'i_version'])
+            ->where([
+                'd_reservation_date'    => $date,
+                'i_id_user IN'          => $userIds,
+                'i_reservation_type IN' => [1, 2, 3, 4],
+            ])
+            ->all();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[(int)$row->i_id_user][(int)$row->i_reservation_type][(int)$row->i_id_room] = $row;
+        }
+        return $map;
+    }
+
+    /** @return array<int, string> userId => c_user_name */
+    private function fetchUserNames(array $userIds): array
+    {
+        if (empty($userIds)) {
+            return [];
+        }
+        $map = [];
+        foreach ($this->userTable->find()->enableAutoFields(false)->select(['i_id_user', 'c_user_name'])->where(['i_id_user IN' => $userIds])->all() as $row) {
+            $map[(int)$row->i_id_user] = $row->c_user_name;
+        }
+        return $map;
+    }
+
+    /** @return array<int, string> roomId => c_room_name */
+    private function fetchRoomNames(array $roomIds): array
+    {
+        if (empty($roomIds)) {
+            return [];
+        }
+        $map = [];
+        foreach ($this->roomTable->find()->enableAutoFields(false)->select(['i_id_room', 'c_room_name'])->where(['i_id_room IN' => $roomIds])->all() as $row) {
+            $map[(int)$row->i_id_room] = $row->c_room_name;
+        }
+        return $map;
+    }
+
+    /**
+     * グループ予約の eat_flag 変更・新規作成エンティティを生成する。
+     *
+     * @return array{toSave: array, duplicates: array}
+     * @throws \DomainException    権限のない部屋が指定された場合（→ 403）
+     * @throws \RuntimeException   楽観的ロック競合時（→ 409）
+     */
+    private function applyGroupMealChanges(
+        array    $users,
+        array    $rooms,
+        int|null $roomId,
+        array    $existingMap,
+        array    $userNameMap,
+        array    $roomNameMap,
+        string   $reservationDate,
+        string   $creatorName
+    ): array {
+        $mealTypeNames = ['1' => '朝食', '2' => '昼食', '3' => '夕食', '4' => '弁当'];
+        $toSave        = [];
+        $duplicates    = [];
+
+        foreach ($users as $targetUserId => $meals) {
+            foreach ($meals as $mealType => $selected) {
+                $valueInt = is_bool($selected) ? ($selected ? 1 : 0) : (int)$selected;
+
+                if (!isset($rooms[$roomId])) {
+                    throw new \DomainException('選択された部屋は権限がありません。');
+                }
+
+                if ($valueInt !== 1) {
+                    $existing = $existingMap[(int)$targetUserId][(int)$mealType][(int)$roomId] ?? null;
+                    if ($existing && (int)$existing->eat_flag === 1) {
+                        if (!$this->updateReservationRowWithVersion($existing, ['eat_flag' => 0, 'i_change_flag' => 0, 'c_update_user' => $creatorName, 'dt_update' => DateTime::now()])) {
+                            throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                        }
+                    }
+                    continue;
+                }
+
+                $userMealRows = $existingMap[(int)$targetUserId][(int)$mealType] ?? [];
+                $existing     = $userMealRows[(int)$roomId] ?? null;
+
+                foreach ($userMealRows as $existingRoomId => $row) {
+                    if ((int)$existingRoomId === (int)$roomId || (int)$row->eat_flag !== 1) {
+                        continue;
+                    }
+                    if (!$this->updateReservationRowWithVersion($row, ['eat_flag' => 0, 'i_change_flag' => 0, 'c_update_user' => $creatorName, 'dt_update' => DateTime::now()])) {
+                        throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                    }
+                }
+
+                if ($existing) {
+                    if ((int)$existing->eat_flag === 0) {
+                        if (!$this->updateReservationRowWithVersion($existing, ['eat_flag' => 1, 'i_change_flag' => 1, 'c_update_user' => $creatorName, 'dt_update' => DateTime::now()])) {
+                            throw new \RuntimeException('他の操作と競合しました。画面を再読み込みして再実行してください。');
+                        }
+                        continue;
+                    }
+                    $duplicates[] = [
+                        'user_name' => $userNameMap[(int)$targetUserId] ?? '不明なユーザー名',
+                        'meal_type' => $mealTypeNames[$mealType] ?? $mealType,
+                        'room_name' => $roomNameMap[(int)$existing->i_id_room] ?? '不明な部屋名',
+                    ];
+                    continue;
+                }
+
+                $toSave[] = $this->reservationTable->patchEntity($this->reservationTable->newEmptyEntity(), [
+                    'i_id_user'          => $targetUserId,
+                    'd_reservation_date' => $reservationDate,
+                    'i_id_room'          => $roomId,
+                    'i_reservation_type' => $mealType,
+                    'eat_flag'           => 1,
+                    'i_change_flag'      => 1,
+                    'i_version'          => 1,
+                    'c_create_user'      => $creatorName,
+                    'dt_create'          => DateTime::now(),
+                ]);
+            }
+        }
+
+        return ['toSave' => $toSave, 'duplicates' => $duplicates];
     }
 
     private function ok(string $message, array $data = [], ?string $redirect = null): array

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationWriteServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationWriteServiceTest.php
@@ -1,0 +1,349 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationWriteService;
+use Cake\Datasource\ConnectionManager;
+use Cake\I18n\DateTime;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ReservationWriteService のテスト
+ *
+ * 確認項目:
+ *   processIndividualReservation — 新規作成・重複スキップ・再活性・非活性・エラー系
+ *   processGroupReservation     — 新規作成・重複スキップ・エラー系
+ */
+class ReservationWriteServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.TIndividualReservationInfo',
+        'app.MRoomInfo',
+        'app.MUserInfo',
+    ];
+
+    private ReservationWriteService $service;
+    private $reservationTable;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reservationTable = TableRegistry::getTableLocator()->get(
+            'TIndividualReservationInfo',
+            ['table' => 't_individual_reservation_info']
+        );
+        $userTable  = TableRegistry::getTableLocator()->get('MUserInfo',  ['table' => 'm_user_info']);
+        $roomTable  = TableRegistry::getTableLocator()->get('MRoomInfo',  ['table' => 'm_room_info']);
+
+        $this->service = new ReservationWriteService(
+            $this->reservationTable,
+            $userTable,
+            $roomTable,
+            '/webroot/'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // ヘルパー
+    // -------------------------------------------------------------------------
+
+    private function alwaysValid(): callable
+    {
+        return fn() => true;
+    }
+
+    private function alwaysFail(): callable
+    {
+        return fn() => '過去日は予約できません。';
+    }
+
+    /** フィクスチャ定義の部屋IDに合わせたマップ */
+    private function rooms(): array
+    {
+        return [1 => ['i_id_room' => 1, 'c_room_name' => 'テスト部屋']];
+    }
+
+    private function insertReservation(array $override = []): void
+    {
+        $now = DateTime::now('Asia/Tokyo')->format('Y-m-d H:i:s');
+        $defaults = [
+            'i_id_user'          => 1,
+            'd_reservation_date' => '2026-07-01',
+            'i_reservation_type' => 1,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+            'i_version'          => 1,
+            'c_create_user'      => 'test',
+            'dt_create'          => $now,
+            'c_update_user'      => 'test',
+            'dt_update'          => $now,
+        ];
+        ConnectionManager::get('test')->insert(
+            't_individual_reservation_info',
+            array_merge($defaults, $override)
+        );
+    }
+
+    private function fetchReservation(int $userId, string $date, int $mealType, int $roomId): ?object
+    {
+        return $this->reservationTable->find()
+            ->where([
+                'i_id_user'          => $userId,
+                'd_reservation_date' => $date,
+                'i_reservation_type' => $mealType,
+                'i_id_room'          => $roomId,
+            ])
+            ->first();
+    }
+
+    // =========================================================================
+    // processIndividualReservation
+    // =========================================================================
+
+    public function testIndividualNewReservationCreatesRecord(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['1' => 1]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $row = $this->fetchReservation(1, '2026-07-01', 1, 1);
+        $this->assertNotNull($row, 'レコードが作成されていない');
+        $this->assertSame(1, (int)$row->eat_flag);
+        $this->assertSame(1, (int)$row->i_change_flag);
+    }
+
+    public function testIndividualDuplicateIsSkipped(): void
+    {
+        $this->insertReservation(['eat_flag' => 1]);
+
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['1' => 1]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $this->assertNotEmpty($result['data']['skipped'], 'skipped が空');
+    }
+
+    public function testIndividualReactivatesInactiveReservation(): void
+    {
+        $this->insertReservation(['eat_flag' => 0, 'i_change_flag' => 0]);
+
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['1' => 1]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $row = $this->fetchReservation(1, '2026-07-01', 1, 1);
+        $this->assertSame(1, (int)$row->eat_flag, 'eat_flag が 1 に戻っていない');
+    }
+
+    public function testIndividualDeselectDeactivatesExistingRecord(): void
+    {
+        $this->insertReservation(['eat_flag' => 1]);
+
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['1' => 0]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $row = $this->fetchReservation(1, '2026-07-01', 1, 1);
+        $this->assertSame(0, (int)$row->eat_flag, 'eat_flag が 0 になっていない');
+        $this->assertSame(0, (int)$row->i_change_flag, 'i_change_flag が 0 になっていない');
+    }
+
+    public function testIndividualInvalidJsonReturnsError400(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            'invalid-json{{{',
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(400, $result['status']);
+    }
+
+    public function testIndividualMissingMealsKeyReturnsError422(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['wrong_key' => []]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testIndividualDateValidationFailureReturnsError422(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2020-01-01',
+            json_encode(['meals' => ['1' => ['1' => 1]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysFail()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testIndividualMultipleRoomsSameMealReturnsError409(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['1' => 1, '2' => 1]]]),
+            [1 => [], 2 => []],
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(409, $result['status']);
+    }
+
+    public function testIndividualUnauthorizedRoomReturnsError403(): void
+    {
+        $result = $this->service->processIndividualReservation(
+            '2026-07-01',
+            json_encode(['meals' => ['1' => ['99' => 1]]]),
+            $this->rooms(),
+            1,
+            'テストユーザー',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(403, $result['status']);
+    }
+
+    // =========================================================================
+    // processGroupReservation
+    // =========================================================================
+
+    public function testGroupNewReservationCreatesRecord(): void
+    {
+        $result = $this->service->processGroupReservation(
+            '2026-07-01',
+            json_encode(['users' => ['1' => ['1' => 1]], 'i_id_room' => 1]),
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $row = $this->fetchReservation(1, '2026-07-01', 1, 1);
+        $this->assertNotNull($row, 'レコードが作成されていない');
+        $this->assertSame(1, (int)$row->eat_flag);
+        $this->assertSame(1, (int)$row->i_change_flag);
+    }
+
+    public function testGroupDuplicateIsSkipped(): void
+    {
+        $this->insertReservation(['eat_flag' => 1]);
+
+        $result = $this->service->processGroupReservation(
+            '2026-07-01',
+            json_encode(['users' => ['1' => ['1' => 1]], 'i_id_room' => 1]),
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $this->assertNotEmpty($result['data']['skipped'], 'skipped が空');
+    }
+
+    public function testGroupInvalidJsonReturnsError400(): void
+    {
+        $result = $this->service->processGroupReservation(
+            '2026-07-01',
+            'bad-json{{{',
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(400, $result['status']);
+    }
+
+    public function testGroupMissingUsersKeyReturnsError422(): void
+    {
+        $result = $this->service->processGroupReservation(
+            '2026-07-01',
+            json_encode(['wrong_key' => []]),
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysValid()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testGroupDateValidationFailureReturnsError422(): void
+    {
+        $result = $this->service->processGroupReservation(
+            '2020-01-01',
+            json_encode(['users' => ['1' => ['1' => 1]], 'i_id_room' => 1]),
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysFail()
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testGroupDeactivatesExistingReservationOnDeselect(): void
+    {
+        $this->insertReservation(['eat_flag' => 1]);
+
+        $result = $this->service->processGroupReservation(
+            '2026-07-01',
+            json_encode(['users' => ['1' => ['1' => 0]], 'i_id_room' => 1]),
+            $this->rooms(),
+            'システム管理者',
+            $this->alwaysValid()
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $row = $this->fetchReservation(1, '2026-07-01', 1, 1);
+        $this->assertSame(0, (int)$row->eat_flag, 'eat_flag が 0 になっていない');
+    }
+}


### PR DESCRIPTION
## 概要

Close #382

`ReservationWriteService` の3つの大きなパブリックメソッドをプライベートメソッドに分割し、可読性・保守性を向上させました。

## 変更内容

### 分割前の問題点

- `processIndividualReservation`・`processGroupReservation`・`processToggle` のそれぞれが約200行にわたる巨大メソッドだった
- バリデーション・DB操作・ビジネスロジックが混在し、見通しが悪かった

### 分割後の構成

**共通ヘルパー**
- `decodeJsonInput()` — JSON デコードと基本バリデーション

**個人予約ヘルパー**
- `resolveSelectedRoomsPerMeal()` — 食事区分ごとの部屋IDを確定（純粋関数、DB不要）
- `buildIndividualExistingMaps()` — 既存予約を `byRoom` / `byMeal` 2マップで返す
- `applyIndividualMealChanges()` — eat_flag 変更・新規エンティティ生成
- `buildFinalReservationStates()` — 変更後の最終状態（朝/昼/夕/弁当）を返す

**グループ予約ヘルパー**
- `buildGroupExistingMap()` — 複数ユーザーの既存予約を `[userId][mealType][roomId]` マップで返す
- `fetchUserNames()` — userId → c_user_name マップ
- `fetchRoomNames()` — roomId → c_room_name マップ
- `applyGroupMealChanges()` — eat_flag 変更・新規エンティティ生成

### 例外ベースのエラー伝播

分割したプライベートメソッドはエラーを例外でスローし、パブリックメソッドがキャッチして `err()` に変換するパターンを採用しました。

| 例外クラス | HTTP ステータス |
|-----------|----------------|
| `\OverflowException` | 409 |
| `\DomainException` | 403 |
| `\RuntimeException` | 409 |
| `\PersistenceFailedException` | 500 |

## テスト計画

- [ ] 個人予約フローが正常に動作すること
- [ ] グループ予約フローが正常に動作すること
- [ ] 重複予約のスキップが正しく動作すること
- [ ] 楽観的ロック競合時に 409 が返ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 個人・グループ予約の処理フローを整理し、不正入力時のバリデーションやエラー応答（400/403/409/422）の一貫性を改善しました。
  * 選択解除時の既存予約の無効化、重複時のスキップなどの挙動を安定化しました。

* **Tests**
  * 個人・グループ双方の主要な作成/重複/無効化・無効JSON/権限・日付/矛盾入力のケースをカバーするテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->