### PR TITLE
Resolve #454: 承認ワークフローの堅牢化（自動反映・履歴閲覧・承認済みデータ保護）

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -224,6 +224,46 @@ class ApprovalController extends AppController
         }
     }
 
+    /**
+     * 承認履歴（ログ）一覧を表示
+     */
+    public function log(): ?Response
+    {
+        $this->Authorization->skipAuthorization();
+        $user = $this->Authentication->getIdentity();
+        $isAdmin = UserRole::isAdmin((int)($user->get('i_admin') ?? 0));
+        $isBlockLeader = UserRole::isBlockLeader((int)($user->get('i_admin') ?? 0));
+
+        if (!$isAdmin && !$isBlockLeader) {
+            $this->Flash->error('この画面を表示する権限がありません。');
+            return $this->redirect(['controller' => 'Pages', 'action' => 'display', 'home']);
+        }
+
+        $query = $this->fetchTable('TApprovalLog')->find()
+            ->contain(['MUserInfo', 'MRoomInfo', 'Approvers']);
+
+        // ブロック長の場合は自分が担当する部屋のログ、または自分が承認したログのみに制限
+        if (!$isAdmin && $isBlockLeader) {
+            $roomAccessService = new \App\Service\RoomAccessService();
+            $myRoomIds = $roomAccessService->getUserRoomIds((int)$user->get('i_id_user'));
+            $query->where([
+                'OR' => [
+                    'TApprovalLog.i_id_room IN' => $myRoomIds,
+                    'TApprovalLog.i_approver_id' => (int)$user->get('i_id_user'),
+                ]
+            ]);
+        }
+
+        $query->order(['TApprovalLog.dt_create' => 'DESC']);
+
+        $logs = $this->paginate($query, [
+            'limit' => 50,
+        ]);
+
+        $this->set(compact('logs'));
+        return null;
+    }
+
     // ------------------------------------------------------------------
     // helpers
     // ------------------------------------------------------------------

--- a/src_web/kamaho-shokusu/src/Controller/PagesController.php
+++ b/src_web/kamaho-shokusu/src/Controller/PagesController.php
@@ -224,6 +224,9 @@ class PagesController extends AppController
                 'admin' => $isAdmin
                     ? $approvalService->countAdminPending($dateFrom, $dateTo)
                     : 0,
+                'unreflected' => $isAdmin
+                    ? $approvalService->countUnreflectedAdminApproved()
+                    : 0,
             ];
         } else {
             // 未ログインの場合: 報告済みフラグは false 固定にし、

--- a/src_web/kamaho-shokusu/src/Model/Table/TIndividualReservationInfoTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/TIndividualReservationInfoTable.php
@@ -163,7 +163,8 @@ class TIndividualReservationInfoTable extends Table
                 ->enableAutoFields(false)
                 ->select([
                     'i_id_user','d_reservation_date','i_id_room','i_reservation_type',
-                    'eat_flag','i_change_flag','i_version','dt_create','c_create_user','dt_update','c_update_user'
+                    'eat_flag','i_change_flag','i_version','dt_create','c_create_user','dt_update','c_update_user',
+                    'i_approval_status'
                 ])
                 ->where([
                     'i_id_user'          => $userId,
@@ -172,6 +173,14 @@ class TIndividualReservationInfoTable extends Table
                     'i_reservation_type' => $meal,
                 ])
                 ->first();
+
+            if ($entity) {
+                $status = (int)($entity->i_approval_status ?? 0);
+                if ($status === 1 || $status === 2) {
+                    $entity->setError('i_approval_status', '承認済みの予約は変更できません。');
+                    throw new PersistenceFailedException($entity, 'Already approved.');
+                }
+            }
 
             $isNew = false;
             if (!$entity) {

--- a/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
+++ b/src_web/kamaho-shokusu/src/Service/ActualMealManagementService.php
@@ -55,7 +55,7 @@ class ActualMealManagementService
             ->andWhere(['MUserInfo.i_id_staff IS NOT' => null])
             ->andWhere(['MUserInfo.i_id_staff !=' => ''])
             ->enableHydration(false)
-            ->orderAsc('MUserInfo.c_user_name')
+            ->orderByAsc('MUserInfo.c_user_name')
             ->all();
 
         $result = [];
@@ -228,7 +228,7 @@ class ActualMealManagementService
             ->enableAutoFields(false)
             ->select([
                 'i_id_user', 'd_reservation_date', 'i_id_room', 'i_reservation_type',
-                'eat_flag', 'i_change_flag', 'i_version',
+                'eat_flag', 'i_change_flag', 'i_version', 'i_approval_status',
             ])
             ->where([
                 'i_id_user'          => $userId,
@@ -238,23 +238,36 @@ class ActualMealManagementService
             ])
             ->first();
 
+        if ($entity !== null) {
+            $currentStatus = (int)($entity->i_approval_status ?? 0);
+            if ($currentStatus === 1 || $currentStatus === 2) {
+                return ['ok' => false, 'message' => '承認済みのデータは変更できません。'];
+            }
+        }
+
         if ($entity === null) {
             // 新規作成
-            $newEntity = $reservationTable->newEmptyEntity();
-            $newEntity->i_id_user          = $userId;
-            $newEntity->d_reservation_date = $date;
-            $newEntity->i_id_room          = $roomId;
-            $newEntity->i_reservation_type = $mealType;
-            $newEntity->eat_flag           = $flagValue;
-            $newEntity->i_change_flag      = $flagValue;
-            $newEntity->i_version          = 1;
-            $newEntity->dt_create          = $now;
-            $newEntity->c_create_user      = $actor;
+            try {
+                $newEntity = $reservationTable->newEmptyEntity();
+                $newEntity->i_id_user          = $userId;
+                $newEntity->d_reservation_date = $date;
+                $newEntity->i_id_room          = $roomId;
+                $newEntity->i_reservation_type = $mealType;
+                $newEntity->eat_flag           = $flagValue;
+                $newEntity->i_change_flag      = $flagValue;
+                $newEntity->i_version          = 1;
+                $newEntity->dt_create          = $now;
+                $newEntity->c_create_user      = $actor;
+                $newEntity->i_approval_status  = 0;
 
-            if (!$reservationTable->save($newEntity)) {
-                return ['ok' => false, 'message' => '保存に失敗しました。'];
+                if (!$reservationTable->save($newEntity)) {
+                    return ['ok' => false, 'message' => '保存に失敗しました。'];
+                }
+                return ['ok' => true, 'message' => '保存しました。', 'version' => 1];
+            } catch (\Exception $e) {
+                // 同時実行による一意制約違反などの場合は、既にデータが存在する可能性があるため再取得を促す
+                return ['ok' => false, 'message' => 'データの状態が変わりました。画面を再読み込みしてください。'];
             }
-            return ['ok' => true, 'message' => '保存しました。', 'version' => 1];
         }
 
         // 楽観的ロック付き更新
@@ -320,6 +333,7 @@ class ActualMealManagementService
                     'i_id_room'          => (int)$key['room_id'],
                     'd_reservation_date' => (string)$key['date'],
                     'i_reservation_type' => (int)$key['meal_type'],
+                    'i_approval_status IN' => [0, 3], // 未承認または差し戻しのみ申請可能
                 ]
             );
         }

--- a/src_web/kamaho-shokusu/src/Service/ApprovalService.php
+++ b/src_web/kamaho-shokusu/src/Service/ApprovalService.php
@@ -216,6 +216,17 @@ class ApprovalService
     }
 
     /**
+     * 未反映データの件数を取得（承認済みだが、反映待ちのレコード数）
+     */
+    public function countUnreflectedAdminApproved(): int
+    {
+        $individualTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        return $individualTable->find()
+            ->where(['i_approval_status' => self::STATUS_ADMIN])
+            ->count();
+    }
+
+    /**
      * ブロック長向けの未承認件数を返す。
      */
     public function countBlockLeaderPending(int $userId, ?string $dateFrom = null, ?string $dateTo = null): int
@@ -319,6 +330,20 @@ class ApprovalService
     public function adminApprove(array $keys, int $approverId, string $actor, string $ipAddress = ''): bool
     {
         $result = $this->updateApprovalStatus($keys, self::STATUS_ADMIN, $approverId, $actor, null, [self::STATUS_PENDING, self::STATUS_BLOCK_LEADER]);
+        
+        if ($result) {
+            // 承認成功時、自動的に予約情報へ反映
+            // keys から対象となる roomId と 日付範囲を抽出して効率的に反映する
+            $roomIds = array_unique(array_column($keys, 'i_id_room'));
+            $dates = array_column($keys, 'd_reservation_date');
+            $dateFrom = min($dates);
+            $dateTo = max($dates);
+
+            foreach ($roomIds as $roomId) {
+                $this->reflectToReservation((int)$roomId, $dateFrom, $dateTo, $actor);
+            }
+        }
+
         AuditLogService::record(
             'approval',
             'approval_admin',
@@ -372,11 +397,16 @@ class ApprovalService
     public function reflectToReservation(?int $roomId, ?string $dateFrom, ?string $dateTo, string $actor): array
     {
         $individualTable  = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userTable        = TableRegistry::getTableLocator()->get('MUserInfo');
         $reservationTable = TableRegistry::getTableLocator()->get('TReservationInfo');
         $now = DateTime::now();
 
         $query = $individualTable->find()
-            ->where(['i_approval_status' => self::STATUS_ADMIN]);
+            ->innerJoin(['MUserInfo' => 'm_user_info'], ['MUserInfo.i_id_user = TIndividualReservationInfo.i_id_user'])
+            ->where([
+                'TIndividualReservationInfo.i_approval_status' => self::STATUS_ADMIN,
+                'MUserInfo.i_del_flag' => 0, // 削除済みユーザーを除外
+            ]);
 
         if ($roomId !== null) {
             $query->where(['i_id_room' => $roomId]);

--- a/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
+++ b/src_web/kamaho-shokusu/src/Service/UserDeletionService.php
@@ -42,6 +42,15 @@ class UserDeletionService
 
         $result = (bool)$userInfoTable->save($user);
 
+        if ($result) {
+            // 未承認の個別予約情報を削除（物理削除またはキャンセル）
+            $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+            $reservationTable->deleteAll([
+                'i_id_user' => $user->i_id_user,
+                'i_approval_status' => 0, // 未承認のみ
+            ]);
+        }
+
         AuditLogService::record(
             'user',
             'user_delete',

--- a/src_web/kamaho-shokusu/templates/Approval/log.php
+++ b/src_web/kamaho-shokusu/templates/Approval/log.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\TApprovalLog[]|\Cake\Collection\CollectionInterface $logs
+ */
+$this->assign('title', '承認履歴');
+
+$statusLabels = [
+    1 => '<span class="badge bg-primary">ブロック長承認</span>',
+    2 => '<span class="badge bg-success">管理者承認</span>',
+    3 => '<span class="badge bg-danger">差し戻し</span>',
+];
+
+$mealTypes = [1 => '朝', 2 => '昼', 3 => '夜', 4 => '弁'];
+?>
+
+<div class="container-fluid py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">承認履歴</h1>
+        <a href="<?= $this->Url->build(['action' => 'adminIndex']) ?>" class="btn btn-outline-secondary btn-sm">承認管理へ戻る</a>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>承認日時</th>
+                            <th>ステータス</th>
+                            <th>承認者</th>
+                            <th>対象者</th>
+                            <th>対象日</th>
+                            <th>食種</th>
+                            <th>理由/備考</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if ($logs->isEmpty()): ?>
+                            <tr>
+                                <td colspan="7" class="text-center py-5 text-muted">承認履歴はありません。</td>
+                            </tr>
+                        <?php else: ?>
+                            <?php foreach ($logs as $log): ?>
+                                <tr>
+                                    <td class="text-nowrap"><?= h($log->dt_create->format('Y/m/d H:i')) ?></td>
+                                    <td><?= $statusLabels[$log->i_approval_status] ?? h($log->i_approval_status) ?></td>
+                                    <td class="text-nowrap"><?= h($log->approver->c_user_name ?? 'ID:'.$log->i_approver_id) ?></td>
+                                    <td class="text-nowrap">
+                                        <?= h($log->m_user_info->c_user_name ?? 'ID:'.$log->i_id_user) ?>
+                                        <br><small class="text-muted"><?= h($log->m_room_info->c_room_name ?? '部屋ID:'.$log->i_id_room) ?></small>
+                                    </td>
+                                    <td class="text-nowrap"><?= h($log->d_reservation_date->format('Y/m/d')) ?></td>
+                                    <td><?= $mealTypes[$log->i_reservation_type] ?? h($log->i_reservation_type) ?></td>
+                                    <td>
+                                        <?php if ($log->i_approval_status === 3 && $log->c_reject_reason): ?>
+                                            <span class="text-danger small"><?= h($log->c_reject_reason) ?></span>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php if (!$logs->isEmpty()): ?>
+            <div class="card-footer bg-white py-3">
+                <nav aria-label="Page navigation">
+                    <ul class="pagination pagination-sm justify-content-center mb-0">
+                        <?= $this->Paginator->prev('« 前') ?>
+                        <?= $this->Paginator->numbers() ?>
+                        <?= $this->Paginator->next('次 »') ?>
+                    </ul>
+                    <p class="text-center small text-muted mt-2 mb-0">
+                        <?= $this->Paginator->counter('{{page}} / {{pages}} ページ（全 {{count}} 件）') ?>
+                    </p>
+                </nav>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<style>
+.pagination a, .pagination span {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #dee2e6;
+    margin-left: -1px;
+    text-decoration: none;
+    color: #0d6efd;
+}
+.pagination .active span {
+    background-color: #0d6efd;
+    color: white;
+    border-color: #0d6efd;
+}
+.pagination .disabled span {
+    color: #6c757d;
+}
+</style>

--- a/src_web/kamaho-shokusu/templates/Pages/dashboard.php
+++ b/src_web/kamaho-shokusu/templates/Pages/dashboard.php
@@ -48,6 +48,7 @@ $fmtWeekRange           = $dashboard['fmtWeekRange']           ?? null; // 「n/
 $approvalCounts         = $dashboard['approvalCounts']         ?? ['blockLeader' => 0, 'admin' => 0];
 $blockLeaderPendingCount = $isAdmin ? 0 : (int)($approvalCounts['blockLeader'] ?? 0);
 $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
+$unreflectedCount      = (int)($approvalCounts['unreflected'] ?? 0);
 ?>
 
 <?= $this->Html->css('pages/home.pc.css') ?>
@@ -241,6 +242,22 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                 </div>
             <?php endif; ?>
 
+            <?php /* ---- 未反映データアラート（管理者用） ---- */ ?>
+            <?php if ($isAdmin && $unreflectedCount > 0): ?>
+                <div class="alert-card" style="border-color:#fef3c7;">
+                    <div class="alert-left">
+                        <div class="alert-icon" style="background:#fef3c7;color:#d97706;">⚠️</div>
+                        <div>
+                            <div class="alert-title">未反映の承認データがあります</div>
+                            <div class="alert-sub"><?= h($unreflectedCount) ?> 件の承認済みデータがまだ予約集計に反映されていません。</div>
+                        </div>
+                    </div>
+                    <div class="alert-actions">
+                        <a class="btn-teal" href="<?= $this->Url->build('/Approval/adminIndex') ?>" style="background:#d97706;">反映処理を行う</a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php /* ---- メインメニューカード ---- */ ?>
             <div class="section-title">各種メニュー</div>
             <div class="card-grid">
@@ -345,6 +362,11 @@ $adminPendingCount       = (int)($approvalCounts['admin'] ?? 0);
                         <div class="menu-icon" style="background:#fff9e6;color:#d97706;">📢</div>
                         <div class="menu-title-text">お知らせ管理</div>
                         <div class="menu-desc">掲示するお知らせの作成・編集・削除</div>
+                    </a>
+                    <a class="menu-card" href="<?= $this->Url->build('/Approval/log') ?>">
+                        <div class="menu-icon" style="background:#f8fafc;color:#64748b;">📜</div>
+                        <div class="menu-title-text">承認履歴</div>
+                        <div class="menu-desc">過去の承認・差し戻しの履歴を確認する</div>
                     </a>
                 </div>
             <?php endif; ?>


### PR DESCRIPTION
Closes #454

## 変更内容

### 管理者承認後に予約集計へ自動反映
- `ApprovalService::adminApprove()` 内で承認成功時に `reflectToReservation()` を自動呼び出し
- 対象の `roomId` と日付範囲を keys から抽出して効率的に反映

### 削除済みユーザーを反映対象から除外
- `reflectToReservation()` に `MUserInfo` との INNER JOIN を追加
- `i_del_flag = 0` の条件で削除済みユーザーのデータを除外

### 承認済み予約の変更禁止
- `TIndividualReservationInfoTable`：承認前に `i_approval_status` が 1 or 2 のレコードは `PersistenceFailedException` をスロー
- `ActualMealManagementService`：実績食数の更新前にも同様のチェックを追加

### 申請可能ステータスの制限
- `ActualMealManagementService::buildApprovalTargetConditions()` に `i_approval_status IN [0, 3]` 条件を追加
- 未承認または差し戻しのレコードのみ承認申請の対象とする

### 承認履歴ログ一覧ページの追加
- `ApprovalController::log()` アクション新設（管理者・ブロック長のみアクセス可）
- ブロック長は担当部屋または自身が承認したログのみ閲覧可
- `templates/Approval/log.php` テンプレート追加（ページネーション付き一覧）

### 未反映データのダッシュボードアラート
- `ApprovalService::countUnreflectedAdminApproved()` 新設（status=2 の未反映件数を返す）
- `PagesController` でカウントを取得し `approvalCounts['unreflected']` として渡す
- `dashboard.php` に管理者向け警告カードを追加

### ユーザー削除時の未承認予約削除
- `UserDeletionService::delete()` でユーザー論理削除後、`i_approval_status = 0` の個別予約レコードを削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 承認履歴を表示する専用画面を追加
  * 管理者向けダッシュボードに未反映データ数を表示し、承認履歴へのアクセスリンクを追加

* **Bug Fixes**
  * 承認済み予約の修正を防止
  * 承認後の予約情報反映処理を実装
  * ユーザー削除時の承認待ち予約を自動削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->