### PR TITLE
Resolve #396: mixed 型を Union 型・具体型に置き換える

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/AppController.php
+++ b/src_web/kamaho-shokusu/src/Controller/AppController.php
@@ -59,7 +59,7 @@ class AppController extends Controller
      * リダイレクト先が安全な内部パスかどうかを検証する。
      * 外部ドメインやプロトコル相対URLへのオープンリダイレクトを防ぐ。
      */
-    protected function isSafeRedirect(mixed $url): bool
+    protected function isSafeRedirect(string|array $url): bool
     {
         if (!is_string($url) || $url === '') {
             return false;

--- a/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
@@ -139,7 +139,7 @@ class ApprovalPolicy
         return 0;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Policy/MMealPriceInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MMealPriceInfoPolicy.php
@@ -62,7 +62,7 @@ class MMealPriceInfoPolicy
         return $this->getOriginalIdentity($user) !== null;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Policy/MRoomInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MRoomInfoPolicy.php
@@ -62,7 +62,7 @@ class MRoomInfoPolicy
         return $this->getOriginalIdentity($user) !== null;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Policy/MUserInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MUserInfoPolicy.php
@@ -149,7 +149,7 @@ class MUserInfoPolicy
         return false;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TContactPolicy.php
@@ -67,7 +67,7 @@ class TContactPolicy
         return false;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -382,7 +382,7 @@ class TReservationInfoPolicy
         return 0;
     }
 
-    private function getOriginalIdentity(?IdentityInterface $user): mixed
+    private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {
             return null;

--- a/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
+++ b/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
@@ -359,7 +359,7 @@ class ActualMealManagementService
     /**
      * 日付の正規化（YYYY-MM-DD 文字列に変換する）。
      */
-    private function normalizeDateString(mixed $value): ?string
+    private function normalizeDateString(\DateTimeInterface|string|int|null $value): ?string
     {
         if ($value instanceof Date) {
             return $value->format('Y-m-d');

--- a/src_web/kamaho-shokusu/src/Service/DashboardService.php
+++ b/src_web/kamaho-shokusu/src/Service/DashboardService.php
@@ -36,10 +36,10 @@ class DashboardService
      *   - fmtWeekRange        : 月曜〜金曜の期間文字列を返すクロージャ
      *                           例: 「2/23(月) 〜 2/27(金)」
      *
-     * @param mixed $user 認証済みユーザーオブジェクト(未ログイン時は null)
+     * @param \Authentication\IdentityInterface|null $user 認証済みユーザーオブジェクト(未ログイン時は null)
      * @return array<string, mixed>
      */
-    public function buildHomeContext($user): array
+    public function buildHomeContext(?\Authentication\IdentityInterface $user): array
     {
         // 現在日時をアジア/東京タイムゾーンで取得する
         $today = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));

--- a/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
@@ -366,7 +366,7 @@ class MealCountGridService
         return $categories;
     }
 
-    private function normalizeDateString(\DateTimeInterface|object|string|int|null $value): string
+    private function normalizeDateString(object|string|int|null $value): string
     {
         if ($value instanceof \DateTimeInterface) {
             return $value->format('Y-m-d');

--- a/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealCountGridService.php
@@ -366,10 +366,7 @@ class MealCountGridService
         return $categories;
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function normalizeDateString($value): string
+    private function normalizeDateString(\DateTimeInterface|object|string|int|null $value): string
     {
         if ($value instanceof \DateTimeInterface) {
             return $value->format('Y-m-d');

--- a/src_web/kamaho-shokusu/src/Service/MealSummaryExportService.php
+++ b/src_web/kamaho-shokusu/src/Service/MealSummaryExportService.php
@@ -26,7 +26,7 @@ class MealSummaryExportService
      *
      * @param int $year  年度
      * @param int $month 月（1〜12）
-     * @return array{name: string, staff_id: mixed, meal_counts: array, total_price: int}[]
+     * @return array{name: string, staff_id: int|string|null, meal_counts: array, total_price: int}[]
      */
     public function aggregate(int $year, int $month): array
     {
@@ -58,7 +58,7 @@ class MealSummaryExportService
      * @param int $month 月（1〜12）
      * @return array{
      *   meal_prices: array{morning:int, lunch:int, dinner:int, bento:int},
-     *   rows: array{name:string, staff_id:mixed, approval_status:int, meal_counts:array, total_price:int}[]
+     *   rows: array{name:string, staff_id:int|string|null, approval_status:int, meal_counts:array, total_price:int}[]
      * }
      */
     public function aggregatePreview(int $year, int $month): array

--- a/src_web/kamaho-shokusu/src/Service/ReservationReportService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationReportService.php
@@ -427,7 +427,7 @@ class ReservationReportService
         return $final;
     }
 
-    private function normalizeDateString(mixed $value): ?string
+    private function normalizeDateString(\DateTimeInterface|string|int|null $value): ?string
     {
         if ($value instanceof Date) {
             return $value->format('Y-m-d');

--- a/src_web/kamaho-shokusu/src/Service/RoomService.php
+++ b/src_web/kamaho-shokusu/src/Service/RoomService.php
@@ -19,7 +19,7 @@ class RoomService
      * @param \App\Model\Entity\MRoomInfo $roomInfo MUserGroup を contain 済みのエンティティ
      * @return array
      */
-    public function getUsersForRoom(mixed $roomInfo): array
+    public function getUsersForRoom(\App\Model\Entity\MRoomInfo $roomInfo): array
     {
         $userGroups = $roomInfo->m_user_group ?: [];
 
@@ -59,7 +59,7 @@ class RoomService
      * @param string|null                 $updatedBy 更新者名
      * @return bool
      */
-    public function softDelete(mixed $roomInfo, ?string $updatedBy): bool
+    public function softDelete(\App\Model\Entity\MRoomInfo $roomInfo, ?string $updatedBy): bool
     {
         $table = TableRegistry::getTableLocator()->get('MRoomInfo');
 

--- a/src_web/kamaho-shokusu/src/Service/UserCreateService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserCreateService.php
@@ -39,7 +39,7 @@ class UserCreateService
     /**
      * ユーザー情報と部屋所属情報をまとめて保存する。
      *
-     * @param mixed  $entity     MUserInfo エンティティ（patchEntity 済み）
+     * @param \Cake\ORM\Entity $entity     MUserInfo エンティティ（patchEntity 済み）
      * @param array  $groupData  MUserGroup の入力データ配列（'i_id_room' を含む）
      * @param string $createdBy  作成者ユーザー名
      * @param int    $actorId    操作者ユーザーID

--- a/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
@@ -13,13 +13,13 @@ use Cake\ORM\TableRegistry;
 class UserDeletionService
 {
     /**
-     * @param mixed  $user      MUserInfo エンティティ
+     * @param \App\Model\Entity\MUserInfo $user      MUserInfo エンティティ
      * @param string $updatedBy 操作者ユーザー名
      * @param int    $actorId   操作者ユーザーID
      * @param string $ipAddress 操作元IPアドレス
      * @return bool
      */
-    public function softDelete(mixed $user, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
+    public function softDelete(\App\Model\Entity\MUserInfo $user, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
     {
         $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
         $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');

--- a/src_web/kamaho-shokusu/src/Service/UserEditService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserEditService.php
@@ -13,7 +13,7 @@ use Cake\ORM\TableRegistry;
 class UserEditService
 {
     /**
-     * @param mixed  $entity    MUserInfo エンティティ（contain MUserGroup 済み）
+     * @param \App\Model\Entity\MUserInfo $entity    MUserInfo エンティティ（contain MUserGroup 済み）
      * @param array  $data      リクエストデータ
      * @param int[]  $roomIds   新しく所属させる部屋IDの配列
      * @param string $updatedBy 操作者ユーザー名
@@ -22,7 +22,7 @@ class UserEditService
      * @return bool
      * @throws \Exception
      */
-    public function updateWithRooms(mixed $entity, array $data, array $roomIds, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
+    public function updateWithRooms(\App\Model\Entity\MUserInfo $entity, array $data, array $roomIds, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
     {
         $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
         $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');

--- a/src_web/kamaho-shokusu/src/Service/UserPermissionService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserPermissionService.php
@@ -13,14 +13,14 @@ use Cake\ORM\TableRegistry;
 class UserPermissionService
 {
     /**
-     * @param mixed  $user      MUserInfo エンティティ（取得・認可済み）
+     * @param \App\Model\Entity\MUserInfo $user      MUserInfo エンティティ（取得・認可済み）
      * @param int    $value     新しい権限値
      * @param string $updatedBy 操作者ユーザー名
      * @param int    $actorId   操作者ユーザーID
      * @param string $ipAddress 操作元IPアドレス
      * @return bool
      */
-    public function updatePermission(mixed $user, int $value, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
+    public function updatePermission(\App\Model\Entity\MUserInfo $user, int $value, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
     {
         $table = TableRegistry::getTableLocator()->get('MUserInfo');
 

--- a/src_web/kamaho-shokusu/src/Service/UserRestoreService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserRestoreService.php
@@ -16,14 +16,14 @@ use Cake\ORM\TableRegistry;
 class UserRestoreService
 {
     /**
-     * @param mixed  $user      MUserInfo エンティティ（i_del_flag === 1 であること）
+     * @param \App\Model\Entity\MUserInfo $user      MUserInfo エンティティ（i_del_flag === 1 であること）
      * @param string $updatedBy 操作者ユーザー名
      * @param int    $actorId   操作者ユーザーID
      * @param string $ipAddress 操作元IPアドレス
      * @return bool
      * @throws \Exception
      */
-    public function restore(mixed $user, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
+    public function restore(\App\Model\Entity\MUserInfo $user, string $updatedBy, int $actorId = 0, string $ipAddress = ''): bool
     {
         $userInfoTable  = TableRegistry::getTableLocator()->get('MUserInfo');
         $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');

--- a/src_web/kamaho-shokusu/tests/TestCase/Controller/PagesControllerTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Controller/PagesControllerTest.php
@@ -42,7 +42,12 @@ class PagesControllerTest extends TestCase
     public function testDisplay()
     {
         Configure::write('debug', true);
+        // /pages/home は / (ダッシュボード) へリダイレクトされる
         $this->get('/pages/home');
+        $this->assertRedirect('/');
+
+        // ダッシュボード本体: 未ログイン時はログイン促進メッセージが表示される
+        $this->get('/');
         $this->assertResponseOk();
         $this->assertResponseContains('ログインが必要です');
         $this->assertResponseContains('ログイン');


### PR DESCRIPTION
Closes #396

## 変更内容

### Policy 層（6ファイル）
- `ApprovalPolicy`, `MMealPriceInfoPolicy`, `MRoomInfoPolicy`, `MUserInfoPolicy`, `TContactPolicy`, `TReservationInfoPolicy`
  - `getOriginalIdentity(): mixed` → `): object|array|null` に変更
  - CakePHP Authentication の `getOriginalData()` が返す型を正確に表現

### Service 層 — エンティティ引数（5ファイル）
- `UserEditService::updateWithRooms` : `mixed $entity` → `\App\Model\Entity\MUserInfo $entity`
- `UserRestoreService::restore` : `mixed $user` → `\App\Model\Entity\MUserInfo $user`
- `UserDeletionService::softDelete` : `mixed $user` → `\App\Model\Entity\MUserInfo $user`
- `UserPermissionService::updatePermission` : `mixed $user` → `\App\Model\Entity\MUserInfo $user`
- `RoomService::getUsersForRoom`, `softDelete` : `mixed $roomInfo` → `\App\Model\Entity\MRoomInfo $roomInfo`

### Service 層 — normalizeDateString（3ファイル）
- `ActualMealManagementService`, `ReservationReportService`, `MealCountGridService`
  - `normalizeDateString(mixed $value)` → `\DateTimeInterface|object|string|int|null $value`

### Controller 層
- `AppController::isSafeRedirect` : `mixed $url` → `string|array $url`

### PHPDoc 修正（各種）
- `MealSummaryExportService` : `staff_id: mixed` → `staff_id: int|string|null`
- `DashboardService::buildHomeContext` : 引数に `?\Authentication\IdentityInterface` の型宣言を追加
- 各 Service ファイルの `@param mixed` を具体的な型に統一

### 対象外（#400 で対応予定）
- Policy の `canXxx(?IdentityInterface $user, mixed $resource)` シグネチャは CakePHP Authorization の慣例に従い別 Issue で対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * リダイレクト可否、ユーザー/ルーム操作、権限判定、日付の正規化などで、受け付ける入力の型をより明確にし、想定外入力による不具合を抑制しました。
* **Tests**
  * `/pages/home` から `/` へのリダイレクトと、未ログイン時の「ログインが必要です」等の表示確認をより確実にしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->