### PR TITLE
fix: AI助手の表示名を「お問い合わせAI」に変更

### DIFF
--- a/src_web/kamaho-shokusu/src/Application/AI/AiUserRole.php
+++ b/src_web/kamaho-shokusu/src/Application/AI/AiUserRole.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace App\Application\AI;
 
 /**
- * AI助手がシステムプロンプトを組み立てる際に使用するロール識別子。
+ * お問い合わせAIがシステムプロンプトを組み立てる際に使用するロール識別子。
  *
  * Domain の UserRole（i_admin 値）と 1:1 に対応するが、
  * AI プロンプト生成という Application 層の関心事として分離する。

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -183,7 +183,7 @@ $recentNotifications     = $recentNotifications ?? [];
     </nav>
 
     <?php if ($user): ?>
-        <button id="ai-assistant-fab" title="AI助手に質問">
+        <button id="ai-assistant-fab" title="お問い合わせAIに質問">
             <i class="bi bi-robot"></i>
             <span class="spinner-border spinner-border-sm d-none" id="ai-assistant-loading-fab" role="status"></span>
         </button>
@@ -191,13 +191,13 @@ $recentNotifications     = $recentNotifications ?? [];
         <!-- AI Assistant Chat Panel (Replaced Modal) -->
         <div id="ai-assistant-panel" class="shadow-lg border">
             <div class="panel-header bg-info text-white d-flex align-items-center justify-content-between p-3">
-                <h5 class="m-0"><i class="bi bi-robot me-2"></i>AI助手</h5>
+                <h5 class="m-0"><i class="bi bi-robot me-2"></i>お問い合わせAI</h5>
                 <button type="button" class="btn-close btn-close-white" id="ai-panel-close"></button>
             </div>
             <div class="panel-body bg-light p-3">
                 <div id="ai-chat-box" class="mb-3 p-3 border rounded bg-white shadow-sm">
                     <div class="mb-3 p-2 rounded bg-info bg-opacity-10">
-                        <strong>AI助手:</strong><br>
+                        <strong>お問い合わせAI:</strong><br>
                         こんにちは！「食数管理システム」の使い方について何でも聞いてください。<br>
                         どのようなお手伝いが必要ですか？
                     </div>


### PR DESCRIPTION
## 変更内容

- `templates/layout/default.php` — チャットボタンのtooltip・パネルヘッダー・初期メッセージ送信者名の「AI助手」を「お問い合わせAI」に変更（3箇所）
- `src/Application/AI/AiUserRole.php` — PHPDocコメント内の「AI助手」を「お問い合わせAI」に変更（1箇所）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * ログイン中ユーザー向けの「お問い合わせAI」表示文言を、画面内の各所で統一しました。
  * ボタン、パネル見出し、初期表示ラベルがより分かりやすい表現に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->