### PR TITLE
fix: #392 個人予約モーダルの昼食・弁当排他制御を全部屋またぎに修正する

### DIFF
--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -77,16 +77,22 @@
             }
         }
 
-        // 個人テーブルのヘッダ「全選択」チェックと行内昼⇔弁当の排他
+        // 個人テーブルの昼⇔弁当の排他（全部屋またぎ）
         function bindRoomTableGuards(){
             if (!roomCheckboxesTbody) return;
-            roomCheckboxesTbody.querySelectorAll('tr').forEach(tr => {
-                const lunch = tr.querySelector('input[name^="meals[2]"]');
-                const bento = tr.querySelector('input[name^="meals[4]"]');
-                if (lunch && bento) {
-                    lunch.addEventListener('change', () => { if (lunch.checked) bento.checked = false; });
-                    bento.addEventListener('change', () => { if (bento.checked) lunch.checked = false; });
-                }
+            roomCheckboxesTbody.querySelectorAll('input[name^="meals[2]"]').forEach(lunch => {
+                lunch.addEventListener('change', () => {
+                    if (lunch.checked) {
+                        roomCheckboxesTbody.querySelectorAll('input[name^="meals[4]"]').forEach(b => { b.checked = false; });
+                    }
+                });
+            });
+            roomCheckboxesTbody.querySelectorAll('input[name^="meals[4]"]').forEach(bento => {
+                bento.addEventListener('change', () => {
+                    if (bento.checked) {
+                        roomCheckboxesTbody.querySelectorAll('input[name^="meals[2]"]').forEach(l => { l.checked = false; });
+                    }
+                });
             });
         }
 

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -3024,38 +3024,40 @@ function isWithin14(dateStr){
         function applyLunchBentoExclusion(scope){
             var root = scope || document;
 
-            // 個人予約
-            var lunchCbs = Array.from(root.querySelectorAll('input[type="checkbox"][name*="lunch"]'));
-            var bentoCbs = Array.from(root.querySelectorAll('input[type="checkbox"][name*="bento"]'));
-            lunchCbs.forEach(function(lunchCb, idx){
-                var bentoCb = bentoCbs[idx];
-                if (!bentoCb) return;
-                if (lunchCb.dataset._paired || bentoCb.dataset._paired) return;
-                
-                // 初期状態での排他適用
-                if (lunchCb.checked && bentoCb.checked) {
-                    bentoCb.checked = false;
+            // 個人予約（add フォーム）: meals[2][roomId] = 昼食, meals[4][roomId] = 弁当
+            // 全部屋またぎで排他制御する（同じ部屋内だけでなく異なる部屋間も排他）
+            var addLunchCbs = Array.from(root.querySelectorAll('input[type="checkbox"][name^="meals[2]"]'));
+            var addBentoCbs = Array.from(root.querySelectorAll('input[type="checkbox"][name^="meals[4]"]'));
+            if (addLunchCbs.length > 0 || addBentoCbs.length > 0) {
+                addLunchCbs.forEach(function(lunchCb) {
+                    if (lunchCb.dataset._mealPaired) return;
+                    lunchCb.addEventListener('change', function() {
+                        if (lunchCb.checked && !lunchCb.disabled) {
+                            root.querySelectorAll('input[type="checkbox"][name^="meals[4]"]').forEach(function(b) {
+                                if (!b.disabled) { b.checked = false; }
+                            });
+                        }
+                    });
+                    lunchCb.dataset._mealPaired = '1';
+                });
+                addBentoCbs.forEach(function(bentoCb) {
+                    if (bentoCb.dataset._mealPaired) return;
+                    bentoCb.addEventListener('change', function() {
+                        if (bentoCb.checked && !bentoCb.disabled) {
+                            root.querySelectorAll('input[type="checkbox"][name^="meals[2]"]').forEach(function(l) {
+                                if (!l.disabled) { l.checked = false; }
+                            });
+                        }
+                    });
+                    bentoCb.dataset._mealPaired = '1';
+                });
+                // 初期状態で両方チェックされていれば弁当を優先して解除
+                var anyLunch = addLunchCbs.some(function(cb) { return cb.checked; });
+                var anyBento = addBentoCbs.some(function(cb) { return cb.checked; });
+                if (anyLunch && anyBento) {
+                    addBentoCbs.forEach(function(cb) { cb.checked = false; });
                 }
-                
-                lunchCb.addEventListener('change', function(){
-                    if (lunchCb.checked && !lunchCb.disabled) {
-                        if (bentoCb && !bentoCb.disabled) {
-                            bentoCb.checked = false;
-                            bentoCb.dispatchEvent(new Event('change'));
-                        }
-                    }
-                });
-                bentoCb.addEventListener('change', function(){
-                    if (bentoCb.checked && !bentoCb.disabled) {
-                        if (lunchCb && !lunchCb.disabled) {
-                            lunchCb.checked = false;
-                            lunchCb.dispatchEvent(new Event('change'));
-                        }
-                    }
-                });
-                lunchCb.dataset._paired = '1';
-                bentoCb.dataset._paired = '1';
-            });
+            }
 
             // 集団予約（利用者別）- users[userId][2] と users[userId][4]
             var groupRows = root.querySelectorAll('#user-checkboxes tr, tbody tr');

--- a/src_web/kamaho-shokusu/webroot/js/reservation.js
+++ b/src_web/kamaho-shokusu/webroot/js/reservation.js
@@ -65,17 +65,39 @@
 
         function validateForm(reservationType){
             if (reservationType === 2) {
-                if (userSelectionTable && userSelectionTable.querySelector('tbody input[type="checkbox"]:checked')) {
-                    return true;
+                const hasChecked  = userSelectionTable?.querySelector('tbody input[type="checkbox"]:checked');
+                const hasExisting = userSelectionTable?.querySelector('tbody input[type="checkbox"][data-existing="1"]');
+                if (!hasChecked && !hasExisting) {
+                    return '集団予約は利用者行でいずれかの食事にチェックが必要です。';
                 }
-                if (userSelectionTable && userSelectionTable.querySelector('tbody input[type="checkbox"][data-existing="1"]')) {
-                    return true;
-                }
-                return false;
+            }
+            const lunchChecked = roomCheckboxes && roomCheckboxes.querySelector('input[name^="meals[2]"]:checked');
+            const bentoChecked = roomCheckboxes && roomCheckboxes.querySelector('input[name^="meals[4]"]:checked');
+            if (lunchChecked && bentoChecked) {
+                return '昼食と弁当は同時に予約できません。どちらか一方を選択してください。';
             }
             return true;
         }
         window.validateForm = validateForm;
+
+        function bindLunchBentoExclusion() {
+            if (!roomCheckboxes) return;
+            roomCheckboxes.querySelectorAll('input[name^="meals[2]"]').forEach(function(lunch) {
+                lunch.addEventListener('change', function() {
+                    if (this.checked) {
+                        roomCheckboxes.querySelectorAll('input[name^="meals[4]"]').forEach(function(b) { b.checked = false; });
+                    }
+                });
+            });
+            roomCheckboxes.querySelectorAll('input[name^="meals[4]"]').forEach(function(bento) {
+                bento.addEventListener('change', function() {
+                    if (this.checked) {
+                        roomCheckboxes.querySelectorAll('input[name^="meals[2]"]').forEach(function(l) { l.checked = false; });
+                    }
+                });
+            });
+        }
+        window.bindLunchBentoExclusion = bindLunchBentoExclusion;
 
         window.toggleAllRooms = function(mealType, checked){
             if (!roomCheckboxes) return;
@@ -130,10 +152,10 @@
 
             form.addEventListener('submit', function(event){
                 event.preventDefault();
-                const reservationType   = parseInt(reservationTypeSelect?.value, 10);
-                const validationSuccess = validateForm(reservationType);
-                if (!validationSuccess) {
-                    toast('エラー: 必須項目を確認してください。（集団予約は利用者行でいずれかの食事にチェックが必要です）', 'danger');
+                const reservationType  = parseInt(reservationTypeSelect?.value, 10);
+                const validationResult = validateForm(reservationType);
+                if (validationResult !== true) {
+                    toast(typeof validationResult === 'string' ? validationResult : '必須項目を確認してください。', 'danger');
                     return;
                 }
                 const formData = new FormData(form);
@@ -182,6 +204,8 @@
                     .finally(hideLoading);
             });
         }
+
+        bindLunchBentoExclusion();
 
         (function autoFetchOnModal(){
             if (!initRoomInput) return;


### PR DESCRIPTION
Closes #392

## 変更内容

### 原因
`treservation_index.inline.js` の `applyLunchBentoExclusion()` が個人予約の昼食・弁当チェックボックスを `name*="lunch"` / `name*="bento"` で検索していたが、add フォームの実際の name 属性は `meals[2][roomId]` / `meals[4][roomId]` であるため一切ヒットしていなかった。また、インデックスでペアリングする実装だったため、行（部屋）をまたいだ排他制御にも対応していなかった。

### 修正内容

**`treservation_index.inline.js`（本命修正）**
- `applyLunchBentoExclusion()` に `meals[2][*]`（昼食）と `meals[4][*]`（弁当）を対象とする正しいセレクタを追加
- 昼食チェック時は全部屋の弁当チェックボックスを解除、弁当チェック時は全部屋の昼食チェックボックスを解除（全部屋またぎの排他制御）
- 初期状態で両方チェック済みの場合は弁当を優先解除

**`reservation.js`**
- `bindLunchBentoExclusion()` を追加し、フォーム初期化時に呼び出すよう修正（reservation.js 単体で読み込まれるケース向け）
- `validateForm()` に昼食・弁当の同時選択チェックを追加し、送信時にエラートーストを表示

**`add.js`**
- `bindRoomTableGuards()` を行単位から全部屋またぎの排他制御に変更（add.js が単独で動作するケース向け）

## テスト計画

- [ ] モーダルで部屋Aの「昼」を選択 → 部屋Bの「弁当」チェック時に部屋Aの「昼」が自動解除される
- [ ] モーダルで部屋Aの「弁当」を選択 → 部屋Bの「昼」チェック時に部屋Aの「弁当」が自動解除される
- [ ] 同一部屋内の昼・弁当の排他制御が引き続き動作する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 食事予約時、昼食と弁当の排他制限を改善しました。一方を選択すると、他方が自動で解除されるようになります。
  * 集団予約のバリデーションエラーメッセージをより詳細に表示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->