### PR TITLE
fix: add.php のAPI URLを相対URLに変更しMixed Content エラーを解消

### DIFF
--- a/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/add.php
@@ -33,14 +33,12 @@ if (!isset($rooms[$defaultRoomId])) {
 
 // ✅ サーバ側でフルURLを作成（モーダル/サブディレクトリ対応）
 $URL_GET_PERSONAL = $this->Url->build(
-        ['controller' => 'TReservationInfo', 'action' => 'getPersonalReservation', '?' => ['date' => $date]],
-        ['fullBase' => true]
+        ['controller' => 'TReservationInfo', 'action' => 'getPersonalReservation', '?' => ['date' => $date]]
 );
 
 // ✅ 「:roomId」ではなく無害なトークン __RID__ を含むテンプレURLを生成（JS で置換）
 $URL_GET_USERS_BY_ROOM_TPL = $this->Url->build(
-        ['controller' => 'TReservationInfo', 'action' => 'getUsersByRoom', '__RID__'],
-        ['fullBase' => true]
+        ['controller' => 'TReservationInfo', 'action' => 'getUsersByRoom', '__RID__']
 );
 ?>
 <!-- ★ 親の抽出ロジックが最優先で拾うラッパー -->


### PR DESCRIPTION
## 変更内容

- `templates/TReservationInfo/add.php` の `$URL_GET_PERSONAL` と `$URL_GET_USERS_BY_ROOM_TPL` の生成を `fullBase => true`（絶対URL）から相対URLに変更

## 背景・原因

PR #444 で個人予約チェックボックスの反映修正を行ったが、ステージング（HTTPS）では依然として反映されなかった。

調査の結果、`$this->Url->build(..., ['fullBase' => true])` が `http://` の絶対URLを生成していたことが原因と判明。  
ステージングはHTTPSで配信されているため、ブラウザが「Mixed Content」としてHTTPのfetchリクエストをブロックしていた。

## 修正方針

`fullBase => true` を削除して相対URL（例: `/kamaho-shokusu/TReservationInfo/getPersonalReservation?date=...`）を使用するよう変更。  
相対URLはHTTP・HTTPSいずれの環境でも動作し、Mixed Contentが発生しない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 予約情報の処理において、URL生成方式の改善を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->