### PR TITLE
fix: #426 ログイン後に「不正なアクセス」エラーが表示される問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/AppController.php
+++ b/src_web/kamaho-shokusu/src/Controller/AppController.php
@@ -59,7 +59,7 @@ class AppController extends Controller
      * リダイレクト先が安全な内部パスかどうかを検証する。
      * 外部ドメインやプロトコル相対URLへのオープンリダイレクトを防ぐ。
      */
-    protected function isSafeRedirect(string|array $url): bool
+    protected function isSafeRedirect(string|array|null $url): bool
     {
         if (!is_string($url) || $url === '') {
             return false;

--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -48,10 +48,13 @@ class MUserInfoController extends AppController
         $this->userRestoreService       = new UserRestoreService();
         $this->userRoomAssignmentService = new UserRoomAssignmentService();
 
-        // これらのアクションは JSON ボディを受け取る AJAX エンドポイントのため
-        // FormProtection のフォームトークン検証対象外にする。
+        // これらのアクションは FormProtection のフォームトークン検証対象外にする。
         // CSRF 保護は CsrfProtectionMiddleware がミドルウェア層で適用済み。
+        // login/logout: セッション切れや複数タブでトークンが失効し「不正なアクセス」になるため除外。
+        // importJson 等: JSON ボディを受け取る AJAX エンドポイントのため除外。
         $this->FormProtection->setConfig('unlockedActions', [
+            'login',
+            'logout',
             'importJson',
             'updateAdminStatus',
             'updateUserLevel',


### PR DESCRIPTION
## 概要

Issue #426 の修正。

ログイン後に「不正なアクセス」エラー（BadRequestException）が表示される問題を解消する。

## 原因

`FormProtection` コンポーネントは `login` / `logout` アクションに対してもフォームトークン検証を実施していた。
セッション切れや複数タブ利用の場合、フォームに埋め込まれたトークンが失効しハッシュ不一致が発生するため、`BadRequestException` が投げられていた。

## 修正内容

`MUserInfoController::initialize()` の `unlockedActions` に `login` と `logout` を追加し、FormProtection の検証対象から除外。

CSRF 保護は `CsrfProtectionMiddleware` がミドルウェア層で引き続き適用されているため、セキュリティ上の問題はない。

## テスト観点

- [ ] ログインフォームを送信して正常にログインできること
- [ ] セッションが切れた状態（別タブ / ブラウザバック）でログインフォームを送信しても「不正なアクセス」エラーが発生しないこと
- [ ] ログアウト後に再ログインできること
- [ ] CSRF トークンが正常に機能していること（開発者ツールで `csrfToken` Cookie の存在を確認）

Closes #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* ログイン/ログアウト時のフォーム保護設定を調整し、複数タブやセッション切れに起因する不正アクセス表示を抑えました。

## Security
* 安全なリダイレクト判定で、null入力時も安全にフォールバックするよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->