### PR TITLE
fix: AI助手のリンクにアプリベースパスを補完してステージング環境での404を解消

### DIFF
--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -14,7 +14,8 @@
     <?= $this->Html->css('layout-header.css') ?>
     <?= $this->Html->script('api_response.js') ?>
     <script>
-        window.AI_ASSISTANT_ASK_URL = '<?= $this->Url->build(['controller' => 'AiAssistant', 'action' => 'ask']) ?>';
+        window.AI_ASSISTANT_ASK_URL  = '<?= $this->Url->build(['controller' => 'AiAssistant', 'action' => 'ask']) ?>';
+        window.AI_ASSISTANT_BASE_URL = '<?= rtrim($this->Url->build('/'), '/') ?>';
     </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <?= $this->fetch('meta') ?>

--- a/src_web/kamaho-shokusu/webroot/js/ai-assistant.js
+++ b/src_web/kamaho-shokusu/webroot/js/ai-assistant.js
@@ -114,7 +114,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#039;');
-            
+
+            // サブディレクトリ運用（例: /kamaho-shokusu）でのベースパスを取得
+            const appBase = (window.AI_ASSISTANT_BASE_URL || '').replace(/\/$/, '');
+
             const urlRegex = /(https?:\/\/[^\s<]+|\[([^\]]+)\]\(([^\)]+)\))/g;
             const linkedAnswer = escapedAnswer.replace(urlRegex, function(match, url, label, path) {
                 if (url && !label) {
@@ -122,9 +125,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     return '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + url + '</a>';
                 } else if (label && path) {
                     // Markdown形式のリンク [ラベル](パス)
-                    // セキュリティのため、パスが http で始まるか / で始まるもののみ許可
-                    if (path.startsWith('http') || path.startsWith('/')) {
+                    if (path.startsWith('http')) {
                         return '<a href="' + path + '" target="_blank" rel="noopener noreferrer">' + label + '</a>';
+                    }
+                    // ルート相対パス（/で始まる）にはアプリのベースパスを補完する
+                    if (path.startsWith('/')) {
+                        return '<a href="' + appBase + path + '" target="_blank" rel="noopener noreferrer">' + label + '</a>';
                     }
                     return match;
                 }


### PR DESCRIPTION
## 概要

ステージング環境（`stg.kamaho-shokusu.jp/kamaho-shokusu/`）でAI助手が生成するリンクが404になる問題を修正します。

## 問題の原因

AIのシステムプロンプトは `[個人予約](/TReservationInfo)` のようなルート相対パスを例示しています。しかしステージング環境ではアプリが `/kamaho-shokusu/` サブディレクトリ下で動作するため、正しいURLは `/kamaho-shokusu/TReservationInfo` でなければなりません。

## 変更内容

### `templates/layout/default.php`
- `window.AI_ASSISTANT_BASE_URL` を追加
- CakePHPの `$this->Url->build('/')` でアプリのベースパスを取得し、JSに渡す
- 本番（ルート運用）では空文字、ステージングでは `/kamaho-shokusu` が設定される

### `webroot/js/ai-assistant.js`
- リンク処理時に `window.AI_ASSISTANT_BASE_URL` を取得
- `/` で始まるルート相対パスにベースパスを補完してリンクを生成
  - 例: `/TReservationInfo` → `/kamaho-shokusu/TReservationInfo`
- `http://` で始まる絶対URLはそのまま使用

## 動作確認ポイント
- [ ] ステージング環境でAI助手の回答リンクをクリックして正しいページに遷移すること
- [ ] 本番環境（ルート運用）でリンクが変わらず動作すること

Closes #465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AIアシスタントのリンク表示が改善され、ルート相対リンクがアプリの設置先パスに合わせて正しく遷移するようになりました。
  * AIアシスタント画面で使う基準URLの扱いが調整され、サブディレクトリ配下でもリンク先が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->