### PR TITLE
hotfix: ApprovalController の UserRole use 宣言を追加

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Domain\ValueObject\UserRole;
 use App\Service\ApprovalService;
 use App\Service\RoomAccessService;
 use Cake\Http\Response;


### PR DESCRIPTION
## 概要

`ApprovalController.php` で `UserRole` クラスを利用しているが、`use` 宣言が欠けているため `/Approval/approval_log` でシステムエラー（`Class "App\Controller\UserRole" not found`）が発生していた。

## 変更内容

- `src/Controller/ApprovalController.php` に `use App\Domain\ValueObject\UserRole;` を追加

## 影響範囲

- `ApprovalController.php` のみ（1行追加）
- 他のファイルへの変更なし

## テスト手順

1. `/Approval/approval_log` にアクセスしてシステムエラーが解消されていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 承認履歴の表示に関する権限判定が正しく動作するようになりました。
  * 管理者やブロックリーダー向けの表示条件が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->