### PR TITLE
fix: #457 #458 getTotalMealsByDate未定義変数エラーとデフォルトユーザー名一意制約違反を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -204,10 +204,6 @@ class MUserInfoController extends AppController
         if ($this->request->is('post')) {
             $data = $this->request->getData();
 
-            if (empty($data['c_user_name'])) {
-                $data['c_user_name'] = 'デフォルトユーザー名';
-            }
-
             if ($this->userCreateService->loginAccountExists($data['c_login_account'])) {
                 $this->Flash->error(__('このログインIDは既に使用されています。他のIDをお試しください。'));
             } else {
@@ -262,7 +258,6 @@ class MUserInfoController extends AppController
 
         if ($this->request->is(['patch', 'post', 'put'])) {
             $data = $this->request->getData();
-            $data['c_user_name']   = $data['c_user_name'] ?? 'デフォルトユーザー名';
             $user                  = $this->request->getAttribute('identity');
             $data['c_update_user'] = $user ? $user->get('c_user_name') : '不明なユーザー';
             $data['dt_update']     = date('Y-m-d H:i:s');

--- a/src_web/kamaho-shokusu/src/Model/Table/TReservationInfoTable.php
+++ b/src_web/kamaho-shokusu/src/Model/Table/TReservationInfoTable.php
@@ -90,14 +90,15 @@ class TReservationInfoTable extends Table
     }
 
 
-    public function getTotalMealsByDate()
+    public function getTotalMealsByDate(): SelectQuery
     {
-        $query = $this->find()
-            ->select([
-                'd_reservation_date',
-                'total_meals' => $query->func()->sum('i_taberu_ninzuu')
-            ])
+        return $this->find()
+            ->select(function (SelectQuery $q) {
+                return [
+                    'd_reservation_date',
+                    'total_meals' => $q->func()->sum('i_taberu_ninzuu'),
+                ];
+            })
             ->groupBy('d_reservation_date');
-        return $query;
     }
 }


### PR DESCRIPTION
Closes #457
Closes #458

## 変更内容

### #457: `getTotalMealsByDate()` の Undefined variable 修正

`$query` 代入の右辺で `$query->func()` を参照していたため、PHP が未定義変数エラーを発生させていた。

`select()` にクロージャを渡すことで、クエリオブジェクト自身から `func()` を呼び出す形に変更。

**Before:**
```php
$query = $this->find()
    ->select([
        'd_reservation_date',
        'total_meals' => $query->func()->sum('i_taberu_ninzuu') // $query 未初期化
    ])
    ->groupBy('d_reservation_date');
```

**After:**
```php
return $this->find()
    ->select(function (SelectQuery $q) {
        return [
            'd_reservation_date',
            'total_meals' => $q->func()->sum('i_taberu_ninzuu'),
        ];
    })
    ->groupBy('d_reservation_date');
```

### #458: デフォルトユーザー名付与ロジックの削除

`create()` および `edit()` で固定文字列 `'デフォルトユーザー名'` を自動付与していたコードを削除。
`MUserInfoTable` の `notEmptyString('c_user_name', 'ユーザー名を入力してください。')` バリデーションに委ね、未入力時はバリデーションエラーをユーザーに返す。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユーザー追加・編集時のユーザー名処理を改善

* **リファクタリング**
  * 予約情報の集計クエリ構築を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->