### PR TITLE
fix: address review comments for #411

### DIFF
--- a/src_web/kamaho-shokusu/tests/js/treservation_lunch_bento.test.js
+++ b/src_web/kamaho-shokusu/tests/js/treservation_lunch_bento.test.js
@@ -9,7 +9,7 @@ function loadScript() {
         'utf8'
     );
     // eslint-disable-next-line no-new-func
-    new Function('window', 'document', src)(global, global.document);
+    new Function('window', 'document', src)(global.window, global.document);
 }
 
 describe('treservation_lunch_bento.js', () => {
@@ -222,12 +222,13 @@ describe('treservation_lunch_bento.js', () => {
         });
 
         test('data-locked="1" の昼食は変更されない', () => {
-            const { lunch, bento } = buildChangeEditRow({ bentoChecked: true });
+            const { lunch, bento } = buildChangeEditRow({ lunchChecked: true, bentoChecked: true });
             lunch.dataset.locked = '1';
+            // 初期補正で bento が unchecked になる → 改めて bento をチェックして change を発火
             bento.checked = true;
             bento.dispatchEvent(new Event('change'));
-            // locked なので昼食は変更されない（既に未チェックでも disabled されない）
-            expect(lunch.checked).toBe(false); // 元々未チェック → 変わらない
+            // lunch は locked なので unchecked にならず true のまま
+            expect(lunch.checked).toBe(true);
         });
     });
 });

--- a/src_web/kamaho-shokusu/tests/js/treservation_meal_cal.test.js
+++ b/src_web/kamaho-shokusu/tests/js/treservation_meal_cal.test.js
@@ -12,7 +12,7 @@ function loadScript() {
         'utf8'
     );
     // eslint-disable-next-line no-new-func
-    new Function('window', 'document', src)(global, global.document);
+    new Function('window', 'document', src)(global.window, global.document);
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
Closes #398

## 変更内容

PR #411 の CodeRabbit レビュー指摘に対応。

### 修正した指摘

| # | ファイル | 内容 |
|---|---|---|
| 1 | `treservation_lunch_bento.test.js` | `data-locked="1"` テストが検証になっていなかった問題を修正（`lunchChecked: true` で開始し、ロックにより `lunch.checked` が `true` のまま維持されることを検証） |
| 2 | `treservation_lunch_bento.test.js` | `new Function` の第 1 引数を `global` → `global.window` に統一 |
| 3 | `treservation_meal_cal.test.js` | 同上 |

### スキップした指摘

PHP テストメソッドのキャメルケース化・PHPDoc 追加については、既存の `AuditLogPolicyTest` / `ApprovalPolicyTest` がアンダースコア形式・PHPDoc なしで統一されているため、一貫性を維持してスキップ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト環境の互換性を改善し、ランチ・弁当機能を含むテストの信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->