### PR TITLE
fix: #470 一般職員が子供の予約セルを操作できない問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -603,7 +603,7 @@ class TReservationInfoController extends ReservationBaseController
         $loginUser = $this->request->getAttribute('identity');
         if ($loginUser !== null) {
             $isAdmin  = UserRole::isAdmin((int)($loginUser->get('i_admin') ?? 0));
-            $isStaff  = (int)($loginUser->get('i_user_level') ?? -1) === 0;
+            $isStaff  = in_array((int)($loginUser->get('i_user_level') ?? -1), [0, 7], true);
             if (!$isAdmin && !$isStaff) {
                 $loginUidEarly = (int)($loginUser->get('i_id_user') ?? 0);
                 $hasAffiliation = $loginUidEarly > 0 && $this->changeEditService->userHasRoomAccess($loginUidEarly);

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -71,8 +71,8 @@ class TReservationInfoPolicy
             return true;
         }
 
-        // 職員IDを持つユーザーは子供の予約編集を試みられる（サービス層で対象が子供かを検証）
-        if ($this->hasStaffId($user)) {
+        // 職員（level 0/7）は子供の予約編集を試みられる（サービス層で対象が子供かを検証）
+        if ($this->isStaff($user)) {
             return true;
         }
 
@@ -278,15 +278,15 @@ class TReservationInfoPolicy
         }
 
         if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_user_level') === 0;
+            return in_array((int)$identity->get('i_user_level'), [0, 7], true);
         }
 
         if (is_array($identity)) {
-            return (int)($identity['i_user_level'] ?? -1) === 0;
+            return in_array((int)($identity['i_user_level'] ?? -1), [0, 7], true);
         }
 
         if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_user_level'] ?? -1) === 0;
+            return in_array((int)($identity['i_user_level'] ?? -1), [0, 7], true);
         }
 
         return false;


### PR DESCRIPTION
Closes #470

## 変更内容

### バグ修正

- **`TReservationInfoPolicy::isStaff()`** を `i_user_level === 0` のみから `in_array([0, 7])` に拡張し、level 7 職員も「職員」として扱うよう修正
- **`TReservationInfoPolicy::canToggle()`** で他ユーザーの予約トグル許可判定を `hasStaffId()`（`i_id_staff` カラム依存）から `isStaff()`（level 0/7 判定）に変更
  - `i_id_staff` が未設定の一般職員（level 0/7）でも、子供（level 1）の予約セルをクリックして予約追加・削除が可能になった
- **`TReservationInfoController::changeEdit()`** 前段の `$isStaff` 判定も `=== 0` から `in_array([0, 7])` に拡張し、level 7 職員も直前編集画面にアクセス可能になった

### 背景

サービス層（`ReservationWriteService::processToggle()`）は既に level 0/7 職員が子供（level=1）の予約を編集できるロジックを持っていたが、ポリシー層が `hasStaffId`（`i_id_staff` の有無）で判断していたため、`i_id_staff` 未設定の職員は 403 エラーで弾かれていた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 職員として扱われる条件を見直し、ユーザーレベルが「0」に加えて「7」でも職員権限として判定されるようになりました。
  * 予約情報の切り替え操作で、より適切な権限判定が行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->