### PR TITLE
fix: MUserInfo ルート不整合・ハードコードパス・デッドルート修正

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -143,10 +143,10 @@ return function (RouteBuilder $routes): void {
         // MUserInfo
         $builder->connect('/MUserInfo', ['controller' => 'MUserInfo', 'action' => 'index']);
         $builder->connect('/MUserInfo/admin_change_password', ['controller' => 'MUserInfo', 'action' => 'adminChangePassword']);
-        $builder->connect('/MUserInfo/changePassword', ['controller' => 'MUserInfo', 'action' => 'changePassword']);
-        $builder->connect('/MUserInfo/AdminChangePassword', ['controller' => 'MUserInfo', 'action' => 'AdminChangePassword']);
         $builder->connect('/MUserInfo/update-admin-status', ['controller' => 'MUserInfo', 'action' => 'updateAdminStatus'])->setMethods(['POST']);
         $builder->connect('/MUserInfo/update-user-level', ['controller' => 'MUserInfo', 'action' => 'updateUserLevel'])->setMethods(['POST']);
+        $builder->connect('/MUserInfo/update-system-admin-status', ['controller' => 'MUserInfo', 'action' => 'updateSystemAdminStatus'])->setMethods(['POST']);
+        $builder->connect('/MUserInfo/generalPasswordReset', ['controller' => 'MUserInfo', 'action' => 'generalPasswordReset']);
         $builder->connect('/MUserInfo/login', ['controller' => 'MUserInfo', 'action' => 'login']);
         $builder->connect('/MUserInfo/add', ['controller' => 'MUserInfo', 'action' => 'add']);
         $builder->connect('/MUserInfo/edit/*', ['controller' => 'MUserInfo', 'action' => 'edit']);

--- a/src_web/kamaho-shokusu/templates/MUserInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/index.php
@@ -195,6 +195,7 @@ $csrfToken = $this->request->getAttribute('csrfToken');
 </div>
 
 <script>
+    const BASE_PATH = <?= json_encode(rtrim($this->request->getAttribute('base') ?? '', '/'), JSON_UNESCAPED_SLASHES) ?>;
     document.addEventListener('DOMContentLoaded', () => {
         const toggleNormal  = document.getElementById('toggleNormal');
         const toggleDeleted = document.getElementById('toggleDeleted');
@@ -216,7 +217,7 @@ $csrfToken = $this->request->getAttribute('csrfToken');
                 const ok = await window.ConfirmPopup.show(message);
                 if (!ok) { this.checked = !this.checked; return; }
 
-                fetch('/kamaho-shokusu/MUserInfo/update-admin-status', {
+                fetch(BASE_PATH + '/MUserInfo/update-admin-status', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
                     body: JSON.stringify({ i_id_user: userId, i_admin: isAdmin })
@@ -250,7 +251,7 @@ $csrfToken = $this->request->getAttribute('csrfToken');
                 const ok = await window.ConfirmPopup.show(message);
                 if (!ok) { this.checked = !this.checked; return; }
 
-                fetch('/kamaho-shokusu/MUserInfo/update-user-level', {
+                fetch(BASE_PATH + '/MUserInfo/update-user-level', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
                     body: JSON.stringify({ i_id_user: userId, i_admin: newAdmin })
@@ -283,7 +284,7 @@ $csrfToken = $this->request->getAttribute('csrfToken');
                 const ok = await window.ConfirmPopup.show(message);
                 if (!ok) { this.checked = !this.checked; return; }
 
-                fetch('/kamaho-shokusu/MUserInfo/update-system-admin-status', {
+                fetch(BASE_PATH + '/MUserInfo/update-system-admin-status', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
                     body: JSON.stringify({ i_id_user: userId, i_system_admin: isSystemAdmin })
@@ -324,14 +325,14 @@ $csrfToken = $this->request->getAttribute('csrfToken');
         if (toggleNormal) {
             toggleNormal.addEventListener('click', () => {
                 if (!toggleNormal.classList.contains('active')) {
-                    window.location.href = '/kamaho-shokusu/MUserInfo/';
+                    window.location.href = BASE_PATH + '/MUserInfo/';
                 }
             });
         }
         if (toggleDeleted) {
             toggleDeleted.addEventListener('click', () => {
                 if (!toggleDeleted.classList.contains('active')) {
-                    window.location.href = '/kamaho-shokusu/MUserInfo?show_deleted=1';
+                    window.location.href = BASE_PATH + '/MUserInfo?show_deleted=1';
                 }
             });
         }

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -155,9 +155,9 @@ $recentNotifications     = $recentNotifications ?? [];
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end animate__animated animate__fadeIn" aria-labelledby="userMenu">
                                 <li><?= $this->Html->link('👤 プロフィール', ['controller' => 'MUserInfo', 'action' => 'view', $user->i_id_user], ['class' => 'dropdown-item']) ?></li>
-                                <li><?= $this->Html->link('🔑 パスワード変更', ['controller' => 'MUserInfo', 'action' => 'general_password_reset'], ['class' => 'dropdown-item']) ?></li>
+                                <li><?= $this->Html->link('🔑 パスワード変更', ['controller' => 'MUserInfo', 'action' => 'generalPasswordReset'], ['class' => 'dropdown-item']) ?></li>
                                 <?php if ($isAdmin): ?>
-                                    <li><?= $this->Html->link('🔑 管理者：パスワード変更', ['controller' => 'MUserInfo', 'action' => 'AdminChangePassword'], ['class' => 'dropdown-item']) ?></li>
+                                    <li><?= $this->Html->link('🔑 管理者：パスワード変更', ['controller' => 'MUserInfo', 'action' => 'adminChangePassword'], ['class' => 'dropdown-item']) ?></li>
                                 <?php endif; ?>
                                 <li><?= $this->Html->link('🚪 ログアウト', ['controller' => 'MUserInfo', 'action' => 'logout'], ['class' => 'dropdown-item']) ?></li>
                             </ul>


### PR DESCRIPTION
## 変更内容

### Bug #1: システム管理者権限トグルAPIのルート追加
- `config/routes.php`: `/MUserInfo/update-system-admin-status` → `updateSystemAdminStatus` のルートが未定義だったため追加
- テンプレートの fetch() 呼び出しはすでに存在していたが、ルートがなく 404 になっていた

### Bug #2: デッドルートの削除（changePassword）
- `config/routes.php`: `/MUserInfo/changePassword` → `changePassword` のルートを削除
- コントローラに対応するメソッドが存在せず、アクセスすると MissingActionException になっていた

### Bug #3: デッドルートの削除（AdminChangePassword）と layout 修正
- `config/routes.php`: `/MUserInfo/AdminChangePassword` → `AdminChangePassword`（大文字 A）のルートを削除
- コントローラのメソッド名は `adminChangePassword`（小文字）で case-sensitive 不一致により MissingActionException
- `templates/layout/default.php`: ナビバーのリンクを `AdminChangePassword` → `adminChangePassword` に修正

### Bug #4: ナビバーのパスワード変更リンク修正
- `templates/layout/default.php`: `['action' => 'general_password_reset']` → `['action' => 'generalPasswordReset']` に修正
- `Route::class` はアンダースコア→camelCase 変換を行わないため、`general_password_reset` のままでは MissingActionException
- `config/routes.php`: `/MUserInfo/generalPasswordReset` ルートを追加

### Bug #5: ハードコードパスの動的化
- `templates/MUserInfo/index.php`: fetch() と window.location.href に含まれる `/kamaho-shokusu/` のハードコードを撤廃
- PHP 側で `BASE_PATH` 定数を JS に埋め込み、全パスを `BASE_PATH + '/MUserInfo/...'` に統一
- 他ページ（TReservationInfo 等）と同様の実装パターンに揃えた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * パスワード変更機能のエンドポイント構成を最適化しました
  * ユーザードロップダウンメニュー内のパスワード変更リンクを更新しました
  * アプリケーション内のURL参照方法を統一し、システムの安定性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->