### PR TITLE
feat: #422 basePath の末尾スラッシュ正規化によるパス重複防止

### DIFF
--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -23,7 +23,7 @@ $statusLabels = [
     3 => ['label' => '差し戻し',         'class' => 'bg-danger text-white'],
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
-$basePath = $this->request->getAttribute('base') ?? '';
+$basePath = rtrim($this->request->getAttribute('base') ?? '', '/');
 $pendingCount = 0;
 $approvedCount = 0;
 foreach ($records as $record) {

--- a/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/block_leader_index.php
@@ -23,7 +23,7 @@ $statusLabels = [
     3 => ['label' => '差し戻し',         'class' => 'bg-danger text-white'],
 ];
 $mealLabels = [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
-$basePath = $this->request->getAttribute('base') ?? '';
+$basePath = rtrim($this->request->getAttribute('base') ?? '', '/');
 $pendingCount = 0;
 $rejectedCount = 0;
 foreach ($records as $record) {

--- a/src_web/kamaho-shokusu/templates/RoomUsage/index.php
+++ b/src_web/kamaho-shokusu/templates/RoomUsage/index.php
@@ -8,7 +8,7 @@ $mealType  = $mealType  ?? null;
 $threshold = $threshold ?? 50.0;
 
 $mealLabels = ['' => '全食種', 1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁当'];
-$basePath   = $this->request->getAttribute('base') ?? '';
+$basePath   = rtrim($this->request->getAttribute('base') ?? '', '/');
 ?>
 <!DOCTYPE html>
 <html lang="ja">

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
@@ -33,7 +33,8 @@ if ($isChild) {
 $here = $this->request->getPath();
 $qs = $this->request->getQueryParams();
 // CakePHPのベースパス（プロジェクト名）を常に先頭へ付与する
-$basePath = $this->request->getAttribute('base') ?? $this->request->getAttribute('webroot') ?? '';
+// rtrim で末尾スラッシュを除去し $here（先頭 / あり）との二重スラッシュを防ぐ
+$basePath = rtrim($this->request->getAttribute('base') ?? $this->request->getAttribute('webroot') ?? '', '/');
 $mkUrl = function (array $merge) use ($here, $qs, $basePath) {
     $q = array_merge($qs, $merge);
     foreach ($q as $k => $v) if ($v === null) unset($q[$k]);

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/meal_count_grid.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/meal_count_grid.php
@@ -29,7 +29,7 @@
 $this->assign('title', 'エクセル食数予約');
 
 $csrfToken = $this->request->getAttribute('csrfToken') ?? '';
-$basePath  = $this->request->getAttribute('base') ?? '';
+$basePath  = rtrim($this->request->getAttribute('base') ?? '', '/');
 
 $dates          = $gridData['dates']       ?? [];
 $meals          = $gridData['meals']       ?? [1 => '朝', 2 => '昼', 3 => '夕', 4 => '弁'];


### PR DESCRIPTION
## 概要

Issue #422 の対応。

`$basePath . $here` の単純連結で、`$basePath` が末尾スラッシュを持つ環境（サブディレクトリ配置・リバースプロキシ）において `//path` のようなスラッシュ重複が発生する可能性があった。

## 修正内容

`$basePath` を取得する際に `rtrim($base, '/')` を適用し、末尾スラッシュを除去するよう統一。

`$here`（`getPath()` の戻り値）は常に `/` で始まるため、`rtrim($basePath, '/') . $here` の形でスラッシュが正確に1本だけになる。

### 対象ファイル

| ファイル | 修正箇所 |
|---|---|
| `templates/TReservationInfo/index.php` | `$mkUrl` の `$basePath` 定義 |
| `templates/TReservationInfo/meal_count_grid.php` | `$makeUrl` の `$basePath` 定義 |
| `templates/RoomUsage/index.php` | `$basePath` 定義 |
| `templates/Approval/block_leader_index.php` | `$basePath` 定義 |
| `templates/Approval/admin_index.php` | `$basePath` 定義 |

## テスト観点

- [ ] 開発環境（サブディレクトリ `/kamaho-shokusu/` 配置）でページ遷移・リンク生成が正常か
- [ ] UIモード切替（`?uimode=kid` / `?uimode=biz`）のリンクが正しく生成されるか
- [ ] 承認ページ・食数グリッドページのナビゲーションが正常か

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * URLのパス形成を改善し、重複するスラッシュによるリンク形成の不整合を解決しました。複数ページにおいて、戻るリンクおよび動的URL生成の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->