### PR TITLE
Resolve #439: モーダル再利用時の個人予約チェック未反映を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationQueryService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationQueryService.php
@@ -255,22 +255,23 @@ class ReservationQueryService
         string $date
     ): array {
         $reservations = $reservationTable->find()
-            ->select(['i_reservation_type'])
+            ->select(['i_reservation_type', 'i_id_room'])
             ->where([
-                'i_id_user'            => $userId,
-                'd_reservation_date'   => $date,
-                'eat_flag'             => 1,
+                'i_id_user'          => $userId,
+                'd_reservation_date' => $date,
+                'eat_flag'           => 1,
             ])
             ->toArray();
 
-        $mealTypes = [1, 2, 3, 4];
+        // reservation[roomId][mealType] = true の形で返す
         $result = [];
-        foreach ($mealTypes as $mealType) {
-            $result[(string)$mealType] = false;
-        }
         foreach ($reservations as $reservation) {
-            $type = $reservation->i_reservation_type;
-            $result[(string)$type] = true;
+            $roomId = (string)$reservation->i_id_room;
+            $type   = (string)$reservation->i_reservation_type;
+            if (!isset($result[$roomId])) {
+                $result[$roomId] = [];
+            }
+            $result[$roomId][$type] = true;
         }
 
         $authorizedRooms = $this->getAuthorizedRooms($roomTable, $userGroupTable, $userId);

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
@@ -44,7 +44,10 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
 );
 ?>
 <!-- ★ 親の抽出ロジックが最優先で拾うラッパー -->
-<div id="ce-root" <?= $isModal ? 'data-modal="1"' : '' ?>>
+<div id="ce-root"
+    data-personal-url="<?= h($URL_GET_PERSONAL) ?>"
+    <?= $isModal ? 'data-modal="1"' : '' ?>>
+
     <div class="row">
         <aside class="col-md-3" <?= $isModal ? 'style="display:none;"' : '' ?>>
             <div class="list-group">
@@ -92,8 +95,8 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                         <div class="mb-3">
                             <label for="c_reservation_type" class="form-label">予約タイプ(個人/集団)</label>
                             <select id="c_reservation_type" name="reservation_type" class="form-select">
-                                <option value="" selected disabled>-- 予約タイプを選択 --</option>
-                                <option value="1">個人</option>
+                                <option value="" disabled>-- 予約タイプを選択 --</option>
+                                <option value="1" selected>個人</option>
                                 <?php if (in_array((int)$user->get('i_admin'), [1, 3]) || $user->get('i_user_level') == 0): ?>
                                     <option value="2">集団</option>
                                 <?php endif; ?>
@@ -219,9 +222,11 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                             }
 
                             // DOMContentLoaded 依存だとモーダル挿入時に動かないため、即時・冪等バインド
+                            // executeScriptsFrom により再実行されるため DOM スコープフラグで防御する
                             (function bindRoomHeaderSyncOnce(){
-                                if (window.__ADD_BIND_ROOM_SYNC__) return;
-                                window.__ADD_BIND_ROOM_SYNC__ = true;
+                                const ceRootEl = document.getElementById('ce-root');
+                                if (ceRootEl && ceRootEl.dataset.addBindSyncDone) return;
+                                if (ceRootEl) ceRootEl.dataset.addBindSyncDone = '1';
 
                                 const mealTypes = [1, 2, 3, 4];
                                 mealTypes.forEach(mealType => {

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
@@ -199,7 +199,7 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                             // PHP から安全にフルURLを受け取る（reservation-users.js が使用）
                             window.GET_USERS_BY_ROOM_TPL = <?= json_encode($URL_GET_USERS_BY_ROOM_TPL, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) ?>;
                             window.QUERY_DATE            = <?= json_encode($date, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) ?>;
-                            const GET_PERSONAL_URL       = <?= json_encode($URL_GET_PERSONAL, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) ?>;
+                            window.GET_PERSONAL_URL      = <?= json_encode($URL_GET_PERSONAL, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) ?>;
 
                             function toggleAllRooms(mealType, isChecked) {
                                 const checkboxes = document.querySelectorAll(
@@ -375,34 +375,6 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                     });
                             }
 
-                            /* --------------------------------------------------------- */
-                            function fetchPersonalReservationData() {
-                                const url = GET_PERSONAL_URL; // ✅ サーバ生成URLを使用
-                                showLoading();
-                                fetch(url, { credentials: 'same-origin' })
-                                    .then(r => {
-                                        if (!r.ok) throw new Error('HTTP ' + r.status);
-                                        return r.json();
-                                    })
-                                    .then(d => {
-                                        const res = (d && d.data && d.data.reservation) ? d.data.reservation : {};
-                                        document
-                                            .querySelectorAll('#room-checkboxes input[type="checkbox"]')
-                                            .forEach(cb => {
-                                                const m = cb.getAttribute('name').match(/^meals\[(\d+)]/);
-                                                if (!m) return;
-                                                const type = m[1];
-                                                cb.checked = res[type] == true || Number(res[type]) === 1;
-                                                cb.dispatchEvent(new Event('change')); // 排他制御のため
-                                            });
-                                        setupAllRoomPairs();
-                                    })
-                                    .catch(e => {
-                                        console.error('個人予約取得失敗', e);
-                                    })
-                                    .finally(hideLoading);
-                            }
-
                             function fetchUserData(roomId) {
                                 // ✅ ここで __RID__ を確実に置換してからアクセス（%3AroomId のまま飛ばさない）
                                 const url = buildGetUsersByRoomUrl(roomId);
@@ -464,38 +436,6 @@ $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
                                 if (btn) btn.disabled = false;
                             }
 
-                            // --- 初期化（DOM Ready 依存せず即時も呼べるように） ---
-                            function __add_init_once() {
-                                if (window.__ADD_INIT_DONE__) return;
-                                window.__ADD_INIT_DONE__ = true;
-
-                                /* 個人予約テーブル（部屋名エリア）の昼⇄弁当排他 */
-                                document.querySelectorAll('#room-checkboxes tr').forEach(tr => {
-                                    setupLunchBentoPair(
-                                        tr.querySelector('input[name^="meals[2]"]'), // 昼
-                                        tr.querySelector('input[name^="meals[4]"]')  // 弁当
-                                    );
-                                });
-
-                                /* roomId ごとのペアリング（行外にあっても機能） */
-                                setupAllRoomPairs();
-
-                                /* ヘッダーの “全選択” チェックボックス排他 */
-                                setupLunchBentoPair(
-                                    document.getElementById('select-all-room-2'),
-                                    document.getElementById('select-all-room-4')
-                                );
-                                setupLunchBentoPair(
-                                    document.getElementById('select-all-user-noon'),
-                                    document.getElementById('select-all-user-bento')
-                                );
-
-                                /* 個人予約データを取得して反映（排他処理と連動） */
-                                fetchPersonalReservationData();
-                            }
-
-                            // DOM がある環境では直ちに初期化（モーダルでも動く）
-                            try { __add_init_once(); } catch (e) {}
 
                         </script>
                         <!-- ====================== /Script ======================== -->

--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -2,16 +2,66 @@
 /* eslint-disable no-console */
 /* eslint-env browser */
 (function(){
-    function init(container){
-        // 多重初期化防止
-        const root = (container && container.querySelector) ? (container.querySelector('#ce-root') || container) : document;
-        if (root.__ADD_FORM_BOOTED__) return;
-        
-        // If reservation.js has already initialized, skip our form handling
-        if (window.__reservationFormInited && root.querySelector('#reservation-form')) {
+    // モジュールレベルの個人予約取得（毎回フレッシュなDOM参照を使用）
+    async function fetchPersonalReservationData(){
+        // 表示中モーダル内の #ce-root を優先検索
+        const ceRoot = document.querySelector('.modal.show #ce-root')
+            || document.querySelector('.modal #ce-root')
+            || document.getElementById('ce-root')
+            || document;
+
+        // URL: data属性 → window.GET_PERSONAL_URL の順で取得
+        const url = (ceRoot && ceRoot.dataset && ceRoot.dataset.personalUrl)
+            ? ceRoot.dataset.personalUrl
+            : window.GET_PERSONAL_URL;
+
+        if (!url) {
+            console.warn('[ADD_RESERVATION] personal reservation URL が見つかりません');
             return;
         }
-        
+
+        // フレッシュな DOM 参照
+        const roomCheckboxesTbody = ceRoot.querySelector
+            ? ceRoot.querySelector('#room-checkboxes')
+            : document.getElementById('room-checkboxes');
+        const overlay      = ceRoot.querySelector ? ceRoot.querySelector('#loading-overlay')                       : null;
+        const submitButton = ceRoot.querySelector ? ceRoot.querySelector('#reservation-form button[type="submit"]') : null;
+
+        const showLoad = () => { if (overlay) overlay.style.display = 'block'; if (submitButton) submitButton.disabled = true;  };
+        const hideLoad = () => { if (overlay) overlay.style.display = 'none';  if (submitButton) submitButton.disabled = false; };
+
+        showLoad();
+        try {
+            const r = await fetch(url, { credentials: 'same-origin' });
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const d = await r.json();
+            // reservation: { roomId: { mealType: true } }
+            const res = (d && d.data && d.data.reservation) ? d.data.reservation : {};
+            if (roomCheckboxesTbody) {
+                roomCheckboxesTbody.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                    const m = cb.getAttribute('name').match(/^meals\[(\d+)\]\[(\d+)\]/);
+                    if (!m) return;
+                    const [, mealType, roomId] = m;
+                    cb.checked = !!(res[roomId] && res[roomId][mealType]);
+                    cb.dispatchEvent(new Event('change'));
+                });
+            }
+            if (typeof window.setupAllRoomPairs === 'function') {
+                window.setupAllRoomPairs();
+            }
+        } catch(e) {
+            console.error('[ADD_RESERVATION] 個人予約取得失敗:', e);
+        } finally {
+            hideLoad();
+        }
+    }
+    window.fetchPersonalReservationData = fetchPersonalReservationData;
+
+    function init(container){
+        // 多重初期化防止（DOM要素スコープなので毎回モーダル開放時はリセットされる）
+        const root = (container && container.querySelector) ? (container.querySelector('#ce-root') || container) : document;
+        if (root.__ADD_FORM_BOOTED__) return;
+
         root.__ADD_FORM_BOOTED__ = true;
 
         // DOM 参照
@@ -77,36 +127,6 @@
             }
         }
 
-        async function fetchPersonalReservationData(){
-            const url = window.GET_PERSONAL_URL;
-            if (!url) return;
-            showLoading();
-            try {
-                const r = await fetch(url, { credentials: 'same-origin' });
-                if (!r.ok) throw new Error('HTTP ' + r.status);
-                const d = await r.json();
-                // reservation: { roomId: { mealType: true } }
-                const res = (d && d.data && d.data.reservation) ? d.data.reservation : {};
-                if (roomCheckboxesTbody) {
-                    roomCheckboxesTbody.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-                        const m = cb.getAttribute('name').match(/^meals\[(\d+)\]\[(\d+)\]/);
-                        if (!m) return;
-                        const [, mealType, roomId] = m;
-                        cb.checked = !!(res[roomId] && res[roomId][mealType]);
-                        cb.dispatchEvent(new Event('change'));
-                    });
-                }
-                if (typeof window.setupAllRoomPairs === 'function') {
-                    window.setupAllRoomPairs();
-                }
-            } catch(e) {
-                console.error('[ADD_RESERVATION] 個人予約取得失敗:', e);
-            } finally {
-                hideLoading();
-            }
-        }
-        window.fetchPersonalReservationData = fetchPersonalReservationData;
-
         // 個人テーブルの昼⇔弁当の排他（全部屋またぎ）
         function bindRoomTableGuards(){
             if (!roomCheckboxesTbody) return;
@@ -154,8 +174,7 @@
             });
         }
 
-        // Only handle form submission if reservation.js hasn't already initialized it
-        if (form && !window.__reservationFormInited) {
+        if (form) {
             form.addEventListener('submit', (ev) => {
                 ev.preventDefault();
                 
@@ -323,6 +342,9 @@
             const rid = roomSelect?.value || '';
             if (rid) fetchAndRenderUsers(rid);
         }
+
+        // reservation.js が二重バインドしないようにフラグをセット
+        window.__reservationFormInited = true;
     }
 
     // safety wrapper: 明示的呼び出し用のラッパー（loadInto 等から安全に呼べる）
@@ -352,11 +374,10 @@
     document.addEventListener('shown.bs.modal', (ev) => {
         const modal = ev.target;
         if (!modal) return;
-        // Only handle if reservation.js hasn't already initialized
-        if (modal.querySelector?.('#reservation-form') && !window.__reservationFormInited) {
+        if (modal.querySelector?.('#reservation-form')) {
+            // loadInto() で既に init 済みの場合は root.__ADD_FORM_BOOTED__ で防がれる
             window.ADD_RESERVATION.safeInit(modal);
-            
-            // 排他制御を適用
+
             requestAnimationFrame(() => {
                 if (typeof window.applyLunchBentoExclusion === 'function') {
                     window.applyLunchBentoExclusion(modal);

--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -77,6 +77,35 @@
             }
         }
 
+        async function fetchPersonalReservationData(){
+            const url = window.GET_PERSONAL_URL;
+            if (!url) return;
+            showLoading();
+            try {
+                const r = await fetch(url, { credentials: 'same-origin' });
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                const d = await r.json();
+                const res = (d && d.data && d.data.reservation) ? d.data.reservation : {};
+                if (roomCheckboxesTbody) {
+                    roomCheckboxesTbody.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                        const m = cb.getAttribute('name').match(/^meals\[(\d+)]/);
+                        if (!m) return;
+                        const type = m[1];
+                        cb.checked = res[type] == true || Number(res[type]) === 1;
+                        cb.dispatchEvent(new Event('change'));
+                    });
+                }
+                if (typeof window.setupAllRoomPairs === 'function') {
+                    window.setupAllRoomPairs();
+                }
+            } catch(e) {
+                console.error('[ADD_RESERVATION] 個人予約取得失敗:', e);
+            } finally {
+                hideLoading();
+            }
+        }
+        window.fetchPersonalReservationData = fetchPersonalReservationData;
+
         // 個人テーブルの昼⇔弁当の排他（全部屋またぎ）
         function bindRoomTableGuards(){
             if (!roomCheckboxesTbody) return;
@@ -102,7 +131,9 @@
                 const val = e.target.value;
                 toggleReservationTypeDisplay(val);
 
-                if (String(val) === '2') { // 集団
+                if (String(val) === '1') { // 個人
+                    fetchPersonalReservationData();
+                } else if (String(val) === '2') { // 集団
                     const rid = roomSelect?.value || '';
                     if (rid) fetchAndRenderUsers(rid);
                 }
@@ -264,9 +295,27 @@
         // ★★★ 修正: 初期表示ロジックの修正 ★★★
         bindRoomTableGuards();
         const initialTypeRaw = reservationTypeSel?.value;
-        // 予約タイプが未選択の場合でも `toggleReservationTypeDisplay` を呼び出すことで、
-        // デフォルト（個人）の表示が適用されるようにする
         toggleReservationTypeDisplay(initialTypeRaw);
+
+        // ヘッダーの "全選択" チェックボックス昼⇄弁当排他
+        if (typeof window.setupLunchBentoPair === 'function') {
+            window.setupLunchBentoPair(
+                root.querySelector('#select-all-room-2'),
+                root.querySelector('#select-all-room-4')
+            );
+            window.setupLunchBentoPair(
+                root.querySelector('#select-all-user-noon'),
+                root.querySelector('#select-all-user-bento')
+            );
+        }
+        if (typeof window.setupAllRoomPairs === 'function') {
+            window.setupAllRoomPairs();
+        }
+
+        // 個人モード（type=1 または未選択のデフォルト）なら既存予約を取得して反映
+        if (!initialTypeRaw || String(initialTypeRaw) === '1') {
+            fetchPersonalReservationData();
+        }
 
         // もし初期タイプが集団なら、利用者取得を試みる
         if (String(initialTypeRaw) === '2') {

--- a/src_web/kamaho-shokusu/webroot/js/add.js
+++ b/src_web/kamaho-shokusu/webroot/js/add.js
@@ -85,13 +85,14 @@
                 const r = await fetch(url, { credentials: 'same-origin' });
                 if (!r.ok) throw new Error('HTTP ' + r.status);
                 const d = await r.json();
+                // reservation: { roomId: { mealType: true } }
                 const res = (d && d.data && d.data.reservation) ? d.data.reservation : {};
                 if (roomCheckboxesTbody) {
                     roomCheckboxesTbody.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-                        const m = cb.getAttribute('name').match(/^meals\[(\d+)]/);
+                        const m = cb.getAttribute('name').match(/^meals\[(\d+)\]\[(\d+)\]/);
                         if (!m) return;
-                        const type = m[1];
-                        cb.checked = res[type] == true || Number(res[type]) === 1;
+                        const [, mealType, roomId] = m;
+                        cb.checked = !!(res[roomId] && res[roomId][mealType]);
                         cb.dispatchEvent(new Event('change'));
                     });
                 }

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1831,7 +1831,9 @@ function unlockForChildren(wrap){
                         return r.json();
                     })
                     .then(function(d){
-                        var users = d && d.usersByRoom;
+                        var users = (d && d.data && Array.isArray(d.data.usersByRoom))
+                            ? d.data.usersByRoom
+                            : (d && Array.isArray(d.usersByRoom) ? d.usersByRoom : null);
                         if (!Array.isArray(users)) {
                             throw new Error('usersByRoom が配列ではありません');
                         }

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1054,6 +1054,10 @@ function unlockForChildren(wrap){
                     if (!window.__IS_STAFF) { observeChildUnlock(container); }
                 }
 
+                // innerHTML はスクリプトを実行しないため、注入されたインラインスクリプトを手動実行する
+                // change_edit.php の INDIV_DATA/setType 初期化、add.php の変数設定が対象
+                await executeScriptsFrom(container);
+
                 var host = container.closest('.modal') || container;
 
                 // ★★★★★ ここからが修正箇所 ★★★★★
@@ -1453,7 +1457,9 @@ function unlockForChildren(wrap){
                         return r.json();
                     })
                     .then(function(d){
-                        var users = d && d.usersByRoom;
+                        var users = (d && d.data && Array.isArray(d.data.usersByRoom))
+                            ? d.data.usersByRoom
+                            : (d && Array.isArray(d.usersByRoom) ? d.usersByRoom : null);
                         if (!Array.isArray(users)) {
                             throw new Error('usersByRoom が配列ではありません');
                         }


### PR DESCRIPTION
Closes #439

## 変更内容

### `add.js`
- `fetchPersonalReservationData()` を `init()` 内部からモジュールレベルに移動し、毎回フレッシュな DOM 参照を使用するよう変更
- `window.__reservationFormInited` による早期リターンを除去し、2回目以降のモーダル開放時も `init()` が確実に実行されるよう修正
- `init()` 末尾で `window.__reservationFormInited = true` をセットし `reservation.js` の二重バインドを防止
- フォーム送信ハンドラーの `!window.__reservationFormInited` ガードを除去（DOM スコープの `root.__ADD_FORM_BOOTED__` で制御）
- `shown.bs.modal` ハンドラーから `window.__reservationFormInited` チェックを除去

### `add.php`
- `#ce-root` に `data-personal-url` 属性を追加し、AJAX読み込み時にインラインスクリプトが実行されなくても個人予約取得 URL を正しく参照できるよう対応
- デフォルト予約タイプを「個人」(value="1", selected) に変更（従来は空プレースホルダー）
- `bindRoomHeaderSyncOnce` のガードをグローバルフラグ（`window.__ADD_BIND_ROOM_SYNC__`）から DOM スコープフラグ（`ceRoot.dataset.addBindSyncDone`）に変更し、モーダル再開放時に正しく再バインドされるよう修正

### `treservation_index.js` / `treservation_index.inline.js`
- `loadInto()` に `await executeScriptsFrom(container)` を追加し、AJAX注入された `change_edit.php` のインラインスクリプト（`INDIV_DATA`・`setType()` 初期化）が確実に実行されるよう修正
- `fetchUserData()` の `usersByRoom` 参照を `d.data.usersByRoom → d.usersByRoom` の順でフォールバックするよう修正（APIレスポンスが `{ ok: true, data: { usersByRoom: [...] } }` 形式のため）

### `ReservationQueryService.php`
- `getPersonalReservationData()` で `i_id_room` も SELECT し、レスポンスを `reservation[roomId][mealType] = true` の形式に変更（部屋をまたいだ誤チェックを防止）