### PR TITLE
fix: JSアセットにタイムスタンプを付与しブラウザキャッシュを無効化

### DIFF
--- a/src_web/kamaho-shokusu/config/app.php
+++ b/src_web/kamaho-shokusu/config/app.php
@@ -91,7 +91,7 @@ return [
      * enable timestamping regardless of debug value.
      */
     'Asset' => [
-        //'timestamp' => true,
+        'timestamp' => 'force',
         // 'cacheTime' => '+1 year'
     ],
 


### PR DESCRIPTION
## 変更内容

- `config/app.php` の `Asset.timestamp` を `'force'` に設定

## 背景

PR #444 のマージ後、ステージング環境でも修正が反映されていない現象が発生。
調査の結果、ブラウザが古い `add.js` / `treservation_index.js` をキャッシュしていたことが原因と判明。

`'force'` 設定により、CakePHP の `Html->script()` / `Html->css()` ヘルパーが生成するURLに
ファイルの最終更新時刻がクエリパラメータとして自動付与される（例: `add.js?1750410000`）。
これにより、デプロイのたびに自動でキャッシュがバストされる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 静的アセット（JavaScript、CSS、画像）のキャッシング動作を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->