### PR TITLE
feat: #438 ルートクラスをDashedRouteに変更しケバブケースURLの自動変換を有効化

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -3,13 +3,13 @@
  * Routes configuration.
  */
 
-use Cake\Routing\Route\Route;
+use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
 return function (RouteBuilder $routes): void {
 
-    $routes->setRouteClass(Route::class);
+    $routes->setRouteClass(DashedRoute::class);
 
     $routes->scope('/', function (RouteBuilder $builder): void {
 
@@ -356,6 +356,6 @@ return function (RouteBuilder $routes): void {
             ->setPatterns(['id' => '\d+']);
 
         // フォールバック
-        $builder->fallbacks(Route::class);
+        $builder->fallbacks(DashedRoute::class);
     });
 };

--- a/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
+++ b/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
@@ -359,7 +359,7 @@ class ActualMealManagementService
     /**
      * 日付の正規化（YYYY-MM-DD 文字列に変換する）。
      */
-    private function normalizeDateString(\DateTimeInterface|string|int|null $value): ?string
+    private function normalizeDateString(\DateTimeInterface|Date|string|int|null $value): ?string
     {
         if ($value instanceof Date) {
             return $value->format('Y-m-d');


### PR DESCRIPTION
Closes #438

## 変更内容

### config/routes.php
- ルートクラスを `Route::class` から `DashedRoute::class` に変更
  - `$routes->setRouteClass()` の引数を変更
  - `$builder->fallbacks()` の引数を変更
- ケバブケースURLが自動的にキャメルケースのアクション名に変換されるようになり、システムエラーが解消

### src/Service/ActualMealManagementService.php
- `normalizeDateString()` メソッドの型宣言に `Date` を追加
  - `\DateTimeInterface|string|int|null` → `\DateTimeInterface|Date|string|int|null`
  - `Cake\I18n\Date` は `\DateTimeInterface` を実装していないため、PHP の型チェックで弾かれ `/TReservationInfo/actual-meal-management` で 500 エラーが発生していた
  - メソッド本体はすでに `instanceof Date` で正しく処理済みだったため、型宣言の修正のみで解消

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ルーティング設定を更新しました。ハイフン形式のルート処理に対応し、ルーターのマッチング・生成の動作を改善しました。
  * 日付正規化の型対応を拡張し、日付オブジェクトを含む入力でも適切に変換できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->