### PR TITLE
fix: 直前編集画面のルーティング修正・UI全面改善

### DIFF
--- a/.github/workflows/stg-investigate.yml
+++ b/.github/workflows/stg-investigate.yml
@@ -36,8 +36,36 @@ jobs:
               -e "SHOW TABLES;" 2>&1
 
             echo ""
+            echo "=== git log (staging) ==="
+            cd /home/ubuntu/shokusuu1 && git log --oneline -5
+
+            echo ""
+            echo "=== change_edit.php の新UI確認 ==="
+            docker exec stg_web grep -c "alert-warning" /var/www/html/kamaho-shokusu/templates/TReservationInfo/change_edit.php 2>&1 || echo "not found"
+            docker exec stg_web grep -c "card-header" /var/www/html/kamaho-shokusu/templates/TReservationInfo/change_edit.php 2>&1 || echo "not found"
+
+            echo ""
+            echo "=== m_user_group の active_flag 分布 ==="
+            docker exec stg_db mysql -u root -p"${DB_ROOT_PASS}" "${DB_NAME}" \
+              -e "SELECT active_flag, COUNT(*) as cnt FROM m_user_group GROUP BY active_flag;" 2>&1
+
+            echo ""
+            echo "=== m_user_group ユーザー詳細（active_flag=0） ==="
+            docker exec stg_db mysql -u root -p"${DB_ROOT_PASS}" "${DB_NAME}" \
+              -e "SELECT ug.i_id_user, ui.c_user_name, ui.i_user_level, ui.i_admin, ug.i_id_room, ri.c_room_name, ug.active_flag FROM m_user_group ug LEFT JOIN m_user_info ui ON ug.i_id_user = ui.i_id_user LEFT JOIN m_room_info ri ON ug.i_id_room = ri.i_id_room WHERE ug.active_flag = 0 ORDER BY ug.i_id_user;" 2>&1
+
+            echo ""
+            echo "=== m_user_info 全ユーザー ==="
+            docker exec stg_db mysql -u root -p"${DB_ROOT_PASS}" "${DB_NAME}" \
+              -e "SELECT i_id_user, c_user_name, i_user_level, i_admin, i_del_flag FROM m_user_info ORDER BY i_id_user;" 2>&1
+
+            echo ""
+            echo "=== 最新エラーログ changeEdit関連 ==="
+            docker exec stg_web grep -i "changeEdit\|change.edit\|allowed.*room\|403\|forbidden" /var/www/html/kamaho-shokusu/logs/error.log 2>&1 | tail -20
+
+            echo ""
             echo "=== 最新エラーログ (DebugKit除外) ==="
-            docker exec stg_web grep -v "DebugKit" /var/www/html/kamaho-shokusu/logs/error.log 2>&1 | tail -60
+            docker exec stg_web grep -v "DebugKit" /var/www/html/kamaho-shokusu/logs/error.log 2>&1 | tail -30
 
             echo ""
             echo "=== m_room_transfer_schedule の現在のデータ ==="

--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -105,6 +105,30 @@ return function (RouteBuilder $routes): void {
                 'mealType' => '\d+',
             ]);
 
+        // ce-change-edit.js が生成するURLはダッシュ区切りアクション名を使うため明示的にルートを登録する
+        $builder->connect(
+            '/TReservationInfo/change-edit/{roomId}/{date}/{mealType}',
+            ['controller' => 'TReservationInfo', 'action' => 'changeEdit']
+        )
+            ->setPass(['roomId', 'date', 'mealType'])
+            ->setPatterns([
+                'roomId'   => '\d+',
+                'date'     => '\d{4}-\d{2}-\d{2}',
+                'mealType' => '[1-4]',
+            ])
+            ->setMethods(['GET', 'POST', 'PUT']);
+
+        $builder->connect(
+            '/TReservationInfo/change-edit/{roomId}/{date}',
+            ['controller' => 'TReservationInfo', 'action' => 'changeEdit']
+        )
+            ->setPass(['roomId', 'date'])
+            ->setPatterns([
+                'roomId' => '\d+',
+                'date'   => '\d{4}-\d{2}-\d{2}',
+            ])
+            ->setMethods(['GET', 'POST']);
+
         // ===== 小文字パス（API） =====
         // 3セグメント版（従来：{roomId}/{date}/{mealType}）
         // ※ changeEdit は TReservationInfoController に実装されているため controller を揃える

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -19,7 +19,13 @@ if (isset($room) && is_object($room)) {
 $basePath = $this->Url->build('/', ['fullBase' => false]);
 $mealType = $this->request->getParam('mealType') ?? $this->request->getQuery('mealType') ?? 2;
 $isModal  = (string)($this->request->getQuery('modal') ?? '') === '1';
+
+$weekMap = ['日','月','火','水','木','金','土'];
+$weekday = isset($date) ? ($weekMap[(int)date('w', strtotime($date))] ?? '') : '';
+
+echo $this->Html->css('pages/t_reservation_add.css');
 echo $this->Html->css('pages/t_reservation_change_edit.css');
+echo $this->Html->meta('csrfToken', $this->request->getAttribute('csrfToken'));
 
 $indivJson = json_encode(
     array_values(array_map(fn($r) => [
@@ -57,154 +63,209 @@ $indivJson = json_encode(
                     <h3><?= __('直前編集') ?></h3>
                 </div>
                 <div class="card-body">
-
-                    <!-- 予約タイプ切替 -->
-                    <div class="mb-3">
-                        <label for="ce-type-select" class="form-label">予約タイプ(個人/集団)</label>
-                        <select id="ce-type-select" class="form-select">
-                            <option value="2">集団（利用者別）</option>
-                            <option value="1">個人（部屋別）</option>
-                        </select>
-                    </div>
-
-                    <!-- 集団：氏名検索 + 部屋選択 -->
-                    <div id="ce-group-toolbar" class="mb-3">
-                        <input type="search" id="ce-name-search" class="form-control mb-2"
-                               placeholder="氏名で絞り込み" autocomplete="off">
-                        <?php if (!empty($rooms) && count($rooms) > 1): ?>
-                            <?= $this->Form->control('i_id_room', [
-                                'type'      => 'select',
-                                'label'     => false,
-                                'options'   => $rooms,
-                                'empty'     => false,
-                                'value'     => $selectedRoomId,
-                                'class'     => 'form-select',
-                                'required'  => true,
-                                'id'        => 'ce-room-select',
-                                'data-date' => $date,
-                            ]) ?>
-                        <?php elseif ($selectedRoomId): ?>
-                            <span class="text-muted small"><?= h($selectedRoomName ?: '（部屋未設定）') ?></span>
-                        <?php endif; ?>
-                    </div>
-
-                    <!-- 集団：食数サマリー -->
-                    <div id="ce-group-summary" class="mb-3 p-2 bg-light rounded">
-                        <span class="fw-semibold me-2">食数：</span>
-                        <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
-                        <span class="ms-3">昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
-                        <span class="ms-3">夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名</span>
-                        <span class="ms-3">弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
-                    </div>
-
-                    <!-- フォーム -->
                     <?= $this->Form->create(null, ['id' => 'change-edit-form', 'url' => ['action' => 'changeEdit']]) ?>
-                    <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
-                    <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
-                    <?= $this->Form->hidden('reservation_type', ['value' => '2', 'id' => 'ce-reservation-type-hidden']) ?>
-                    <?php if ($selectedRoomId): ?>
-                        <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
-                    <?php endif; ?>
+                    <fieldset class="form-section">
+                        <legend><?= __('食数予約') ?></legend>
 
-                    <!-- ■ 個人予約セクション ■ -->
-                    <div id="ce-individual-section" class="mb-3" style="display:none;">
-                        <label class="form-label">部屋名と食事選択</label>
-                        <div class="table-responsive">
-                            <table class="table table-sm table-bordered" id="ce-room-table">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th class="text-start">部屋名</th>
-                                        <th class="text-center">朝</th>
-                                        <th class="text-center">昼</th>
-                                        <th class="text-center">夕</th>
-                                        <th class="text-center">弁当</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="ce-room-tbody">
-                                    <?php foreach ($rooms as $rid => $rname): ?>
-                                    <tr data-room-id="<?= h($rid) ?>">
-                                        <td><?= h($rname) ?></td>
-                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[1][<?= h($rid) ?>]" value="1"></td>
-                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[2][<?= h($rid) ?>]" value="1"></td>
-                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[3][<?= h($rid) ?>]" value="1"></td>
-                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[4][<?= h($rid) ?>]" value="1"></td>
-                                    </tr>
-                                    <?php endforeach; ?>
-                                </tbody>
-                            </table>
+                        <!-- 予約日 -->
+                        <div class="row mb-3">
+                            <?= $this->Form->label('d_reservation_date', '予約日', ['class' => 'col-sm-3 col-form-label']) ?>
+                            <div class="col-sm-9">
+                                <div class="d-flex align-items-center">
+                                    <?= $this->Form->control('d_reservation_date', [
+                                        'type'     => 'date',
+                                        'label'    => false,
+                                        'class'    => 'form-control',
+                                        'disabled' => true,
+                                        'value'    => $date,
+                                    ]) ?>
+                                    <span class="ms-2">(<?= h($weekday) ?>)</span>
+                                </div>
+                            </div>
                         </div>
-                    </div>
 
-                    <!-- ■ 集団予約セクション ■ -->
-                    <div id="ce-group-section" class="mb-3">
-                        <label class="form-label">部屋に属する利用者と食事選択</label>
-                        <div class="table-responsive">
-                            <table class="table table-sm table-bordered" id="ce-table">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th class="text-start">氏名</th>
-                                        <th class="text-center">朝<br><input type="checkbox" class="form-check-input" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
-                                        <th class="text-center">昼<br><input type="checkbox" class="form-check-input" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
-                                        <th class="text-center">夕<br><input type="checkbox" class="form-check-input" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
-                                        <th class="text-center">弁当<br><input type="checkbox" class="form-check-input" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
-                                    </tr>
-                                </thead>
-                                <tbody id="ce-tbody">
-                                    <tr>
-                                        <td colspan="5" class="text-center py-4 text-muted">
-                                            <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                        <!-- hidden fields -->
+                        <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
+                        <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
+                        <?= $this->Form->hidden('reservation_type', ['value' => '2', 'id' => 'ce-reservation-type-hidden']) ?>
+                        <?php if ($selectedRoomId): ?>
+                            <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
+                        <?php endif; ?>
+
+                        <!-- 予約タイプ -->
+                        <div class="mb-3">
+                            <label for="ce-type-select" class="form-label">予約タイプ(個人/集団)</label>
+                            <select id="ce-type-select" class="form-select">
+                                <option value="" disabled>-- 予約タイプを選択 --</option>
+                                <option value="1">個人</option>
+                                <option value="2">集団（利用者別）</option>
+                            </select>
                         </div>
-                    </div>
 
-                    <!-- フッター -->
+                        <!-- 個人：部屋ごとのチェック -->
+                        <div class="mb-3 d-none" id="ce-individual-section">
+                            <?= $this->Form->label('rooms', '部屋名と食事選択', ['class' => 'form-label']) ?>
+                            <div class="table-responsive">
+                                <table class="table table-bordered mb-0" id="ce-room-table">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th scope="col">部屋名</th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-room-1">朝</label>
+                                                <input type="checkbox" id="select-all-room-1">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-room-2">昼</label>
+                                                <input type="checkbox" id="select-all-room-2">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-room-3">夕</label>
+                                                <input type="checkbox" id="select-all-room-3">
+                                            </th>
+                                            <th scope="col" class="text-center">
+                                                <label for="select-all-room-4">弁当</label>
+                                                <input type="checkbox" id="select-all-room-4">
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="ce-room-tbody">
+                                        <?php foreach ($rooms as $rid => $rname): ?>
+                                        <tr data-room-id="<?= h($rid) ?>">
+                                            <td><?= h($rname) ?></td>
+                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[1][<?= h($rid) ?>]" value="1"></td>
+                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[2][<?= h($rid) ?>]" value="1"></td>
+                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[3][<?= h($rid) ?>]" value="1"></td>
+                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[4][<?= h($rid) ?>]" value="1"></td>
+                                        </tr>
+                                        <?php endforeach; ?>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <!-- 集団：氏名検索 + 部屋選択 -->
+                        <div id="ce-group-toolbar" class="mb-3 d-none">
+                            <input type="search" id="ce-name-search" class="form-control mb-2"
+                                   placeholder="氏名で絞り込み" autocomplete="off">
+                            <?php if (!empty($rooms) && count($rooms) > 1): ?>
+                                <?= $this->Form->label('ce-room-select', '部屋を選択', ['class' => 'form-label']) ?>
+                                <?= $this->Form->control('i_id_room', [
+                                    'type'      => 'select',
+                                    'label'     => false,
+                                    'options'   => $rooms,
+                                    'empty'     => false,
+                                    'value'     => $selectedRoomId,
+                                    'class'     => 'form-select',
+                                    'required'  => true,
+                                    'id'        => 'ce-room-select',
+                                    'data-date' => $date,
+                                ]) ?>
+                            <?php elseif ($selectedRoomId): ?>
+                                <span class="text-muted small"><?= h($selectedRoomName ?: '（部屋未設定）') ?></span>
+                            <?php endif; ?>
+                        </div>
+
+                        <!-- 集団：食数サマリー -->
+                        <div id="ce-group-summary" class="mb-3 p-2 bg-light rounded d-none">
+                            <span class="fw-semibold me-2">食数：</span>
+                            <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
+                            <span class="ms-3">昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
+                            <span class="ms-3">夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名</span>
+                            <span class="ms-3">弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
+                        </div>
+
+                        <!-- 集団：利用者テーブル -->
+                        <div id="ce-group-section" class="mb-3 d-none">
+                            <?= $this->Form->label('users', '部屋に属する利用者と食事選択', ['class' => 'form-label']) ?>
+                            <div class="table-responsive">
+                                <table class="table table-bordered mb-0" id="ce-table">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th scope="col" class="text-start">氏名</th>
+                                            <th scope="col" class="text-center">朝<br><input type="checkbox" class="form-check-input" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
+                                            <th scope="col" class="text-center">昼<br><input type="checkbox" class="form-check-input" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
+                                            <th scope="col" class="text-center">夕<br><input type="checkbox" class="form-check-input" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
+                                            <th scope="col" class="text-center">弁当<br><input type="checkbox" class="form-check-input" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="ce-tbody">
+                                        <tr>
+                                            <td colspan="5" class="text-center py-4 text-muted">
+                                                <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <script>
+                        (function(){
+                            var INDIV_DATA   = <?= $indivJson ?>;
+                            var typeHidden   = document.getElementById('ce-reservation-type-hidden');
+                            var groupToolbar = document.getElementById('ce-group-toolbar');
+                            var groupSummary = document.getElementById('ce-group-summary');
+                            var indivSection = document.getElementById('ce-individual-section');
+                            var groupSection = document.getElementById('ce-group-section');
+                            var _prefilled   = false;
+
+                            function showEl(el){ if (el) el.classList.remove('d-none'); }
+                            function hideEl(el){ if (el) el.classList.add('d-none'); }
+
+                            function setType(val) {
+                                if (typeHidden) typeHidden.value = val;
+                                var isIndiv = (val === '1');
+                                if (isIndiv) {
+                                    showEl(indivSection);
+                                    hideEl(groupToolbar);
+                                    hideEl(groupSummary);
+                                    hideEl(groupSection);
+                                } else {
+                                    hideEl(indivSection);
+                                    showEl(groupToolbar);
+                                    showEl(groupSummary);
+                                    showEl(groupSection);
+                                }
+                                if (isIndiv && !_prefilled) {
+                                    _prefilled = true;
+                                    INDIV_DATA.forEach(function(r) {
+                                        var cb = document.querySelector('input[name="meals[' + r.type + '][' + r.room_id + ']"]');
+                                        if (cb) cb.checked = true;
+                                    });
+                                }
+                            }
+
+                            var typeSelect = document.getElementById('ce-type-select');
+                            if (typeSelect) {
+                                typeSelect.addEventListener('change', function() { setType(this.value); });
+                            }
+
+                            if (typeSelect) typeSelect.value = '2';
+                            setType('2');
+                        })();
+                        </script>
+
+                    </fieldset>
+
+                    <!-- 送信ボタン & ローディング -->
                     <div class="d-flex align-items-center justify-content-between mt-3">
                         <span id="ce-change-count" class="text-muted small me-auto"></span>
                         <span id="ce-save-spinner" class="text-muted small me-2">
                             <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>保存中...
                         </span>
-                        <button type="submit" class="btn btn-primary btn-sm" id="ce-save-btn">変更を保存</button>
+                        <button type="submit" class="btn btn-primary" id="ce-save-btn">変更を保存</button>
                     </div>
-
+                    <div id="loading-overlay"
+                         role="status"
+                         aria-live="polite"
+                         aria-label="処理中"
+                         style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.5); z-index: 9999; text-align: center;">
+                        <div style="position: relative; top: 50%; transform: translateY(-50%);">
+                            <div class="spinner-border text-info" aria-hidden="true"></div>
+                            <p style="color: white; margin-top: 10px;">処理中です。少々お待ちください...</p>
+                        </div>
+                    </div>
                     <?= $this->Form->end() ?>
-
-                    <script>
-                    (function(){
-                        var INDIV_DATA   = <?= $indivJson ?>;
-                        var typeHidden   = document.getElementById('ce-reservation-type-hidden');
-                        var groupToolbar = document.getElementById('ce-group-toolbar');
-                        var groupSummary = document.getElementById('ce-group-summary');
-                        var indivSection = document.getElementById('ce-individual-section');
-                        var groupSection = document.getElementById('ce-group-section');
-                        var _prefilled   = false;
-
-                        function setType(val) {
-                            if (typeHidden) typeHidden.value = val;
-                            var isIndiv = (val === '1');
-                            if (indivSection) indivSection.style.display = isIndiv ? '' : 'none';
-                            if (groupSection) groupSection.style.display = isIndiv ? 'none' : '';
-                            if (groupToolbar) groupToolbar.style.display = isIndiv ? 'none' : '';
-                            if (groupSummary) groupSummary.style.display = isIndiv ? 'none' : '';
-                            if (isIndiv && !_prefilled) {
-                                _prefilled = true;
-                                INDIV_DATA.forEach(function(r) {
-                                    var cb = document.querySelector('input[name="meals[' + r.type + '][' + r.room_id + ']"]');
-                                    if (cb) cb.checked = true;
-                                });
-                            }
-                        }
-
-                        var typeSelect = document.getElementById('ce-type-select');
-                        if (typeSelect) {
-                            typeSelect.addEventListener('change', function() { setType(this.value); });
-                        }
-
-                        setType('2');
-                    })();
-                    </script>
 
                 </div><!-- /.card-body -->
             </div><!-- /.card -->

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -23,8 +23,8 @@ $isModal  = (string)($this->request->getQuery('modal') ?? '') === '1';
 $weekMap = ['日','月','火','水','木','金','土'];
 $weekday = isset($date) ? ($weekMap[(int)date('w', strtotime($date))] ?? '') : '';
 
-echo $this->Html->css('pages/t_reservation_add.css');
-echo $this->Html->css('pages/t_reservation_change_edit.css');
+$this->Html->css('pages/t_reservation_add.css', ['block' => 'css']);
+$this->Html->css('pages/t_reservation_change_edit.css', ['block' => 'css']);
 echo $this->Html->meta('csrfToken', $this->request->getAttribute('csrfToken'));
 
 $indivJson = json_encode(

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/change_edit.php
@@ -23,6 +23,16 @@ $isModal  = (string)($this->request->getQuery('modal') ?? '') === '1';
 $weekMap = ['日','月','火','水','木','金','土'];
 $weekday = isset($date) ? ($weekMap[(int)date('w', strtotime($date))] ?? '') : '';
 
+$mealLabels = [1 => '朝食', 2 => '昼食', 3 => '夕食', 4 => '弁当'];
+$mealBadgeClasses = [
+    1 => 'bg-warning text-dark',
+    2 => 'bg-success',
+    3 => 'bg-primary',
+    4 => 'bg-info text-dark',
+];
+$mealLabel      = $mealLabels[(int)$mealType]      ?? "食種{$mealType}";
+$mealBadgeClass = $mealBadgeClasses[(int)$mealType] ?? 'bg-secondary';
+
 $this->Html->css('pages/t_reservation_add.css', ['block' => 'css']);
 $this->Html->css('pages/t_reservation_change_edit.css', ['block' => 'css']);
 echo $this->Html->meta('csrfToken', $this->request->getAttribute('csrfToken'));
@@ -40,13 +50,20 @@ $indivJson = json_encode(
      data-date="<?= h($date) ?>"
      data-mealtype="<?= h($mealType) ?>">
 
-    <!-- 直前編集警告バナー -->
-    <div class="alert alert-warning d-flex align-items-start gap-2 mb-3 py-2" role="alert">
-        <i class="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0"></i>
-        <div>
-            <strong>直前編集（当日〜14日以内）</strong>：発注済みです。変更内容をよく確認してください。<br>
-            職員の既存予約の削除はできません。新規追加のみ可能です。
+    <!-- 直前編集警告バナー（日付・食種を明示） -->
+    <div class="alert alert-warning mb-3" role="alert">
+        <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-1">
+            <span class="fw-bold">
+                <i class="bi bi-exclamation-triangle-fill me-1"></i>直前編集（発注済み期間）
+            </span>
+            <span class="d-flex gap-2 align-items-center">
+                <span class="badge bg-dark fs-6"><?= h($date) ?>（<?= h($weekday) ?>）</span>
+                <span class="badge <?= h($mealBadgeClass) ?> fs-6"><?= h($mealLabel) ?></span>
+            </span>
         </div>
+        <small class="text-body-secondary">
+            変更内容をよく確認してください。職員の既存予約は削除できません（追加のみ可能）。
+        </small>
     </div>
 
     <div class="row">
@@ -64,188 +81,126 @@ $indivJson = json_encode(
                 </div>
                 <div class="card-body">
                     <?= $this->Form->create(null, ['id' => 'change-edit-form', 'url' => ['action' => 'changeEdit']]) ?>
-                    <fieldset class="form-section">
-                        <legend><?= __('食数予約') ?></legend>
 
-                        <!-- 予約日 -->
-                        <div class="row mb-3">
-                            <?= $this->Form->label('d_reservation_date', '予約日', ['class' => 'col-sm-3 col-form-label']) ?>
-                            <div class="col-sm-9">
-                                <div class="d-flex align-items-center">
-                                    <?= $this->Form->control('d_reservation_date', [
-                                        'type'     => 'date',
-                                        'label'    => false,
-                                        'class'    => 'form-control',
-                                        'disabled' => true,
-                                        'value'    => $date,
-                                    ]) ?>
-                                    <span class="ms-2">(<?= h($weekday) ?>)</span>
-                                </div>
-                            </div>
+                    <!-- hidden fields -->
+                    <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
+                    <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
+                    <?= $this->Form->hidden('reservation_type', ['value' => '2', 'id' => 'ce-reservation-type-hidden']) ?>
+                    <?php if ($selectedRoomId): ?>
+                        <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
+                    <?php endif; ?>
+
+                    <!-- 予約タイプ：トグルボタン -->
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">予約タイプ</label>
+                        <div class="btn-group w-100" role="group" aria-label="予約タイプ切替">
+                            <button type="button" class="btn btn-outline-secondary ce-type-btn active"
+                                    id="ce-btn-group" data-ce-type="2">
+                                <i class="bi bi-people-fill me-1"></i>集団（利用者別）
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary ce-type-btn"
+                                    id="ce-btn-individual" data-ce-type="1">
+                                <i class="bi bi-person-fill me-1"></i>個人（部屋別）
+                            </button>
                         </div>
+                    </div>
 
-                        <!-- hidden fields -->
-                        <?= $this->Form->hidden('d_reservation_date', ['value' => $date, 'id' => 'ce-date-hidden']) ?>
-                        <?= $this->Form->hidden('meal_type', ['value' => $mealType, 'id' => 'ce-mealtype-hidden']) ?>
-                        <?= $this->Form->hidden('reservation_type', ['value' => '2', 'id' => 'ce-reservation-type-hidden']) ?>
-                        <?php if ($selectedRoomId): ?>
-                            <?= $this->Form->hidden('i_id_room', ['value' => $selectedRoomId, 'id' => 'ce-room-hidden']) ?>
+                    <!-- 集団：部屋選択 + 氏名検索 -->
+                    <div id="ce-group-toolbar" class="mb-3 d-none">
+                        <?php if (!empty($rooms) && count($rooms) > 1): ?>
+                            <label for="ce-room-select" class="form-label fw-semibold">部屋を選択</label>
+                            <?= $this->Form->control('i_id_room', [
+                                'type'      => 'select',
+                                'label'     => false,
+                                'options'   => $rooms,
+                                'empty'     => false,
+                                'value'     => $selectedRoomId,
+                                'class'     => 'form-select mb-2',
+                                'required'  => true,
+                                'id'        => 'ce-room-select',
+                                'data-date' => $date,
+                            ]) ?>
+                        <?php elseif ($selectedRoomId): ?>
+                            <p class="text-muted small mb-2"><?= h($selectedRoomName ?: '（部屋未設定）') ?></p>
                         <?php endif; ?>
+                        <input type="search" id="ce-name-search" class="form-control"
+                               placeholder="氏名で絞り込み" autocomplete="off">
+                    </div>
 
-                        <!-- 予約タイプ -->
-                        <div class="mb-3">
-                            <label for="ce-type-select" class="form-label">予約タイプ(個人/集団)</label>
-                            <select id="ce-type-select" class="form-select">
-                                <option value="" disabled>-- 予約タイプを選択 --</option>
-                                <option value="1">個人</option>
-                                <option value="2">集団（利用者別）</option>
-                            </select>
+                    <!-- 集団：食数サマリー -->
+                    <div id="ce-group-summary" class="mb-3 p-2 bg-light rounded d-none">
+                        <span class="fw-semibold me-2">チェック中の食数：</span>
+                        <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
+                        <span class="ms-3">昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
+                        <span class="ms-3">夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名</span>
+                        <span class="ms-3">弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
+                    </div>
+
+                    <!-- 集団：利用者テーブル -->
+                    <div id="ce-group-section" class="mb-3 d-none">
+                        <label class="form-label fw-semibold">部屋に属する利用者と食事選択</label>
+                        <div class="table-responsive">
+                            <table class="table table-bordered mb-0" id="ce-table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col" class="text-start">氏名</th>
+                                        <th scope="col" class="text-center">朝<br><input type="checkbox" class="form-check-input" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
+                                        <th scope="col" class="text-center">昼<br><input type="checkbox" class="form-check-input" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
+                                        <th scope="col" class="text-center">夕<br><input type="checkbox" class="form-check-input" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
+                                        <th scope="col" class="text-center">弁当<br><input type="checkbox" class="form-check-input" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
+                                    </tr>
+                                </thead>
+                                <tbody id="ce-tbody">
+                                    <tr>
+                                        <td colspan="5" class="text-center py-4 text-muted">
+                                            <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
+                    </div>
 
-                        <!-- 個人：部屋ごとのチェック -->
-                        <div class="mb-3 d-none" id="ce-individual-section">
-                            <?= $this->Form->label('rooms', '部屋名と食事選択', ['class' => 'form-label']) ?>
-                            <div class="table-responsive">
-                                <table class="table table-bordered mb-0" id="ce-room-table">
-                                    <thead class="table-light">
-                                        <tr>
-                                            <th scope="col">部屋名</th>
-                                            <th scope="col" class="text-center">
-                                                <label for="select-all-room-1">朝</label>
-                                                <input type="checkbox" id="select-all-room-1">
-                                            </th>
-                                            <th scope="col" class="text-center">
-                                                <label for="select-all-room-2">昼</label>
-                                                <input type="checkbox" id="select-all-room-2">
-                                            </th>
-                                            <th scope="col" class="text-center">
-                                                <label for="select-all-room-3">夕</label>
-                                                <input type="checkbox" id="select-all-room-3">
-                                            </th>
-                                            <th scope="col" class="text-center">
-                                                <label for="select-all-room-4">弁当</label>
-                                                <input type="checkbox" id="select-all-room-4">
-                                            </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="ce-room-tbody">
-                                        <?php foreach ($rooms as $rid => $rname): ?>
-                                        <tr data-room-id="<?= h($rid) ?>">
-                                            <td><?= h($rname) ?></td>
-                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[1][<?= h($rid) ?>]" value="1"></td>
-                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[2][<?= h($rid) ?>]" value="1"></td>
-                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[3][<?= h($rid) ?>]" value="1"></td>
-                                            <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[4][<?= h($rid) ?>]" value="1"></td>
-                                        </tr>
-                                        <?php endforeach; ?>
-                                    </tbody>
-                                </table>
-                            </div>
+                    <!-- 個人：部屋ごとのチェック -->
+                    <div class="mb-3 d-none" id="ce-individual-section">
+                        <label class="form-label fw-semibold">部屋名と食事選択</label>
+                        <div class="table-responsive">
+                            <table class="table table-bordered mb-0" id="ce-room-table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">部屋名</th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-1">朝</label>
+                                            <input type="checkbox" id="select-all-room-1">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-2">昼</label>
+                                            <input type="checkbox" id="select-all-room-2">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-3">夕</label>
+                                            <input type="checkbox" id="select-all-room-3">
+                                        </th>
+                                        <th scope="col" class="text-center">
+                                            <label for="select-all-room-4">弁当</label>
+                                            <input type="checkbox" id="select-all-room-4">
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody id="ce-room-tbody">
+                                    <?php foreach ($rooms as $rid => $rname): ?>
+                                    <tr data-room-id="<?= h($rid) ?>">
+                                        <td><?= h($rname) ?></td>
+                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[1][<?= h($rid) ?>]" value="1"></td>
+                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[2][<?= h($rid) ?>]" value="1"></td>
+                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[3][<?= h($rid) ?>]" value="1"></td>
+                                        <td class="text-center"><input type="checkbox" class="form-check-input meal-checkbox" name="meals[4][<?= h($rid) ?>]" value="1"></td>
+                                    </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
                         </div>
-
-                        <!-- 集団：氏名検索 + 部屋選択 -->
-                        <div id="ce-group-toolbar" class="mb-3 d-none">
-                            <input type="search" id="ce-name-search" class="form-control mb-2"
-                                   placeholder="氏名で絞り込み" autocomplete="off">
-                            <?php if (!empty($rooms) && count($rooms) > 1): ?>
-                                <?= $this->Form->label('ce-room-select', '部屋を選択', ['class' => 'form-label']) ?>
-                                <?= $this->Form->control('i_id_room', [
-                                    'type'      => 'select',
-                                    'label'     => false,
-                                    'options'   => $rooms,
-                                    'empty'     => false,
-                                    'value'     => $selectedRoomId,
-                                    'class'     => 'form-select',
-                                    'required'  => true,
-                                    'id'        => 'ce-room-select',
-                                    'data-date' => $date,
-                                ]) ?>
-                            <?php elseif ($selectedRoomId): ?>
-                                <span class="text-muted small"><?= h($selectedRoomName ?: '（部屋未設定）') ?></span>
-                            <?php endif; ?>
-                        </div>
-
-                        <!-- 集団：食数サマリー -->
-                        <div id="ce-group-summary" class="mb-3 p-2 bg-light rounded d-none">
-                            <span class="fw-semibold me-2">食数：</span>
-                            <span>朝&nbsp;<span class="ce-count" data-meal-summary="1">-</span>名</span>
-                            <span class="ms-3">昼&nbsp;<span class="ce-count" data-meal-summary="2">-</span>名</span>
-                            <span class="ms-3">夕&nbsp;<span class="ce-count" data-meal-summary="3">-</span>名</span>
-                            <span class="ms-3">弁当&nbsp;<span class="ce-count" data-meal-summary="4">-</span>名</span>
-                        </div>
-
-                        <!-- 集団：利用者テーブル -->
-                        <div id="ce-group-section" class="mb-3 d-none">
-                            <?= $this->Form->label('users', '部屋に属する利用者と食事選択', ['class' => 'form-label']) ?>
-                            <div class="table-responsive">
-                                <table class="table table-bordered mb-0" id="ce-table">
-                                    <thead class="table-light">
-                                        <tr>
-                                            <th scope="col" class="text-start">氏名</th>
-                                            <th scope="col" class="text-center">朝<br><input type="checkbox" class="form-check-input" id="select-all-1" aria-label="朝 全選択/解除" title="全選択/解除"></th>
-                                            <th scope="col" class="text-center">昼<br><input type="checkbox" class="form-check-input" id="select-all-2" aria-label="昼 全選択/解除" title="全選択/解除"></th>
-                                            <th scope="col" class="text-center">夕<br><input type="checkbox" class="form-check-input" id="select-all-3" aria-label="夕 全選択/解除" title="全選択/解除"></th>
-                                            <th scope="col" class="text-center">弁当<br><input type="checkbox" class="form-check-input" id="select-all-4" aria-label="弁当 全選択/解除" title="全選択/解除"></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="ce-tbody">
-                                        <tr>
-                                            <td colspan="5" class="text-center py-4 text-muted">
-                                                <div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>読み込み中...
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-
-                        <script>
-                        (function(){
-                            var INDIV_DATA   = <?= $indivJson ?>;
-                            var typeHidden   = document.getElementById('ce-reservation-type-hidden');
-                            var groupToolbar = document.getElementById('ce-group-toolbar');
-                            var groupSummary = document.getElementById('ce-group-summary');
-                            var indivSection = document.getElementById('ce-individual-section');
-                            var groupSection = document.getElementById('ce-group-section');
-                            var _prefilled   = false;
-
-                            function showEl(el){ if (el) el.classList.remove('d-none'); }
-                            function hideEl(el){ if (el) el.classList.add('d-none'); }
-
-                            function setType(val) {
-                                if (typeHidden) typeHidden.value = val;
-                                var isIndiv = (val === '1');
-                                if (isIndiv) {
-                                    showEl(indivSection);
-                                    hideEl(groupToolbar);
-                                    hideEl(groupSummary);
-                                    hideEl(groupSection);
-                                } else {
-                                    hideEl(indivSection);
-                                    showEl(groupToolbar);
-                                    showEl(groupSummary);
-                                    showEl(groupSection);
-                                }
-                                if (isIndiv && !_prefilled) {
-                                    _prefilled = true;
-                                    INDIV_DATA.forEach(function(r) {
-                                        var cb = document.querySelector('input[name="meals[' + r.type + '][' + r.room_id + ']"]');
-                                        if (cb) cb.checked = true;
-                                    });
-                                }
-                            }
-
-                            var typeSelect = document.getElementById('ce-type-select');
-                            if (typeSelect) {
-                                typeSelect.addEventListener('change', function() { setType(this.value); });
-                            }
-
-                            if (typeSelect) typeSelect.value = '2';
-                            setType('2');
-                        })();
-                        </script>
-
-                    </fieldset>
+                    </div>
 
                     <!-- 送信ボタン & ローディング -->
                     <div class="d-flex align-items-center justify-content-between mt-3">
@@ -265,7 +220,68 @@ $indivJson = json_encode(
                             <p style="color: white; margin-top: 10px;">処理中です。少々お待ちください...</p>
                         </div>
                     </div>
+
                     <?= $this->Form->end() ?>
+
+                    <script>
+                    (function(){
+                        var INDIV_DATA   = <?= $indivJson ?>;
+                        var typeHidden   = document.getElementById('ce-reservation-type-hidden');
+                        var groupToolbar = document.getElementById('ce-group-toolbar');
+                        var groupSummary = document.getElementById('ce-group-summary');
+                        var indivSection = document.getElementById('ce-individual-section');
+                        var groupSection = document.getElementById('ce-group-section');
+                        var _prefilled   = false;
+
+                        function showEl(el){ if (el) el.classList.remove('d-none'); }
+                        function hideEl(el){ if (el) el.classList.add('d-none'); }
+
+                        function setType(val) {
+                            if (typeHidden) typeHidden.value = val;
+                            var isIndiv = (val === '1');
+
+                            // ボタンのアクティブ状態を更新
+                            document.querySelectorAll('.ce-type-btn').forEach(function(btn) {
+                                if (btn.getAttribute('data-ce-type') === val) {
+                                    btn.classList.add('active');
+                                    btn.classList.remove('btn-outline-secondary');
+                                    btn.classList.add(isIndiv ? 'btn-secondary' : 'btn-secondary');
+                                } else {
+                                    btn.classList.remove('active');
+                                    btn.classList.add('btn-outline-secondary');
+                                    btn.classList.remove('btn-secondary');
+                                }
+                            });
+
+                            if (isIndiv) {
+                                showEl(indivSection);
+                                hideEl(groupToolbar);
+                                hideEl(groupSummary);
+                                hideEl(groupSection);
+                            } else {
+                                hideEl(indivSection);
+                                showEl(groupToolbar);
+                                showEl(groupSummary);
+                                showEl(groupSection);
+                            }
+                            if (isIndiv && !_prefilled) {
+                                _prefilled = true;
+                                INDIV_DATA.forEach(function(r) {
+                                    var cb = document.querySelector('input[name="meals[' + r.type + '][' + r.room_id + ']"]');
+                                    if (cb) cb.checked = true;
+                                });
+                            }
+                        }
+
+                        document.querySelectorAll('.ce-type-btn').forEach(function(btn) {
+                            btn.addEventListener('click', function() {
+                                setType(this.getAttribute('data-ce-type'));
+                            });
+                        });
+
+                        setType('2');
+                    })();
+                    </script>
 
                 </div><!-- /.card-body -->
             </div><!-- /.card -->

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
@@ -5,6 +5,9 @@ $this->Html->script('reservation-users.js', ['block' => true]);
 $this->Html->script('reservation.js', ['block' => true]);
 $this->Html->script('ce-change-edit.js', ['block' => true]);
 $this->Html->script('add.js', ['block' => true]);
+// モーダルで add.php / change_edit.php のコンテンツを描画する際に必要な CSS
+$this->Html->css('pages/t_reservation_add.css', ['block' => 'css']);
+$this->Html->css('pages/t_reservation_change_edit.css', ['block' => 'css']);
 $user = $this->request->getAttribute('identity');
 $isChild = ($user && (int)$user->get('i_user_level') === 1);
 $isStaff = ($user && (int)$user->get('i_user_level') === 0);


### PR DESCRIPTION
## 変更内容

### ルーティング修正（`config/routes.php`）
- `ce-change-edit.js` が生成する `TReservationInfo/change-edit/{roomId}/{date}/{mealType}` 形式のURLに対応する明示的ルートを追加
- DashedRouteフォールバックでは解決できなかったPascalCase＋ダッシュ区切り混在のURLを正しく `changeEdit` アクションにルーティング

### 直前編集画面の UI 全面改善（`change_edit.php`）
- **日付・食種の明示**：警告バナーに日付バッジ（例: `2026-06-21（日）`）と食種バッジ（朝食/昼食/夕食/弁当）を追加し、何を編集中か一目でわかるようにした
- **予約タイプ切替のトグルボタン化**：`<select>` ドロップダウンを `btn-group` の横並びボタン（集団／個人）に変更し、現在のモードが視覚的に明確になるようにした
- **add.php のデザインを流用**：ローディングオーバーレイ（全画面スピナー）を採用、セクション表示切替を `style.display` → Bootstrap `d-none` クラスに統一
- **CSSブロック登録**：`echo $this->Html->css()` から `['block' => 'css']` に変更し、直接アクセス時もヘッドに正しく配置

### モーダルでCSSが効かない問題を修正（`index.php`）
- `replaceWithExtract()` はモーダルに `#ce-root` のみ抽出するため、`change_edit.php` 内のCSSリンクタグはDOMに追加されずスタイルが無効になっていた
- `index.php` に `t_reservation_add.css` と `t_reservation_change_edit.css` を `['block' => 'css']` で登録し、モーダル表示時も両CSSが適用されるよう修正

### ステージング調査ワークフロー更新（`.github/workflows/stg-investigate.yml`）
- `m_user_group` の `active_flag` 分布確認・ユーザー詳細・エラーログ確認などの診断ステップを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 予約情報の変更・編集に対応するエンドポイントを追加しました（日付・食種を含む形式を制約、更新系の受付を調整）。

* **UI/機能改善**
  * 直前編集画面で曜日計算や食種バッジ表示を反映し、警告バナー内容を更新しました。
  * 予約タイプ切替UIをトグル方式へ見直し、表示制御を改善しました。

* **チューニング**
  * ステージング環境の調査手順を強化し、ログ確認の精度を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->