### PR TITLE
fix: 直前編集/通常予約モーダルの日付切り替えを復元

### DIFF
--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.inline.js
@@ -1590,9 +1590,10 @@ function unlockForChildren(wrap){
 
         window.quickOpenDayModal = function(dateStr){
             try{
-                applyQuickModalMode(dateStr, false);
+                var useChange = typeof isWithin14 === 'function' ? isWithin14(dateStr) : false;
+                applyQuickModalMode(dateStr, useChange);
                 openModalById('quickDayModal');
-                loadViewIntoModal(dateStr, false).catch(function(){});
+                loadViewIntoModal(dateStr, useChange).catch(function(){});
             } catch(e){
                 openModalById('quickDayModal');
             }

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1216,9 +1216,10 @@ function unlockForChildren(wrap){
 
         window.quickOpenDayModal = function(dateStr){
             try{
-                applyQuickModalMode(dateStr, false);
+                var useChange = typeof isWithin14 === 'function' ? isWithin14(dateStr) : false;
+                applyQuickModalMode(dateStr, useChange);
                 openModalById('quickDayModal');
-                loadViewIntoModal(dateStr, false).catch(function(){});
+                loadViewIntoModal(dateStr, useChange).catch(function(){});
             } catch(e){
                 openModalById('quickDayModal');
             }


### PR DESCRIPTION
## 変更内容

- `treservation_index.js` / `treservation_index.inline.js` の `quickOpenDayModal` で `isWithin14` による `changeEdit/add` 切り替えを復活

## 背景

コミット `2766ee6`（feat: 直前編集モーダルを通常予約(add)画面に統一）で日付に基づくモーダル切り替えが廃止されていたが、直前編集を廃止する方針はまだ出ていないため元の挙動に戻す。

## 修正内容

```js
// 修正前（常に通常予約モーダル）
applyQuickModalMode(dateStr, false);
loadViewIntoModal(dateStr, false);

// 修正後（14日以内なら直前編集モーダル）
var useChange = typeof isWithin14 === 'function' ? isWithin14(dateStr) : false;
applyQuickModalMode(dateStr, useChange);
loadViewIntoModal(dateStr, useChange);
```

- 14日以内の日付をクリック → `change_edit.php`（直前編集モーダル、黄色ヘッダー）
- 15日以降の日付をクリック → `add.php`（通常予約モーダル、青ヘッダー）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善
* 食数予約画面で日付を選択する際、対象日が14日以内の場合は編集モード、14日以上先の場合は新規追加モードで予約モーダルが開くようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->