### PR TITLE
Resolve #406: システム管理者向け機能使用頻度ダッシュボードを追加する

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -160,6 +160,9 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/AuditLog', ['controller' => 'AuditLog', 'action' => 'index'])->setMethods(['GET']);
         $builder->connect('/AuditLog/export', ['controller' => 'AuditLog', 'action' => 'export'])->setMethods(['GET']);
 
+        // 機能使用頻度ダッシュボード（システム管理者専用）
+        $builder->connect('/FeatureUsageSummary', ['controller' => 'FeatureUsageSummary', 'action' => 'index'])->setMethods(['GET']);
+
         // 部屋使用率（システム管理者専用）
         $builder->connect('/RoomUsage', ['controller' => 'RoomUsage', 'action' => 'index'])->setMethods(['GET']);
         $builder->connect('/RoomUsage/roomUsage', ['controller' => 'RoomUsage', 'action' => 'roomUsage'])->setMethods(['GET']);

--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -130,8 +130,9 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             \App\Controller\ApprovalController::class     => \App\Policy\ApprovalPolicy::class,
             \App\Controller\NotificationsController::class => \App\Policy\NotificationPolicy::class,
             \App\Controller\ContactsController::class      => \App\Policy\ContactsPolicy::class,
-            \App\Controller\AuditLogController::class      => \App\Policy\AuditLogPolicy::class,
-            \App\Controller\RoomUsageController::class    => \App\Policy\RoomUsagePolicy::class,
+            \App\Controller\AuditLogController::class             => \App\Policy\AuditLogPolicy::class,
+            \App\Controller\RoomUsageController::class           => \App\Policy\RoomUsagePolicy::class,
+            \App\Controller\FeatureUsageSummaryController::class => \App\Policy\FeatureUsageSummaryPolicy::class,
         ]);
 
         // MapResolver で解決できない場合は OrmResolver（エンティティ→ポリシー）にフォールバック

--- a/src_web/kamaho-shokusu/src/Controller/FeatureUsageSummaryController.php
+++ b/src_web/kamaho-shokusu/src/Controller/FeatureUsageSummaryController.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\FeatureUsageSummaryService;
+use Authorization\Exception\ForbiddenException;
+use Cake\Http\Response;
+
+/**
+ * 機能使用頻度ダッシュボードコントローラー
+ *
+ * システム管理者（i_admin = 3）専用。
+ * audit_log を月次集計し、機能ごとの使用回数・ユニークユーザー数・最終利用日を表示する。
+ */
+class FeatureUsageSummaryController extends AppController
+{
+    private FeatureUsageSummaryService $summaryService;
+
+    public function initialize(): void
+    {
+        parent::initialize();
+        $this->summaryService = new FeatureUsageSummaryService();
+    }
+
+    /**
+     * 機能使用頻度ダッシュボード
+     *
+     * @return Response|null
+     */
+    public function index(): ?Response
+    {
+        try {
+            $this->Authorization->authorize($this, 'index');
+        } catch (ForbiddenException $e) {
+            $this->Flash->error(__('この機能はシステム管理者のみ利用できます。'));
+            return $this->redirect(['controller' => 'Pages', 'action' => 'dashboard']);
+        }
+
+        $q         = $this->request->getQueryParams();
+        $yearMonth = $q['month'] ?? date('Y-m');
+        $category  = $q['category'] ?? null;
+
+        // YYYY-MM 形式でない場合は今月にフォールバック
+        if (!preg_match('/^\d{4}-\d{2}$/', $yearMonth)) {
+            $yearMonth = date('Y-m');
+        }
+
+        $summary      = $this->summaryService->getSummary($yearMonth, $category ?: null);
+        $monthOptions = $this->summaryService->getMonthOptions();
+        $categories   = FeatureUsageSummaryService::CATEGORY_LABELS;
+
+        $this->set(compact('summary', 'monthOptions', 'categories', 'yearMonth', 'category'));
+        return null;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Policy/FeatureUsageSummaryPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/FeatureUsageSummaryPolicy.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Policy;
+
+use App\Domain\ValueObject\UserRole;
+use Authorization\IdentityInterface;
+
+/**
+ * 機能使用頻度ダッシュボード認可ポリシー
+ *
+ * システム管理者（i_admin === 3）のみアクセスを許可する。
+ */
+class FeatureUsageSummaryPolicy
+{
+    public function canIndex(?IdentityInterface $user, mixed $resource): bool
+    {
+        return $this->isSystemAdmin($user);
+    }
+
+    private function isSystemAdmin(?IdentityInterface $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+        $identity = $user->getOriginalData();
+        if ($identity === null) {
+            return false;
+        }
+
+        if (is_object($identity) && method_exists($identity, 'get')) {
+            return UserRole::isSystemAdmin((int)$identity->get('i_admin'));
+        }
+        if (is_array($identity)) {
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
+        }
+        if ($identity instanceof \ArrayAccess) {
+            return UserRole::isSystemAdmin((int)($identity['i_admin'] ?? 0));
+        }
+        return false;
+    }
+}

--- a/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
+++ b/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Cake\ORM\TableRegistry;
+
+/**
+ * 機能使用頻度集計サービス
+ *
+ * t_audit_log を集計し、機能ごとの使用回数・ユニークユーザー数・最終利用日を返す。
+ * システム管理者専用ダッシュボードで利用する。
+ */
+class FeatureUsageSummaryService
+{
+    /** @var array<string, string> アクション名 → 表示用機能名 */
+    private const ACTION_LABELS = [
+        'reservation_individual_save' => '予約登録（個人）',
+        'reservation_group_save'      => '予約登録（集団）',
+        'reservation_toggle'          => '直前予約トグル',
+        'reservation_copy'            => '予約コピー',
+        'reservation_bulk_add'        => '予約一括登録',
+        'reservation_change_edit'     => '予約直前変更',
+        'user_login'                  => 'ログイン',
+        'user_login_failed'           => 'ログイン失敗',
+        'user_logout'                 => 'ログアウト',
+        'user_create'                 => 'ユーザー作成',
+        'user_update'                 => 'ユーザー更新',
+        'user_delete'                 => 'ユーザー削除',
+        'user_restore'                => 'ユーザー復元',
+        'user_bulk_import'            => 'ユーザー一括取込',
+        'actual_meal_save'            => '実食入力',
+        'approval_block_leader'       => '承認（ブロック長）',
+        'approval_admin'              => '承認（管理者）',
+        'approval_rejected'           => '承認却下',
+        'audit_export'                => '監査ログCSV出力',
+        'room_create'                 => '部屋作成',
+        'room_update'                 => '部屋更新',
+        'room_delete'                 => '部屋削除',
+    ];
+
+    /** @var array<string, string> カテゴリ → 表示用ラベル */
+    public const CATEGORY_LABELS = [
+        'reservation'  => '予約',
+        'user'         => 'ユーザー管理',
+        'actual_meal'  => '実食管理',
+        'approval'     => '承認フロー',
+        'master'       => 'マスタ管理',
+        'system'       => 'システム',
+    ];
+
+    /**
+     * 機能使用頻度を集計して返す。
+     *
+     * @param string $yearMonth 対象月 (YYYY-MM)
+     * @param string|null $category カテゴリ絞り込み（null = 全件）
+     * @return array{rows: list<array{action: string, label: string, category: string, category_label: string, total: int, unique_users: int, last_used: string}>, total_operations: int, top_feature: string}
+     */
+    public function getSummary(string $yearMonth, ?string $category = null): array
+    {
+        $table    = TableRegistry::getTableLocator()->get('TAuditLog');
+        $dateFrom = $yearMonth . '-01 00:00:00';
+        $dateTo   = date('Y-m-t', (int)strtotime($yearMonth . '-01')) . ' 23:59:59';
+
+        $query = $table->find()
+            ->select([
+                'action'       => 'c_action',
+                'category'     => 'c_category',
+                'total'        => 'COUNT(*)',
+                'unique_users' => 'COUNT(DISTINCT i_actor_user_id)',
+                'last_used'    => 'MAX(dt_create)',
+            ])
+            ->where([
+                'dt_create >=' => $dateFrom,
+                'dt_create <=' => $dateTo,
+                'i_result'     => 1,
+            ])
+            ->group(['c_action', 'c_category'])
+            ->order(['total' => 'DESC'])
+            ->disableHydration();
+
+        if ($category !== null && $category !== '') {
+            $query->andWhere(['c_category' => $category]);
+        }
+
+        $rows            = [];
+        $totalOperations = 0;
+        $topFeature      = '';
+        $maxCount        = 0;
+
+        foreach ($query->toArray() as $row) {
+            $action = (string)($row['action'] ?? '');
+            $cat    = (string)($row['category'] ?? '');
+            $total  = (int)($row['total'] ?? 0);
+
+            $rows[] = [
+                'action'         => $action,
+                'label'          => self::ACTION_LABELS[$action] ?? $action,
+                'category'       => $cat,
+                'category_label' => self::CATEGORY_LABELS[$cat] ?? $cat,
+                'total'          => $total,
+                'unique_users'   => (int)($row['unique_users'] ?? 0),
+                'last_used'      => $row['last_used'] !== null
+                    ? substr((string)$row['last_used'], 0, 10)
+                    : '-',
+            ];
+
+            $totalOperations += $total;
+
+            if ($total > $maxCount) {
+                $maxCount   = $total;
+                $topFeature = self::ACTION_LABELS[$action] ?? $action;
+            }
+        }
+
+        return [
+            'rows'             => $rows,
+            'total_operations' => $totalOperations,
+            'top_feature'      => $topFeature,
+        ];
+    }
+
+    /**
+     * 選択可能な月一覧（過去12ヶ月）を返す。
+     *
+     * @return array<string, string>
+     */
+    public function getMonthOptions(): array
+    {
+        $options = [];
+        for ($i = 0; $i < 12; $i++) {
+            $ym            = date('Y-m', strtotime("-{$i} months"));
+            $options[$ym]  = date('Y年n月', (int)strtotime($ym . '-01'));
+        }
+        return $options;
+    }
+}

--- a/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
+++ b/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array{rows: list<array{action: string, label: string, category: string, category_label: string, total: int, unique_users: int, last_used: string}>, total_operations: int, top_feature: string} $summary
+ * @var array<string, string> $monthOptions
+ * @var array<string, string> $categories
+ * @var string $yearMonth
+ * @var string|null $category
+ */
+$this->assign('title', '機能使用頻度ダッシュボード');
+$q = $this->request->getQueryParams();
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<!-- ページヘッダー -->
+<div class="rounded-3 shadow-sm mb-4 px-4 py-3 d-flex align-items-center justify-content-between"
+     style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%); color:#fff;">
+    <div class="d-flex align-items-center gap-3">
+        <div class="d-flex align-items-center justify-content-center rounded-circle shadow"
+             style="width:48px; height:48px; flex-shrink:0; background:#f97316;">
+            <i class="bi bi-bar-chart-fill fs-4 text-white"></i>
+        </div>
+        <div>
+            <h1 class="h5 fw-bold mb-0 text-white">機能使用頻度ダッシュボード</h1>
+            <small class="text-white-50">システム管理者専用 — 操作ログから機能の利用状況を集計</small>
+        </div>
+    </div>
+</div>
+
+<!-- サマリーカード -->
+<div class="row g-3 mb-4">
+    <div class="col-sm-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle d-flex align-items-center justify-content-center bg-primary bg-opacity-10"
+                     style="width:48px;height:48px;flex-shrink:0;">
+                    <i class="bi bi-activity text-primary fs-5"></i>
+                </div>
+                <div>
+                    <div class="text-muted small">月間オペレーション数</div>
+                    <div class="fw-bold fs-4"><?= number_format($summary['total_operations']) ?> <span class="fs-6 text-muted fw-normal">回</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle d-flex align-items-center justify-content-center bg-success bg-opacity-10"
+                     style="width:48px;height:48px;flex-shrink:0;">
+                    <i class="bi bi-trophy-fill text-success fs-5"></i>
+                </div>
+                <div>
+                    <div class="text-muted small">最多利用機能</div>
+                    <div class="fw-bold fs-6"><?= $summary['top_feature'] !== '' ? h($summary['top_feature']) : '—' ?></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle d-flex align-items-center justify-content-center bg-info bg-opacity-10"
+                     style="width:48px;height:48px;flex-shrink:0;">
+                    <i class="bi bi-list-check text-info fs-5"></i>
+                </div>
+                <div>
+                    <div class="text-muted small">操作種別数</div>
+                    <div class="fw-bold fs-4"><?= count($summary['rows']) ?> <span class="fs-6 text-muted fw-normal">種</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- フィルターフォーム -->
+<div class="card border-0 shadow-sm mb-4">
+    <div class="card-header bg-white border-bottom d-flex align-items-center gap-2 py-2">
+        <i class="bi bi-funnel-fill text-secondary"></i>
+        <span class="fw-semibold text-secondary small">絞り込み条件</span>
+        <?php if (!empty($q['month']) || !empty($q['category'])): ?>
+            <span class="badge bg-primary ms-1">適用中</span>
+        <?php endif; ?>
+    </div>
+    <div class="card-body pb-2">
+        <?= $this->Form->create(null, ['type' => 'get', 'url' => ['action' => 'index']]) ?>
+        <div class="row g-3 align-items-end">
+            <div class="col-sm-4 col-md-3">
+                <label class="form-label small fw-semibold text-muted mb-1">対象月</label>
+                <?= $this->Form->select('month', $monthOptions, [
+                    'class' => 'form-select form-select-sm',
+                    'value' => $yearMonth,
+                ]) ?>
+            </div>
+            <div class="col-sm-4 col-md-3">
+                <label class="form-label small fw-semibold text-muted mb-1">カテゴリ</label>
+                <?= $this->Form->select('category',
+                    array_merge(['' => 'すべて'], $categories),
+                    ['class' => 'form-select form-select-sm', 'value' => $category ?? '']
+                ) ?>
+            </div>
+            <div class="col-sm-4 col-md-2">
+                <button type="submit" class="btn btn-primary btn-sm w-100">
+                    <i class="bi bi-search me-1"></i>集計
+                </button>
+            </div>
+            <?php if (!empty($q['month']) || !empty($q['category'])): ?>
+                <div class="col-auto">
+                    <a href="<?= $this->Url->build(['action' => 'index']) ?>"
+                       class="btn btn-outline-secondary btn-sm">
+                        <i class="bi bi-x-circle me-1"></i>クリア
+                    </a>
+                </div>
+            <?php endif; ?>
+        </div>
+        <?= $this->Form->end() ?>
+    </div>
+</div>
+
+<!-- 集計テーブル -->
+<div class="card border-0 shadow-sm">
+    <div class="card-header bg-white border-bottom d-flex align-items-center justify-content-between py-2">
+        <span class="fw-semibold text-secondary small">
+            <i class="bi bi-table me-1"></i>
+            機能別使用状況
+            <span class="badge bg-secondary ms-1"><?= h($yearMonth) ?></span>
+        </span>
+        <span class="text-muted small"><?= count($summary['rows']) ?> 種別</span>
+    </div>
+
+    <?php if (empty($summary['rows'])): ?>
+        <div class="card-body text-center text-muted py-5">
+            <i class="bi bi-inbox fs-1 d-block mb-2 text-secondary opacity-50"></i>
+            <p class="mb-0">対象期間にデータがありません。</p>
+        </div>
+    <?php else: ?>
+        <div class="table-responsive">
+            <table class="table table-hover table-sm mb-0 align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th class="ps-3" style="width:2.5rem;">#</th>
+                        <th>機能名</th>
+                        <th>カテゴリ</th>
+                        <th class="text-end pe-3" style="width:8rem;">使用回数</th>
+                        <th class="text-end pe-3" style="width:10rem;">ユニークユーザー</th>
+                        <th class="text-end pe-3" style="width:8rem;">最終利用日</th>
+                        <th style="width:12rem;">使用率</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php
+                    $maxTotal = !empty($summary['rows']) ? (int)$summary['rows'][0]['total'] : 1;
+                    foreach ($summary['rows'] as $i => $row):
+                        $pct = $maxTotal > 0 ? (int)round($row['total'] / $maxTotal * 100) : 0;
+                        $barColor = match($row['category']) {
+                            'reservation'  => 'bg-primary',
+                            'user'         => 'bg-info',
+                            'actual_meal'  => 'bg-success',
+                            'approval'     => 'bg-warning',
+                            'master'       => 'bg-secondary',
+                            default        => 'bg-dark',
+                        };
+                    ?>
+                        <tr>
+                            <td class="ps-3 text-muted small"><?= $i + 1 ?></td>
+                            <td>
+                                <span class="fw-semibold"><?= h($row['label']) ?></span>
+                                <br>
+                                <code class="text-muted" style="font-size:0.7rem;"><?= h($row['action']) ?></code>
+                            </td>
+                            <td>
+                                <span class="badge bg-secondary bg-opacity-75"><?= h($row['category_label']) ?></span>
+                            </td>
+                            <td class="text-end pe-3 fw-bold">
+                                <?= number_format($row['total']) ?>
+                            </td>
+                            <td class="text-end pe-3">
+                                <i class="bi bi-people text-muted me-1"></i><?= number_format($row['unique_users']) ?>
+                            </td>
+                            <td class="text-end pe-3 text-muted small">
+                                <?= h($row['last_used']) ?>
+                            </td>
+                            <td class="pe-3">
+                                <div class="d-flex align-items-center gap-2">
+                                    <div class="progress flex-grow-1" style="height:8px;">
+                                        <div class="progress-bar <?= $barColor ?>"
+                                             role="progressbar"
+                                             style="width:<?= $pct ?>%"
+                                             aria-valuenow="<?= $pct ?>"
+                                             aria-valuemin="0"
+                                             aria-valuemax="100">
+                                        </div>
+                                    </div>
+                                    <span class="text-muted small" style="width:2.5rem;"><?= $pct ?>%</span>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</div>

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -93,8 +93,22 @@ $recentNotifications     = $recentNotifications ?? [];
                     <?php endif; ?>
 
                     <?php if ($user && $isSysAdmin): ?>
-                        <li class="nav-item">
-                            <a class="nav-link fw-bold" href="<?= $this->Url->build('/AuditLog') ?>">監査ログ</a>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link fw-bold dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                管理
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="dropdown-item" href="<?= $this->Url->build('/AuditLog') ?>">
+                                        <i class="bi bi-shield-lock me-2 text-danger"></i>監査ログ
+                                    </a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item" href="<?= $this->Url->build('/FeatureUsageSummary') ?>">
+                                        <i class="bi bi-bar-chart me-2 text-warning"></i>機能使用頻度
+                                    </a>
+                                </li>
+                            </ul>
                         </li>
                     <?php endif; ?>
                 </ul>


### PR DESCRIPTION
Closes #406

## 変更内容

### 新規追加

| ファイル | 役割 |
|---|---|
| `src/Service/FeatureUsageSummaryService.php` | `t_audit_log` を月次集計するサービス |
| `src/Policy/FeatureUsageSummaryPolicy.php` | システム管理者（i_admin=3）のみアクセス許可 |
| `src/Controller/FeatureUsageSummaryController.php` | 月・カテゴリフィルター付きダッシュボードコントローラー |
| `templates/FeatureUsageSummary/index.php` | 機能別使用頻度ダッシュボード画面 |

### 変更

- `config/routes.php`: `/FeatureUsageSummary` ルートを追加
- `src/Application.php`: `MapResolver` に `FeatureUsageSummaryPolicy` を登録
- `templates/layout/default.php`: システム管理者向けナビを「管理」ドロップダウンに統合（監査ログ + 機能使用頻度）

### 機能概要

- **集計対象**: `t_audit_log` の `c_action` × `c_category` でグループ化
- **表示項目**: 使用回数 / ユニークユーザー数 / 最終利用日 / 最多機能との相対バー
- **フィルター**: 対象月（過去12ヶ月） / カテゴリ（予約・ユーザー管理・実食管理・承認等）
- **認可**: `FeatureUsageSummaryPolicy` でシステム管理者のみ許可、それ以外はダッシュボードへリダイレクト
- **サマリーカード**: 月間オペレーション総数・最多利用機能・操作種別数を上部に表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * システム管理者向けの「機能使用頻度ダッシュボード」を追加。過去12ヶ月の機能利用状況を月別・カテゴリ別で集計・表示でき、操作回数やユニークユーザー数、最終利用日などを確認できます。
  * 管理メニューに「機能使用頻度」オプションを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->