### PR TITLE
fix: デプロイ後にOPcacheクリアのためstg_webコンテナを再起動

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -174,6 +174,11 @@ jobs:
             docker compose -f docker-compose.staging.yml --env-file .env.staging up -d --no-build --remove-orphans
             docker image prune -f
 
+            # ── OPcache クリアのためコンテナを再起動 ─────────────────────────
+            # Dockerfileが変わらない場合イメージSHAが同一になり up -d がコンテナを
+            # 再作成しない。OPcacheが古いバイトコードを保持し続けるためリスタートが必要。
+            docker restart stg_web
+
             # ── Composer install (composer.lock が変わった時のみ実行) ─────────
             LOCK_FILE="${DEPLOY_PATH}/src_web/kamaho-shokusu/composer.lock"
             HASH_CACHE="/tmp/shokusuu1_composer_lock_hash"


### PR DESCRIPTION
Closes #(関連なし)

## 原因

Dockerfileが変更されない場合、GitHub Actions のレイヤーキャッシュ（`type=gha`）により
ビルドされるDockerイメージのSHAが前回と同一になる。

`docker compose up -d` はイメージSHAが変わらない場合コンテナを再作成しないため、
OPcacheが古いPHPバイトコードをキャッシュし続ける。

結果として `git reset --hard` でソースを更新しても画面が変わらない現象が発生していた。

## 変更内容

- `docker compose up -d` の後に `docker restart stg_web` を追加
- これによりデプロイのたびにコンテナが再起動され、OPcacheがクリアされる

## 確認方法

1. このPRをdevelopにmerge
2. deployワークフローが自動実行される
3. ステージングで最新のPHPが反映されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境のデプロイプロセスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->