### PR TITLE
fix: AIアシスタントの「考え中」スピナーが消えない問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/config/routes.php
+++ b/src_web/kamaho-shokusu/config/routes.php
@@ -379,6 +379,9 @@ return function (RouteBuilder $routes): void {
             ->setPass(['id'])
             ->setPatterns(['id' => '\d+']);
 
+        // ── AIアシスタント ──
+        $builder->connect('/AiAssistant/ask', ['controller' => 'AiAssistant', 'action' => 'ask'])->setMethods(['POST']);
+
         // フォールバック
         $builder->fallbacks(DashedRoute::class);
     });

--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -133,6 +133,7 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             \App\Controller\AuditLogController::class             => \App\Policy\AuditLogPolicy::class,
             \App\Controller\RoomUsageController::class           => \App\Policy\RoomUsagePolicy::class,
             \App\Controller\FeatureUsageSummaryController::class => \App\Policy\FeatureUsageSummaryPolicy::class,
+            \App\Controller\AiAssistantController::class      => \App\Policy\AiAssistantPolicy::class,
         ]);
 
         // MapResolver で解決できない場合は OrmResolver（エンティティ→ポリシー）にフォールバック

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -10,7 +10,12 @@
     <?= $this->Html->meta('csrfToken', $this->request->getAttribute('csrfToken')) ?>
     <?= $this->Html->css('animate.min.css') ?>
     <?= $this->Html->css('custom.css') ?>
+    <?= $this->Html->css('ai-assistant.css') ?>
+    <?= $this->Html->css('layout-header.css') ?>
     <?= $this->Html->script('api_response.js') ?>
+    <script>
+        window.AI_ASSISTANT_ASK_URL = '<?= $this->Url->build(['controller' => 'AiAssistant', 'action' => 'ask']) ?>';
+    </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <?= $this->fetch('meta') ?>
     <?= $this->fetch('css') ?>
@@ -32,10 +37,13 @@ $recentNotifications     = $recentNotifications ?? [];
 ?>
 
 <?php if (!$isModal): ?>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-info shadow-sm py-2 fixed-top" id="mainNav">
+    <nav class="navbar navbar-expand-lg navbar-dark navbar-custom fixed-top" id="mainNav">
         <div class="container">
-            <a class="navbar-brand fs-4" href="<?= $this->Url->build($isChild ? '/TReservationInfo' : '/') ?>">食数管理システム</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <a class="navbar-brand d-flex align-items-center gap-2" href="<?= $this->Url->build($isChild ? '/TReservationInfo' : '/') ?>">
+                <i class="bi bi-calendar-check-fill fs-4"></i>
+                <span>食数管理システム</span>
+            </a>
+            <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
             </button>
 
@@ -44,18 +52,26 @@ $recentNotifications     = $recentNotifications ?? [];
                     <?php if ($user): ?>
                         <?php if ($isStaff): ?>
                             <li class="nav-item">
-                                <a class="nav-link" href="<?= $this->Url->build('/') ?>">ダッシュボード</a>
+                                <a class="nav-link" href="<?= $this->Url->build('/') ?>">
+                                    <i class="bi bi-speedometer2"></i>ダッシュボード
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="<?= $this->Url->build('/TReservationInfo') ?>">予約（従来）</a>
+                                <a class="nav-link" href="<?= $this->Url->build('/TReservationInfo') ?>">
+                                    <i class="bi bi-calendar3"></i>予約
+                                </a>
                             </li>
                         <?php endif; ?>
                         <li class="nav-item">
-                            <a class="nav-link" href="<?= $this->Url->build('/MRoomInfo/') ?>">部屋情報</a>
+                            <a class="nav-link" href="<?= $this->Url->build('/MRoomInfo/') ?>">
+                                <i class="bi bi-door-open"></i>部屋情報
+                            </a>
                         </li>
                         <?php if ($isAdmin): ?>
                             <li class="nav-item">
-                                <a class="nav-link" href="<?= $this->Url->build('/MUserInfo/') ?>">ユーザ一覧</a>
+                                <a class="nav-link" href="<?= $this->Url->build('/MUserInfo/') ?>">
+                                    <i class="bi bi-people"></i>ユーザ一覧
+                                </a>
                             </li>
                         <?php endif; ?>
                     <?php endif; ?>
@@ -63,11 +79,11 @@ $recentNotifications     = $recentNotifications ?? [];
                     <?php if ($user && $user->i_admin): ?>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" id="adminDropdown" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                予約情報
+                                <i class="bi bi-journal-text"></i>予約管理
                             </a>
-                            <ul class="dropdown-menu animate__animated animate__fadeIn" aria-labelledby="adminDropdown">
+                            <ul class="dropdown-menu border-0 shadow-sm animate__animated animate__fadeIn" aria-labelledby="adminDropdown">
                                 <li><?= $this->Html->link('💰 食数単価一覧', ['controller' => 'MMealPriceInfo', 'action' => 'index'], ['class' => 'dropdown-item']) ?></li>
-                                <li><?= $this->Html->link('📄 食事控除表ダウンロード', ['controller' => 'MMealPriceInfo', 'action' => 'GetMealSummary'], ['class' => 'dropdown-item']) ?></li>
+                                <li><?= $this->Html->link('📄 食事控除表', ['controller' => 'MMealPriceInfo', 'action' => 'GetMealSummary'], ['class' => 'dropdown-item']) ?></li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li><?= $this->Html->link('🔄 部屋異動予約', ['controller' => 'MRoomTransferSchedule', 'action' => 'index'], ['class' => 'dropdown-item']) ?></li>
                             </ul>
@@ -75,29 +91,19 @@ $recentNotifications     = $recentNotifications ?? [];
                     <?php endif; ?>
 
                     <?php if ($user): ?>
-                        <?php if ($isAdmin): ?>
-                            <li class="nav-item dropdown">
-                                <a class="nav-link dropdown-toggle" href="#" id="contactDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                    お問い合わせ
-                                </a>
-                                <ul class="dropdown-menu animate__animated animate__fadeIn" aria-labelledby="contactDropdown">
-                                    <li><?= $this->Html->link('&#128140; お問い合わせフォーム', ['controller' => 'Contacts', 'action' => 'index'], ['class' => 'dropdown-item', 'escape' => false]) ?></li>
-                                    <li><?= $this->Html->link('&#128235; 問い合わせ一覧', ['controller' => 'Contacts', 'action' => 'adminIndex'], ['class' => 'dropdown-item', 'escape' => false]) ?></li>
-                                </ul>
-                            </li>
-                        <?php else: ?>
-                            <li class="nav-item">
-                                <a class="nav-link" href="<?= $this->Url->build('/Contacts') ?>">お問い合わせ</a>
-                            </li>
-                        <?php endif; ?>
+                        <li class="nav-item">
+                            <a class="nav-link" href="<?= $this->Url->build('/Contacts') ?>">
+                                <i class="bi bi-envelope"></i>お問い合わせ
+                            </a>
+                        </li>
                     <?php endif; ?>
 
                     <?php if ($user && $isSysAdmin): ?>
                         <li class="nav-item dropdown">
-                            <a class="nav-link fw-bold dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                管理
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="bi bi-gear"></i>管理
                             </a>
-                            <ul class="dropdown-menu">
+                            <ul class="dropdown-menu border-0 shadow-sm">
                                 <li>
                                     <a class="dropdown-item" href="<?= $this->Url->build('/AuditLog') ?>">
                                         <i class="bi bi-shield-lock me-2 text-danger"></i>監査ログ
@@ -113,64 +119,99 @@ $recentNotifications     = $recentNotifications ?? [];
                     <?php endif; ?>
                 </ul>
 
-                <ul class="navbar-nav ms-auto">
+                <ul class="navbar-nav ms-auto align-items-lg-center">
                     <?php if ($user): ?>
                         <li class="nav-item dropdown me-2">
                             <a class="nav-link dropdown-toggle position-relative" href="#" id="notificationMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                通知
+                                <i class="bi bi-bell"></i>
                                 <?php if ($notificationUnreadCount > 0): ?>
-                                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                                    <span class="badge rounded-pill bg-danger">
                                         <?= h($notificationUnreadCount > 99 ? '99+' : (string)$notificationUnreadCount) ?>
                                     </span>
                                 <?php endif; ?>
                             </a>
-                            <ul class="dropdown-menu dropdown-menu-end animate__animated animate__fadeIn" aria-labelledby="notificationMenu" style="min-width: 24rem;">
+                            <ul class="dropdown-menu dropdown-menu-end border-0 shadow animate__animated animate__fadeIn" aria-labelledby="notificationMenu" style="min-width: 24rem;">
                                 <?php if (empty($recentNotifications)): ?>
                                     <li><span class="dropdown-item-text text-muted">未読通知はありません</span></li>
                                 <?php else: ?>
                                     <?php foreach ($recentNotifications as $notification): ?>
                                         <li>
-                                            <a class="dropdown-item text-wrap" href="<?= $this->Url->build('/Notifications') ?>">
+                                            <a class="dropdown-item text-wrap border-bottom py-2" href="<?= $this->Url->build('/Notifications') ?>">
                                                 <div class="d-flex justify-content-between align-items-start gap-2">
-                                                    <strong class="<?= (int)$notification->i_is_read === 0 ? 'text-dark' : 'text-muted' ?>">
+                                                    <strong class="<?= (int)$notification->i_is_read === 0 ? 'text-dark' : 'text-muted' ?> small">
                                                         <?= h($notification->c_title) ?>
                                                     </strong>
                                                     <?php if ((int)$notification->i_is_read === 0): ?>
-                                                        <span class="badge bg-danger">未読</span>
+                                                        <span class="badge bg-danger" style="font-size: 0.6rem;">未読</span>
                                                     <?php endif; ?>
                                                 </div>
-                                                <div class="small text-muted mt-1"><?= h($notification->c_message) ?></div>
+                                                <div class="small text-muted mt-1" style="font-size: 0.75rem;"><?= h($notification->c_message) ?></div>
                                             </a>
                                         </li>
                                     <?php endforeach; ?>
-                                    <li><hr class="dropdown-divider"></li>
                                 <?php endif; ?>
-                                <li><?= $this->Html->link('通知一覧を開く', ['controller' => 'Notifications', 'action' => 'index'], ['class' => 'dropdown-item']) ?></li>
+                                <li class="text-center pt-2"><?= $this->Html->link('すべての通知を表示', ['controller' => 'Notifications', 'action' => 'index'], ['class' => 'dropdown-item small text-primary']) ?></li>
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <?= !empty($user->i_id_staff) ? '<span class="small text-light">(職員ID: ' . h($user->i_id_staff) . ')</span>' : '' ?>
-                                <?= h($user->c_user_name) ?>
+                            <a class="nav-link dropdown-toggle text-white rounded-pill px-3" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="background: rgba(255,255,255,0.2);">
+                                <i class="bi bi-person-circle"></i>
+                                <span class="d-inline-block text-truncate" style="max-width: 100px;"><?= h($user->c_user_name) ?></span>
                             </a>
-                            <ul class="dropdown-menu dropdown-menu-end animate__animated animate__fadeIn" aria-labelledby="userMenu">
+                            <ul class="dropdown-menu dropdown-menu-end border-0 shadow animate__animated animate__fadeIn" aria-labelledby="userMenu">
+                                <li class="dropdown-header">
+                                    <?= !empty($user->i_id_staff) ? '職員ID: ' . h($user->i_id_staff) : 'ユーザー' ?>
+                                </li>
                                 <li><?= $this->Html->link('👤 プロフィール', ['controller' => 'MUserInfo', 'action' => 'view', $user->i_id_user], ['class' => 'dropdown-item']) ?></li>
                                 <li><?= $this->Html->link('🔑 パスワード変更', ['controller' => 'MUserInfo', 'action' => 'generalPasswordReset'], ['class' => 'dropdown-item']) ?></li>
                                 <?php if ($isAdmin): ?>
                                     <li><?= $this->Html->link('🔑 管理者：パスワード変更', ['controller' => 'MUserInfo', 'action' => 'adminChangePassword'], ['class' => 'dropdown-item']) ?></li>
                                 <?php endif; ?>
-                                <li><?= $this->Html->link('🚪 ログアウト', ['controller' => 'MUserInfo', 'action' => 'logout'], ['class' => 'dropdown-item']) ?></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><?= $this->Html->link('🚪 ログアウト', ['controller' => 'MUserInfo', 'action' => 'logout'], ['class' => 'dropdown-item text-danger']) ?></li>
                             </ul>
                         </li>
                     <?php else: ?>
                         <li class="nav-item">
-                            <?= $this->Html->link('ログイン', ['controller' => 'MUserInfo', 'action' => 'login'], ['class' => 'nav-link']) ?>
+                            <?= $this->Html->link('ログイン', ['controller' => 'MUserInfo', 'action' => 'login'], ['class' => 'btn btn-outline-info rounded-pill px-4']) ?>
                         </li>
                     <?php endif; ?>
                 </ul>
             </div>
         </div>
     </nav>
+
+    <?php if ($user): ?>
+        <button id="ai-assistant-fab" title="AI助手に質問">
+            <i class="bi bi-robot"></i>
+            <span class="spinner-border spinner-border-sm d-none" id="ai-assistant-loading-fab" role="status"></span>
+        </button>
+
+        <!-- AI Assistant Chat Panel (Replaced Modal) -->
+        <div id="ai-assistant-panel" class="shadow-lg border">
+            <div class="panel-header bg-info text-white d-flex align-items-center justify-content-between p-3">
+                <h5 class="m-0"><i class="bi bi-robot me-2"></i>AI助手</h5>
+                <button type="button" class="btn-close btn-close-white" id="ai-panel-close"></button>
+            </div>
+            <div class="panel-body bg-light p-3">
+                <div id="ai-chat-box" class="mb-3 p-3 border rounded bg-white shadow-sm">
+                    <div class="mb-3 p-2 rounded bg-info bg-opacity-10">
+                        <strong>AI助手:</strong><br>
+                        こんにちは！「食数管理システム」の使い方について何でも聞いてください。<br>
+                        どのようなお手伝いが必要ですか？
+                    </div>
+                </div>
+                <form id="ai-assistant-form">
+                    <div class="input-group">
+                        <input type="text" id="ai-question" class="form-control form-control-sm" placeholder="質問を入力..." required>
+                        <button class="btn btn-info text-white btn-sm px-3" type="submit" id="ai-submit-btn">
+                            <i class="bi bi-send"></i>
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    <?php endif; ?>
 <?php endif; ?>
 
 <main class="<?= $isModal ? '' : 'container mt-3' ?>">
@@ -181,6 +222,7 @@ $recentNotifications     = $recentNotifications ?? [];
 <?= $this->Html->script('jquery-3.5.1.min.js') ?>
 <?= $this->Html->script('bootstrap.bundle.min.js') ?>
 <?= $this->Html->script('confirm_popup.js') ?>
+<?= $this->Html->script('ai-assistant.js') ?>
 
 <script>
     (() => {
@@ -188,7 +230,9 @@ $recentNotifications     = $recentNotifications ?? [];
         if (!nav) return;
 
         const applyPad = () => {
-            document.body.style.paddingTop = nav.getBoundingClientRect().height + 'px';
+            const height = nav.getBoundingClientRect().height;
+            document.body.style.paddingTop = height + 'px';
+            document.documentElement.style.setProperty('--nav-height', height + 'px');
         };
 
         applyPad();

--- a/src_web/kamaho-shokusu/webroot/js/ai-assistant.js
+++ b/src_web/kamaho-shokusu/webroot/js/ai-assistant.js
@@ -1,0 +1,166 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const aiButton = document.getElementById('ai-assistant-fab');
+    const aiPanel = document.getElementById('ai-assistant-panel');
+    const aiPanelClose = document.getElementById('ai-panel-close');
+    const aiForm = document.getElementById('ai-assistant-form');
+    const aiQuestion = document.getElementById('ai-question');
+    const aiChatBox = document.getElementById('ai-chat-box');
+    const aiSubmitBtn = document.getElementById('ai-submit-btn');
+    const aiLoadingFab = document.getElementById('ai-assistant-loading-fab');
+
+    if (!aiButton || !aiPanel) return;
+
+    aiButton.addEventListener('click', function() {
+        aiPanel.classList.toggle('show');
+        if (aiPanel.classList.contains('show')) {
+            aiQuestion.focus();
+            scrollToBottom();
+        }
+    });
+
+    if (aiPanelClose) {
+        aiPanelClose.addEventListener('click', function() {
+            aiPanel.classList.remove('show');
+        });
+    }
+
+    // パネル外クリックで閉じる（オプション）
+    document.addEventListener('click', function(e) {
+        if (!aiPanel.contains(e.target) && !aiButton.contains(e.target) && aiPanel.classList.contains('show')) {
+            aiPanel.classList.remove('show');
+        }
+    });
+
+    aiForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const question = aiQuestion.value.trim();
+        if (!question || aiSubmitBtn.disabled) return;
+
+        // ユーザーの質問を表示
+        appendMessage('user', question);
+        aiQuestion.value = '';
+        
+        // ローディング表示（IDではなく要素参照を直接保持する）
+        const loadingEl = createLoadingMessage();
+        aiChatBox.appendChild(loadingEl);
+        aiChatBox.scrollTop = aiChatBox.scrollHeight;
+
+        aiSubmitBtn.disabled = true;
+        if (aiLoadingFab) aiLoadingFab.classList.remove('d-none');
+        const robotIcon = aiButton ? aiButton.querySelector('i') : null;
+        if (robotIcon) robotIcon.classList.add('d-none');
+
+        // コンテキストの取得
+        let context = `現在のページ: ${document.title}\nURL: ${window.location.href}`;
+        
+        // ページ内の主要な見出しや説明文があればコンテキストに含める
+        const mainHeading = document.querySelector('h1, h2');
+        if (mainHeading) {
+            context += `\n画面見出し: ${mainHeading.innerText.trim()}`;
+        }
+
+        const description = document.querySelector('.description, .help-block');
+        if (description) {
+            context += `\n画面説明: ${description.innerText.trim().substring(0, 200)}`;
+        }
+
+        // ベースパスを取得（サブディレクトリ運用への対応）
+        // meta[name="csrfToken"] の存在確認
+        const csrfTokenMeta = document.querySelector('meta[name="csrfToken"]');
+        const csrfToken = csrfTokenMeta ? csrfTokenMeta.content : '';
+
+        // APIのURLを構築（PHP側で生成された URL があれば優先する）
+        const askUrl = window.AI_ASSISTANT_ASK_URL || '/AiAssistant/ask';
+
+        fetch(askUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRF-Token': csrfToken,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json'
+            },
+            body: new URLSearchParams({
+                'question': question,
+                'context': context
+            })
+        })
+        .then(async response => {
+            const contentType = response.headers.get('content-type');
+            if (!response.ok) {
+                let errorMessage = 'エラーが発生しました';
+                if (contentType && contentType.includes('application/json')) {
+                    const errData = await response.json();
+                    errorMessage = errData.message || errorMessage;
+                } else {
+                    errorMessage = `サーバーエラーが発生しました (Status: ${response.status})`;
+                }
+                throw new Error(errorMessage);
+            }
+            if (!contentType || !contentType.includes('application/json')) {
+                throw new Error('サーバーから不正な応答（HTML）が返されました。URL設定を確認してください。');
+            }
+            return response.json();
+        })
+        .then(data => {
+            loadingEl.remove();
+            if (aiLoadingFab) aiLoadingFab.classList.add('d-none');
+            if (robotIcon) robotIcon.classList.remove('d-none');
+            
+            // 回答内のURLをリンクに変換（安全にHTMLをエスケープした後にリンク化）
+            const escapedAnswer = data.answer
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+            
+            const urlRegex = /(https?:\/\/[^\s<]+|\[([^\]]+)\]\(([^\)]+)\))/g;
+            const linkedAnswer = escapedAnswer.replace(urlRegex, function(match, url, label, path) {
+                if (url && !label) {
+                    // 通常のURL (http...)
+                    return '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + url + '</a>';
+                } else if (label && path) {
+                    // Markdown形式のリンク [ラベル](パス)
+                    // セキュリティのため、パスが http で始まるか / で始まるもののみ許可
+                    if (path.startsWith('http') || path.startsWith('/')) {
+                        return '<a href="' + path + '" target="_blank" rel="noopener noreferrer">' + label + '</a>';
+                    }
+                    return match;
+                }
+                return match;
+            });
+            
+            const formattedAnswer = linkedAnswer.replace(/\n/g, '<br>');
+            appendMessage('ai', formattedAnswer);
+        })
+        .catch(error => {
+            loadingEl.remove();
+            if (aiLoadingFab) aiLoadingFab.classList.add('d-none');
+            if (robotIcon) robotIcon.classList.remove('d-none');
+            appendMessage('ai', `<span class="text-danger">エラー: ${error.message}</span>`);
+        })
+        .finally(() => {
+            aiSubmitBtn.disabled = false;
+        });
+    });
+
+    function appendMessage(role, text) {
+        const div = document.createElement('div');
+        div.className = `mb-3 p-2 rounded ${role === 'user' ? 'bg-light text-end' : 'bg-info bg-opacity-10'}`;
+        div.innerHTML = `<strong>${role === 'user' ? 'あなた' : 'AI助手'}:</strong><br>${text}`;
+        aiChatBox.appendChild(div);
+        aiChatBox.scrollTop = aiChatBox.scrollHeight;
+    }
+
+    function createLoadingMessage() {
+        const div = document.createElement('div');
+        div.className = 'mb-3 p-2 rounded bg-info bg-opacity-10';
+        div.innerHTML = '<strong>AI助手:</strong><br><div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div> 考え中...';
+        return div;
+    }
+
+    function scrollToBottom() {
+        aiChatBox.scrollTop = aiChatBox.scrollHeight;
+    }
+});


### PR DESCRIPTION
## 概要

AI アシスタントで「食数管理システムに無関係な質問」をした際、AI の回答（「回答できません」）が表示されても、その上に「考え中...」スピナーが残り続ける問題を修正します。

## 原因

`removeMessage(loadingId)` は `Date.now()` ベースのID文字列で `getElementById` を使って要素を検索していました。Promise チェーン内で例外が発生した場合（例：`aiButton.querySelector('i')` が null を返す場合など）、要素参照が失われて「考え中」要素が削除されないケースがありました。また、`aiButton.querySelector('i')` に対する null チェックがなく、`TypeError` が発生する可能性がありました。

## 変更内容

- `appendMessage()` の戻り値（ID文字列）を使う方式をやめ、`createLoadingMessage()` で要素を直接生成・返却する方式に変更
- `.then` / `.catch` の両ハンドラで `loadingEl.remove()` を直接呼び出すことで、ID検索の失敗リスクを排除
- `aiButton.querySelector('i')` の結果を `robotIcon` 変数に先に保存し、null チェックを追加
- 不要になった `removeMessage()` 関数を削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AIアシスタントのチャットUIを追加し、画面上から質問できるようになりました。
  * フローティングボタンでパネルを開閉でき、チャット履歴の表示や送信状態の確認が可能です。
  * ページ情報をもとに文脈を含めて質問を送信し、回答内のURLやリンクをクリック可能な形式で表示します。
  * 送信失敗時は内容に応じたエラーメッセージを表示し、再送信しやすく改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->