### PR TITLE
Resolve #474: Domain・全サービス層のテストケースを強化

### DIFF
--- a/src_web/kamaho-shokusu/tests/Fixture/MRoomTransferScheduleFixture.php
+++ b/src_web/kamaho-shokusu/tests/Fixture/MRoomTransferScheduleFixture.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class MRoomTransferScheduleFixture extends TestFixture
+{
+    public string $table = 'm_room_transfer_schedule';
+
+    public function init(): void
+    {
+        $this->records = [];
+        parent::init();
+    }
+}

--- a/src_web/kamaho-shokusu/tests/Fixture/MRoomTransferScheduleFixture.php
+++ b/src_web/kamaho-shokusu/tests/Fixture/MRoomTransferScheduleFixture.php
@@ -5,10 +5,16 @@ namespace App\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 
+/**
+ * m_room_transfer_schedule テーブル用フィクスチャ。
+ *
+ * テスト用に空レコードでテーブルを準備する。
+ */
 class MRoomTransferScheduleFixture extends TestFixture
 {
     public string $table = 'm_room_transfer_schedule';
 
+    /** @throws \Exception */
     public function init(): void
     {
         $this->records = [];

--- a/src_web/kamaho-shokusu/tests/TestCase/Domain/Exception/DomainExceptionTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Domain/Exception/DomainExceptionTest.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Domain\Exception;
+
+use App\Domain\Exception\ConflictException;
+use App\Domain\Exception\DomainException;
+use App\Domain\Exception\InvalidInputException;
+use App\Domain\Exception\NotFoundException;
+use App\Domain\Exception\UnauthorizedException;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Domain 例外クラスのテスト。
+ *
+ * 各例外が正しい HTTP ステータスコードとメッセージを返すことを検証する。
+ */
+class DomainExceptionTest extends TestCase
+{
+    // ----------------------------------------------------------------
+    // 継承関係
+    // ----------------------------------------------------------------
+
+    public function testAllExceptionsExtendDomainException(): void
+    {
+        $this->assertInstanceOf(DomainException::class, new InvalidInputException('test'));
+        $this->assertInstanceOf(DomainException::class, new NotFoundException());
+        $this->assertInstanceOf(DomainException::class, new ConflictException());
+        $this->assertInstanceOf(DomainException::class, new UnauthorizedException());
+    }
+
+    // ----------------------------------------------------------------
+    // InvalidInputException
+    // ----------------------------------------------------------------
+
+    public function testInvalidInputExceptionDefaultStatusIs422(): void
+    {
+        $e = new InvalidInputException('入力エラー');
+
+        $this->assertSame(422, $e->getStatusCode());
+        $this->assertSame('入力エラー', $e->getMessage());
+    }
+
+    public function testInvalidInputExceptionAcceptsCustomStatus(): void
+    {
+        $e = new InvalidInputException('不正なリクエスト', 400);
+
+        $this->assertSame(400, $e->getStatusCode());
+    }
+
+    // ----------------------------------------------------------------
+    // NotFoundException
+    // ----------------------------------------------------------------
+
+    public function testNotFoundExceptionStatusIs404(): void
+    {
+        $e = new NotFoundException();
+
+        $this->assertSame(404, $e->getStatusCode());
+    }
+
+    public function testNotFoundExceptionHasDefaultMessage(): void
+    {
+        $e = new NotFoundException();
+
+        $this->assertSame('リソースが見つかりません。', $e->getMessage());
+    }
+
+    public function testNotFoundExceptionAcceptsCustomMessage(): void
+    {
+        $e = new NotFoundException('ユーザーが見つかりません。');
+
+        $this->assertSame('ユーザーが見つかりません。', $e->getMessage());
+    }
+
+    // ----------------------------------------------------------------
+    // ConflictException
+    // ----------------------------------------------------------------
+
+    public function testConflictExceptionStatusIs409(): void
+    {
+        $e = new ConflictException();
+
+        $this->assertSame(409, $e->getStatusCode());
+    }
+
+    public function testConflictExceptionHasDefaultMessage(): void
+    {
+        $e = new ConflictException();
+
+        $this->assertSame('既に登録されています。', $e->getMessage());
+    }
+
+    public function testConflictExceptionAcceptsCustomMessage(): void
+    {
+        $e = new ConflictException('この日付は既に予約済みです。');
+
+        $this->assertSame('この日付は既に予約済みです。', $e->getMessage());
+    }
+
+    // ----------------------------------------------------------------
+    // UnauthorizedException
+    // ----------------------------------------------------------------
+
+    public function testUnauthorizedExceptionStatusIs403(): void
+    {
+        $e = new UnauthorizedException();
+
+        $this->assertSame(403, $e->getStatusCode());
+    }
+
+    public function testUnauthorizedExceptionHasDefaultMessage(): void
+    {
+        $e = new UnauthorizedException();
+
+        $this->assertSame('操作権限がありません。', $e->getMessage());
+    }
+
+    public function testUnauthorizedExceptionAcceptsCustomMessage(): void
+    {
+        $e = new UnauthorizedException('この部屋へのアクセス権がありません。');
+
+        $this->assertSame('この部屋へのアクセス権がありません。', $e->getMessage());
+    }
+
+    // ----------------------------------------------------------------
+    // 例外として throw できることの確認
+    // ----------------------------------------------------------------
+
+    public function testExceptionsAreThrowable(): void
+    {
+        $this->expectException(DomainException::class);
+        throw new NotFoundException();
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Domain/ValueObject/UserRoleTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Domain/ValueObject/UserRoleTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Domain\ValueObject;
+
+use App\Domain\ValueObject\UserRole;
+use Cake\TestSuite\TestCase;
+
+/**
+ * UserRole 値オブジェクトのテスト。
+ *
+ * 定数値とロール判定メソッドが正しく機能することを検証する。
+ */
+class UserRoleTest extends TestCase
+{
+    // ----------------------------------------------------------------
+    // 定数値
+    // ----------------------------------------------------------------
+
+    public function testConstantsHaveExpectedValues(): void
+    {
+        $this->assertSame(0, UserRole::GENERAL);
+        $this->assertSame(1, UserRole::ADMIN);
+        $this->assertSame(2, UserRole::BLOCK_LEADER);
+        $this->assertSame(3, UserRole::SYSTEM_ADMIN);
+    }
+
+    // ----------------------------------------------------------------
+    // isAdmin
+    // ----------------------------------------------------------------
+
+    public function testIsAdminReturnsTrueForAdmin(): void
+    {
+        $this->assertTrue(UserRole::isAdmin(UserRole::ADMIN));
+    }
+
+    public function testIsAdminReturnsTrueForSystemAdmin(): void
+    {
+        $this->assertTrue(UserRole::isAdmin(UserRole::SYSTEM_ADMIN));
+    }
+
+    public function testIsAdminReturnsFalseForGeneral(): void
+    {
+        $this->assertFalse(UserRole::isAdmin(UserRole::GENERAL));
+    }
+
+    public function testIsAdminReturnsFalseForBlockLeader(): void
+    {
+        $this->assertFalse(UserRole::isAdmin(UserRole::BLOCK_LEADER));
+    }
+
+    // ----------------------------------------------------------------
+    // isBlockLeader
+    // ----------------------------------------------------------------
+
+    public function testIsBlockLeaderReturnsTrueForBlockLeader(): void
+    {
+        $this->assertTrue(UserRole::isBlockLeader(UserRole::BLOCK_LEADER));
+    }
+
+    public function testIsBlockLeaderReturnsFalseForGeneral(): void
+    {
+        $this->assertFalse(UserRole::isBlockLeader(UserRole::GENERAL));
+    }
+
+    public function testIsBlockLeaderReturnsFalseForAdmin(): void
+    {
+        $this->assertFalse(UserRole::isBlockLeader(UserRole::ADMIN));
+    }
+
+    public function testIsBlockLeaderReturnsFalseForSystemAdmin(): void
+    {
+        $this->assertFalse(UserRole::isBlockLeader(UserRole::SYSTEM_ADMIN));
+    }
+
+    // ----------------------------------------------------------------
+    // isSystemAdmin
+    // ----------------------------------------------------------------
+
+    public function testIsSystemAdminReturnsTrueForSystemAdmin(): void
+    {
+        $this->assertTrue(UserRole::isSystemAdmin(UserRole::SYSTEM_ADMIN));
+    }
+
+    public function testIsSystemAdminReturnsFalseForAdmin(): void
+    {
+        $this->assertFalse(UserRole::isSystemAdmin(UserRole::ADMIN));
+    }
+
+    public function testIsSystemAdminReturnsFalseForGeneral(): void
+    {
+        $this->assertFalse(UserRole::isSystemAdmin(UserRole::GENERAL));
+    }
+
+    public function testIsSystemAdminReturnsFalseForBlockLeader(): void
+    {
+        $this->assertFalse(UserRole::isSystemAdmin(UserRole::BLOCK_LEADER));
+    }
+
+    // ----------------------------------------------------------------
+    // データプロバイダーを使った網羅テスト
+    // ----------------------------------------------------------------
+
+    /**
+     * @dataProvider isAdminProvider
+     */
+    public function testIsAdminExhaustive(int $value, bool $expected): void
+    {
+        $this->assertSame($expected, UserRole::isAdmin($value));
+    }
+
+    public static function isAdminProvider(): array
+    {
+        return [
+            'GENERAL(0) → false'      => [0, false],
+            'ADMIN(1) → true'         => [1, true],
+            'BLOCK_LEADER(2) → false' => [2, false],
+            'SYSTEM_ADMIN(3) → true'  => [3, true],
+        ];
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ActualMealManagementService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ActualMealManagementServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+        'app.TAuditLog',
+    ];
+
+    private ActualMealManagementService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ActualMealManagementService();
+    }
+
+    // ----------------------------------------------------------------
+    // getAdminOldestAllowedMonday — DB不要
+    // ----------------------------------------------------------------
+
+    public function testGetAdminOldestAllowedMonday_returnsDateTimeImmutable(): void
+    {
+        $result = $this->service->getAdminOldestAllowedMonday();
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+    }
+
+    public function testGetAdminOldestAllowedMonday_returnsMonday(): void
+    {
+        $result = $this->service->getAdminOldestAllowedMonday();
+        // ISO weekday: 1 = Monday
+        $this->assertSame('1', $result->format('N'));
+    }
+
+    public function testGetAdminOldestAllowedMonday_isApproximatelyTwoMonthsAgo(): void
+    {
+        $result = $this->service->getAdminOldestAllowedMonday();
+        $now    = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
+
+        // 2ヶ月前 ±7日の範囲内であること
+        $twoMonthsAgo = $now->modify('-2 months');
+        $diff = abs((int)$result->diff($twoMonthsAgo)->days);
+        $this->assertLessThanOrEqual(7, $diff);
+    }
+
+    // ----------------------------------------------------------------
+    // getAdultUsers — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetAdultUsers_returnsArray(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $userTable      = TableRegistry::getTableLocator()->get('MUserInfo');
+
+        $result = $this->service->getAdultUsers($userGroupTable, $userTable, 1);
+
+        $this->assertIsArray($result);
+    }
+
+    public function testGetAdultUsers_returnsExpectedKeys(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $userTable      = TableRegistry::getTableLocator()->get('MUserInfo');
+
+        $result = $this->service->getAdultUsers($userGroupTable, $userTable, 1);
+
+        // フィクスチャのユーザーは i_id_staff が null なので空配列が返るはず
+        // (staff_id 未設定ユーザーは除外される)
+        $this->assertIsArray($result);
+        foreach ($result as $user) {
+            $this->assertArrayHasKey('id', $user);
+            $this->assertArrayHasKey('name', $user);
+            $this->assertArrayHasKey('staff_id', $user);
+        }
+    }
+
+    public function testGetAdultUsers_nonExistentRoom_returnsEmpty(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $userTable      = TableRegistry::getTableLocator()->get('MUserInfo');
+
+        $result = $this->service->getAdultUsers($userGroupTable, $userTable, 9999);
+
+        $this->assertSame([], $result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildWeekGrid — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildWeekGrid_returnsRequiredKeys(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $monday = (new \DateTimeImmutable('monday this week'))->format('Y-m-d');
+
+        $result = $this->service->buildWeekGrid($reservationTable, [], $monday);
+
+        $this->assertArrayHasKey('dates', $result);
+        $this->assertArrayHasKey('meals', $result);
+        $this->assertArrayHasKey('grid', $result);
+        $this->assertArrayHasKey('versions', $result);
+        $this->assertArrayHasKey('statuses', $result);
+    }
+
+    public function testBuildWeekGrid_emptyUsers_returnSevenDates(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $monday = (new \DateTimeImmutable('monday this week'))->format('Y-m-d');
+
+        $result = $this->service->buildWeekGrid($reservationTable, [], $monday);
+
+        $this->assertCount(7, $result['dates']);
+        $this->assertSame([], $result['grid']);
+    }
+
+    public function testBuildWeekGrid_mealsHasThreeTypes(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $monday = (new \DateTimeImmutable('monday this week'))->format('Y-m-d');
+
+        $result = $this->service->buildWeekGrid($reservationTable, [], $monday);
+
+        $this->assertArrayHasKey(1, $result['meals']);
+        $this->assertArrayHasKey(2, $result['meals']);
+        $this->assertArrayHasKey(3, $result['meals']);
+    }
+
+    // ----------------------------------------------------------------
+    // saveActualMeal — 無効な食事タイプのガード条件
+    // ----------------------------------------------------------------
+
+    public function testSaveActualMeal_invalidMealType_returnsError(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->saveActualMeal(
+            $reservationTable,
+            userId: 1,
+            roomId: 1,
+            date: '2099-01-01',
+            mealType: 4, // 4 は無効 (1,2,3 のみ有効)
+            checked: true,
+            expectedVersion: 1,
+            actor: 'tester'
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('無効な食事タイプ', $result['message']);
+    }
+
+    // ----------------------------------------------------------------
+    // requestApproval — 空キーのガード条件
+    // ----------------------------------------------------------------
+
+    public function testRequestApproval_emptyKeys_returnsZero(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->requestApproval($reservationTable, [], 'tester');
+
+        $this->assertSame(0, $result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ActualMealManagementServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\ActualMealManagementService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ActualMealManagementService テスト。
+ *
+ * getAdminOldestAllowedMonday・getAdultUsers・buildWeekGrid・saveActualMeal・requestApproval の挙動を検証する。
+ */
 class ActualMealManagementServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -74,14 +79,8 @@ class ActualMealManagementServiceTest extends TestCase
 
         $result = $this->service->getAdultUsers($userGroupTable, $userTable, 1);
 
-        // フィクスチャのユーザーは i_id_staff が null なので空配列が返るはず
-        // (staff_id 未設定ユーザーは除外される)
-        $this->assertIsArray($result);
-        foreach ($result as $user) {
-            $this->assertArrayHasKey('id', $user);
-            $this->assertArrayHasKey('name', $user);
-            $this->assertArrayHasKey('staff_id', $user);
-        }
+        // フィクスチャのユーザーは i_id_staff が null なので staff_id 未設定ユーザーは除外され空配列が返る
+        $this->assertSame([], $result);
     }
 
     public function testGetAdultUsers_nonExistentRoom_returnsEmpty(): void

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/BulkReservationFormServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/BulkReservationFormServiceTest.php
@@ -6,6 +6,11 @@ namespace App\Test\TestCase\Service;
 use App\Service\BulkReservationFormService;
 use Cake\TestSuite\TestCase;
 
+/**
+ * BulkReservationFormService テスト。
+ *
+ * buildBulkAddData と buildBulkChangeEditData の日付ウィンドウ・無効化ロジックを検証する。
+ */
 class BulkReservationFormServiceTest extends TestCase
 {
     private BulkReservationFormService $service;
@@ -103,7 +108,7 @@ class BulkReservationFormServiceTest extends TestCase
 
         $today = new \DateTimeImmutable('today', new \DateTimeZone('Asia/Tokyo'));
         foreach ($result['days'] as $day) {
-            $dayDate = new \DateTimeImmutable($day['date']);
+            $dayDate = new \DateTimeImmutable($day['date'], new \DateTimeZone('Asia/Tokyo'));
             if ($dayDate < $today) {
                 $this->assertTrue($day['is_disabled'], "past day {$day['date']} should be disabled");
             }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/BulkReservationFormServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/BulkReservationFormServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\BulkReservationFormService;
+use Cake\TestSuite\TestCase;
+
+class BulkReservationFormServiceTest extends TestCase
+{
+    private BulkReservationFormService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new BulkReservationFormService();
+    }
+
+    // ----------------------------------------------------------------
+    // buildBulkAddData — DB不要
+    // ----------------------------------------------------------------
+
+    public function testBuildBulkAddData_returnsRequiredKeys(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkAddData($future, null);
+
+        $this->assertArrayHasKey('days', $result);
+        $this->assertArrayHasKey('activeWeekDate', $result);
+        $this->assertArrayHasKey('weekStarts', $result);
+    }
+
+    public function testBuildBulkAddData_daysAreAtLeastFifteenDaysAhead(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkAddData($future, null);
+
+        $today = new \DateTimeImmutable('today', new \DateTimeZone('Asia/Tokyo'));
+        foreach ($result['days'] as $day) {
+            $dayDate = new \DateTimeImmutable($day['date'], new \DateTimeZone('Asia/Tokyo'));
+            $diff = (int)$today->diff($dayDate)->days;
+            $this->assertGreaterThanOrEqual(15, $diff, "day {$day['date']} should be >= 15 days from today");
+        }
+    }
+
+    public function testBuildBulkAddData_weekStartsHasFourEntries(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkAddData($future, null);
+
+        $this->assertCount(4, $result['weekStarts']);
+    }
+
+    public function testBuildBulkAddData_eachDayHasRequiredKeys(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkAddData($future, null);
+
+        foreach ($result['days'] as $day) {
+            $this->assertArrayHasKey('date', $day);
+            $this->assertArrayHasKey('label', $day);
+            $this->assertArrayHasKey('is_disabled', $day);
+            $this->assertFalse($day['is_disabled']);
+        }
+    }
+
+    public function testBuildBulkAddData_pastDateProducesNoDays(): void
+    {
+        // 過去日を選択した週はすべてのdayが15日以内になるので days は空になる
+        $past = (new \DateTimeImmutable('-1 week'))->format('Y-m-d');
+        $result = $this->service->buildBulkAddData($past, null);
+
+        $this->assertSame([], $result['days']);
+    }
+
+    // ----------------------------------------------------------------
+    // buildBulkChangeEditData — DB不要
+    // ----------------------------------------------------------------
+
+    public function testBuildBulkChangeEditData_returnsRequiredKeys(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkChangeEditData($future, null);
+
+        $this->assertArrayHasKey('days', $result);
+        $this->assertArrayHasKey('activeWeekDate', $result);
+        $this->assertArrayHasKey('weekStarts', $result);
+    }
+
+    public function testBuildBulkChangeEditData_alwaysReturnSevenDays(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkChangeEditData($future, null);
+
+        $this->assertCount(7, $result['days']);
+    }
+
+    public function testBuildBulkChangeEditData_pastDaysAreDisabled(): void
+    {
+        // 過去の月曜日を基点に選択
+        $pastMonday = (new \DateTimeImmutable('monday last week'))->format('Y-m-d');
+        $result = $this->service->buildBulkChangeEditData($pastMonday, null);
+
+        $today = new \DateTimeImmutable('today', new \DateTimeZone('Asia/Tokyo'));
+        foreach ($result['days'] as $day) {
+            $dayDate = new \DateTimeImmutable($day['date']);
+            if ($dayDate < $today) {
+                $this->assertTrue($day['is_disabled'], "past day {$day['date']} should be disabled");
+            }
+        }
+    }
+
+    public function testBuildBulkChangeEditData_futureDaysAreNotDisabled(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkChangeEditData($future, null);
+
+        foreach ($result['days'] as $day) {
+            $this->assertFalse($day['is_disabled']);
+        }
+    }
+
+    public function testBuildBulkChangeEditData_activeWeekDateIsMonday(): void
+    {
+        $future = (new \DateTimeImmutable('+30 days'))->format('Y-m-d');
+        $result = $this->service->buildBulkChangeEditData($future, null);
+
+        $activeWeek = new \DateTimeImmutable($result['activeWeekDate']);
+        $this->assertSame('1', $activeWeek->format('N')); // 月曜 = 1
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/NotificationServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/NotificationServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\NotificationService;
+use Cake\TestSuite\TestCase;
+
+class NotificationServiceTest extends TestCase
+{
+    private NotificationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new NotificationService();
+    }
+
+    // ----------------------------------------------------------------
+    // getUnreadCount — DB不要のガード条件
+    // ----------------------------------------------------------------
+
+    public function testGetUnreadCount_zeroUserId_returnsZero(): void
+    {
+        $result = $this->service->getUnreadCount(0);
+        $this->assertSame(0, $result);
+    }
+
+    public function testGetUnreadCount_negativeUserId_returnsZero(): void
+    {
+        $result = $this->service->getUnreadCount(-5);
+        $this->assertSame(0, $result);
+    }
+
+    // ----------------------------------------------------------------
+    // markAsRead — DB不要のガード条件
+    // ----------------------------------------------------------------
+
+    public function testMarkAsRead_zeroUserId_returnsZero(): void
+    {
+        $result = $this->service->markAsRead(0, [1, 2, 3]);
+        $this->assertSame(0, $result);
+    }
+
+    public function testMarkAsRead_emptyIds_returnsZero(): void
+    {
+        $result = $this->service->markAsRead(1, []);
+        $this->assertSame(0, $result);
+    }
+
+    public function testMarkAsRead_zeroUserIdAndEmptyIds_returnsZero(): void
+    {
+        $result = $this->service->markAsRead(0, []);
+        $this->assertSame(0, $result);
+    }
+
+    // ----------------------------------------------------------------
+    // markAllAsRead — DB不要のガード条件
+    // ----------------------------------------------------------------
+
+    public function testMarkAllAsRead_zeroUserId_returnsZero(): void
+    {
+        $result = $this->service->markAllAsRead(0);
+        $this->assertSame(0, $result);
+    }
+
+    public function testMarkAllAsRead_negativeUserId_returnsZero(): void
+    {
+        $result = $this->service->markAllAsRead(-1);
+        $this->assertSame(0, $result);
+    }
+
+    // ----------------------------------------------------------------
+    // getRecentNotifications / getNotifications — DB不要のガード条件
+    // ----------------------------------------------------------------
+
+    public function testGetRecentNotifications_zeroUserId_returnsEmptyArray(): void
+    {
+        $result = $this->service->getRecentNotifications(0);
+        $this->assertSame([], $result);
+    }
+
+    public function testGetNotifications_zeroUserId_returnsEmptyArray(): void
+    {
+        $result = $this->service->getNotifications(0);
+        $this->assertSame([], $result);
+    }
+
+    // ----------------------------------------------------------------
+    // createRejectionNotifications — DB不要のガード条件（空キー）
+    // ----------------------------------------------------------------
+
+    public function testCreateRejectionNotifications_emptyKeys_returnsWithoutError(): void
+    {
+        // 空キーはガード条件で早期リターンするため例外が発生しないこと
+        $this->service->createRejectionNotifications([], 1, null);
+        $this->assertTrue(true); // ここに到達すれば成功
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/NotificationServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/NotificationServiceTest.php
@@ -6,6 +6,11 @@ namespace App\Test\TestCase\Service;
 use App\Service\NotificationService;
 use Cake\TestSuite\TestCase;
 
+/**
+ * NotificationService テスト。
+ *
+ * getUnreadCount・markAsRead・markAllAsRead・getRecentNotifications・getNotifications・createRejectionNotifications のガード条件を検証する。
+ */
 class NotificationServiceTest extends TestCase
 {
     private NotificationService $service;

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationCalendarService;
+use Cake\I18n\Date;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationCalendarServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private ReservationCalendarService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationCalendarService();
+    }
+
+    // ----------------------------------------------------------------
+    // getPrimaryRoomId — DB不要
+    // ----------------------------------------------------------------
+
+    public function testGetPrimaryRoomId_emptyArray_returnsNull(): void
+    {
+        $this->assertNull($this->service->getPrimaryRoomId([]));
+    }
+
+    public function testGetPrimaryRoomId_returnsFirstElement(): void
+    {
+        $this->assertSame(42, $this->service->getPrimaryRoomId([42, 10, 5]));
+    }
+
+    // ----------------------------------------------------------------
+    // buildMyReservationDates — DB不要
+    // ----------------------------------------------------------------
+
+    public function testBuildMyReservationDates_emptyDetails_returnsEmpty(): void
+    {
+        $this->assertSame([], $this->service->buildMyReservationDates([]));
+    }
+
+    public function testBuildMyReservationDates_onlyReservedDatesIncluded(): void
+    {
+        $details = [
+            '2099-01-01' => ['breakfast' => 1, 'lunch' => null, 'dinner' => null, 'bento' => null],
+            '2099-01-02' => ['breakfast' => 0, 'lunch' => 0, 'dinner' => 0, 'bento' => 0],
+            '2099-01-03' => ['breakfast' => null, 'lunch' => null, 'dinner' => null, 'bento' => null],
+        ];
+
+        $result = $this->service->buildMyReservationDates($details);
+
+        $this->assertSame(['2099-01-01'], $result);
+    }
+
+    public function testBuildMyReservationDates_sortsDates(): void
+    {
+        $details = [
+            '2099-03-01' => ['breakfast' => 1, 'lunch' => null, 'dinner' => null, 'bento' => null],
+            '2099-01-01' => ['breakfast' => 1, 'lunch' => null, 'dinner' => null, 'bento' => null],
+            '2099-02-01' => ['breakfast' => 1, 'lunch' => null, 'dinner' => null, 'bento' => null],
+        ];
+
+        $result = $this->service->buildMyReservationDates($details);
+
+        $this->assertSame(['2099-01-01', '2099-02-01', '2099-03-01'], $result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildCalendarEvents — DB不要
+    // ----------------------------------------------------------------
+
+    public function testBuildCalendarEvents_noReservations_generatesUnreservedEvents(): void
+    {
+        $startDate = new Date('2099-01-01');
+        $endDate   = new Date('2099-01-04');
+
+        $events = $this->service->buildCalendarEvents([], [], $startDate, $endDate);
+
+        // 予約なしの場合、日付ごとに「未予約」イベントが生成されること
+        $titles = array_column($events, 'title');
+        $this->assertContains('未予約', $titles);
+    }
+
+    public function testBuildCalendarEvents_withReservation_addsReservedEvent(): void
+    {
+        $startDate = new Date('2099-01-01');
+        $endDate   = new Date('2099-01-03');
+        $details   = [
+            '2099-01-01' => ['breakfast' => 1, 'lunch' => null, 'dinner' => null, 'bento' => null],
+        ];
+
+        $events = $this->service->buildCalendarEvents([], $details, $startDate, $endDate);
+
+        $starts = array_column($events, 'start');
+        $this->assertContains('2099-01-01', $starts);
+    }
+
+    // ----------------------------------------------------------------
+    // getUserRoomIds — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetUserRoomIds_existingUser_returnsRoomIds(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $result = $this->service->getUserRoomIds($userGroupTable, 1);
+
+        $this->assertIsArray($result);
+        $this->assertContains(1, $result);
+    }
+
+    public function testGetUserRoomIds_nonExistentUser_returnsEmpty(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $result = $this->service->getUserRoomIds($userGroupTable, 9999);
+
+        $this->assertSame([], $result);
+    }
+
+    // ----------------------------------------------------------------
+    // isOfficeUser — DB使用
+    // ----------------------------------------------------------------
+
+    public function testIsOfficeUser_zeroUserId_returnsFalse(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $roomTable      = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $this->assertFalse($this->service->isOfficeUser($userGroupTable, $roomTable, 0));
+    }
+
+    public function testIsOfficeUser_noOfficeRoom_returnsFalse(): void
+    {
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $roomTable      = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        // フィクスチャの部屋名は '事務所' を含まないので false が返る
+        $this->assertFalse($this->service->isOfficeUser($userGroupTable, $roomTable, 1));
+    }
+
+    // ----------------------------------------------------------------
+    // getRoomsForUser — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetRoomsForUser_adminReturnsAllRooms(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsForUser($roomTable, [], isAdmin: true);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey(1, $result); // fixture にid=1の部屋が存在する
+    }
+
+    public function testGetRoomsForUser_emptyRoomIds_returnsEmpty(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsForUser($roomTable, [], isAdmin: false);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
@@ -8,6 +8,11 @@ use Cake\I18n\Date;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationCalendarService テスト。
+ *
+ * getPrimaryRoomId・buildMyReservationDates・buildCalendarEvents・getUserRoomIds・isOfficeUser・getRoomsForUser の挙動を検証する。
+ */
 class ReservationCalendarServiceTest extends TestCase
 {
     protected array $fixtures = [

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationChangeEditServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationChangeEditServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\ReservationChangeEditService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationChangeEditService テスト。
+ *
+ * resolveDefaultRoomId のガード条件と buildUsersForJson の権限別挙動を検証する。
+ */
 class ReservationChangeEditServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -68,7 +73,7 @@ class ReservationChangeEditServiceTest extends TestCase
     {
         // i_admin=1 のユーザーはすべてを編集できる
         $loginUser = new class {
-            public function get(string $key): mixed
+            public function get(string $key): int|null
             {
                 return match ($key) {
                     'i_admin'      => 1,

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationChangeEditServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationChangeEditServiceTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationChangeEditService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationChangeEditServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+        'app.TAuditLog',
+    ];
+
+    private ReservationChangeEditService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationChangeEditService();
+    }
+
+    // ----------------------------------------------------------------
+    // resolveDefaultRoomId — DB不要のガード条件
+    // ----------------------------------------------------------------
+
+    public function testResolveDefaultRoomId_emptyRooms_returnsNull(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $result = $this->service->resolveDefaultRoomId([], '2099-01-01', $reservationTable);
+        $this->assertNull($result);
+    }
+
+    public function testResolveDefaultRoomId_singleRoom_returnsFirstKey(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $result = $this->service->resolveDefaultRoomId([5 => 'ルームA'], '2099-01-01', $reservationTable);
+        $this->assertSame(5, $result);
+    }
+
+    public function testResolveDefaultRoomId_multipleRoomsNoReservation_returnsFirstKey(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $result = $this->service->resolveDefaultRoomId(
+            [10 => 'ルームA', 20 => 'ルームB'],
+            '2099-12-31',
+            $reservationTable
+        );
+        $this->assertSame(10, $result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildUsersForJson — DB不要
+    // ----------------------------------------------------------------
+
+    public function testBuildUsersForJson_emptyUsers_returnsEmpty(): void
+    {
+        $result = $this->service->buildUsersForJson([], null, false, false);
+        $this->assertSame([], $result);
+    }
+
+    public function testBuildUsersForJson_adminCanEditAll(): void
+    {
+        // i_admin=1 のユーザーはすべてを編集できる
+        $loginUser = new class {
+            public function get(string $key): mixed
+            {
+                return match ($key) {
+                    'i_admin'      => 1,
+                    'i_user_level' => 0,
+                    'i_id_user'    => 99,
+                    default        => null,
+                };
+            }
+        };
+
+        $users = [
+            ['id' => 1, 'name' => 'テスト', 'i_user_level' => 1],
+        ];
+
+        $result = $this->service->buildUsersForJson($users, $loginUser, false, false);
+
+        $this->assertCount(1, $result);
+        $this->assertTrue($result[0]['allowEdit']);
+    }
+
+    public function testBuildUsersForJson_returnsRequiredKeys(): void
+    {
+        $users = [
+            ['id' => 1, 'name' => 'テスト', 'i_user_level' => 1],
+        ];
+
+        $result = $this->service->buildUsersForJson($users, null, false, false);
+
+        $this->assertArrayHasKey('id', $result[0]);
+        $this->assertArrayHasKey('name', $result[0]);
+        $this->assertArrayHasKey('i_user_level', $result[0]);
+        $this->assertArrayHasKey('allowEdit', $result[0]);
+        $this->assertArrayHasKey('isStaff', $result[0]);
+    }
+
+    public function testBuildUsersForJson_staffUserLevel_isStaffTrue(): void
+    {
+        $users = [
+            ['id' => 1, 'name' => '職員', 'i_user_level' => 0],
+        ];
+
+        $result = $this->service->buildUsersForJson($users, null, false, false);
+
+        $this->assertTrue($result[0]['isStaff']);
+    }
+
+    public function testBuildUsersForJson_childUserLevel_isStaffFalse(): void
+    {
+        $users = [
+            ['id' => 2, 'name' => '子供', 'i_user_level' => 1],
+        ];
+
+        $result = $this->service->buildUsersForJson($users, null, false, false);
+
+        $this->assertFalse($result[0]['isStaff']);
+    }
+
+    public function testBuildUsersForJson_roomManager_canEditAll(): void
+    {
+        $users = [
+            ['id' => 5, 'name' => '他者', 'i_user_level' => 0],
+        ];
+
+        $result = $this->service->buildUsersForJson($users, null, isRoomManager: true, isBlockLeaderInRoom: false);
+
+        $this->assertTrue($result[0]['allowEdit']);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCopyServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCopyServiceTest.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationCopyService;
+use Cake\I18n\Date;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ReservationCopyService テスト。
+ *
+ * DB に依存しない normalizeCopyParams() のバリデーションロジックを検証する。
+ */
+class ReservationCopyServiceTest extends TestCase
+{
+    private ReservationCopyService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationCopyService();
+    }
+
+    // ----------------------------------------------------------------
+    // mode バリデーション
+    // ----------------------------------------------------------------
+
+    public function testNormalizeReturnErrorForInvalidMode(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'daily',
+            'source' => '2026-06-01',
+            'target' => '2026-07-01',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testNormalizeAcceptsWeekMode(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-02',
+            'target' => '2026-06-09',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('week', $result['mode']);
+    }
+
+    public function testNormalizeAcceptsMonthMode(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'month',
+            'source' => '2026-06-01',
+            'target' => '2026-07-01',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('month', $result['mode']);
+    }
+
+    // ----------------------------------------------------------------
+    // source / target バリデーション
+    // ----------------------------------------------------------------
+
+    public function testNormalizeReturnErrorForMissingSource(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'target' => '2026-06-09',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testNormalizeReturnErrorForMissingTarget(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-02',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    public function testNormalizeReturnErrorForInvalidDateFormat(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => 'not-a-date',
+            'target' => '2026-06-09',
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(422, $result['status']);
+    }
+
+    // ----------------------------------------------------------------
+    // week モード: 月曜日への正規化
+    // ----------------------------------------------------------------
+
+    public function testNormalizeWeekNormalizesToMonday(): void
+    {
+        // 2026-06-04（木曜） → 月曜（2026-06-01）に正規化される
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-04',
+            'target' => '2026-06-11',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('2026-06-01', $result['src']->format('Y-m-d'));
+        $this->assertSame('2026-06-08', $result['dst']->format('Y-m-d'));
+    }
+
+    public function testNormalizeWeekKeepsMondayAsIs(): void
+    {
+        // 2026-06-01（月曜）はそのまま
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-01',
+            'target' => '2026-06-08',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('2026-06-01', $result['src']->format('Y-m-d'));
+    }
+
+    // ----------------------------------------------------------------
+    // month モード: 月初への正規化
+    // ----------------------------------------------------------------
+
+    public function testNormalizeMonthNormalizesToFirstDayOfMonth(): void
+    {
+        // 2026-06-15 → 2026-06-01 に正規化される
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'month',
+            'source' => '2026-06-15',
+            'target' => '2026-07-20',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('2026-06-01', $result['src']->format('Y-m-d'));
+        $this->assertSame('2026-07-01', $result['dst']->format('Y-m-d'));
+    }
+
+    // ----------------------------------------------------------------
+    // room_id と only_children
+    // ----------------------------------------------------------------
+
+    public function testNormalizeRoomIdParsedCorrectly(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-01',
+            'target' => '2026-06-08',
+            'room_id' => '5',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(5, $result['roomId']);
+    }
+
+    public function testNormalizeRoomIdIsNullWhenZero(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-01',
+            'target' => '2026-06-08',
+            'room_id' => '0',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertNull($result['roomId']);
+    }
+
+    public function testNormalizeOnlyChildrenDefaultsFalse(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-01',
+            'target' => '2026-06-08',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertFalse($result['onlyChildren']);
+    }
+
+    public function testNormalizeOnlyChildrenParsedAsTrue(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source' => '2026-06-01',
+            'target' => '2026-06-08',
+            'only_children' => '1',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['onlyChildren']);
+    }
+
+    // ----------------------------------------------------------------
+    // source_start / target_start エイリアス
+    // ----------------------------------------------------------------
+
+    public function testNormalizeAcceptsSourceStartAlias(): void
+    {
+        $result = $this->service->normalizeCopyParams([
+            'mode' => 'week',
+            'source_start' => '2026-06-01',
+            'target_start' => '2026-06-08',
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('2026-06-01', $result['src']->format('Y-m-d'));
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationQueryServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationQueryServiceTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationQueryService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationQueryServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private ReservationQueryService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationQueryService();
+    }
+
+    // ----------------------------------------------------------------
+    // hasDuplicateReservation — DB使用
+    // ----------------------------------------------------------------
+
+    public function testHasDuplicateReservation_nonExistent_returnsFalse(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->hasDuplicateReservation(
+            $reservationTable,
+            '2099-12-31',
+            9999,
+            1
+        );
+
+        $this->assertFalse($result);
+    }
+
+    // ----------------------------------------------------------------
+    // getUsersByRoom — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetUsersByRoom_returnsArray(): void
+    {
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getUsersByRoom($userGroupTable, $reservationTable, 1, null);
+
+        $this->assertIsArray($result);
+    }
+
+    public function testGetUsersByRoom_eachEntryHasRequiredKeys(): void
+    {
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getUsersByRoom($userGroupTable, $reservationTable, 1, null);
+
+        foreach ($result as $entry) {
+            $this->assertArrayHasKey('id', $entry);
+            $this->assertArrayHasKey('name', $entry);
+            $this->assertArrayHasKey('morning', $entry);
+            $this->assertArrayHasKey('noon', $entry);
+            $this->assertArrayHasKey('night', $entry);
+            $this->assertArrayHasKey('bento', $entry);
+        }
+    }
+
+    public function testGetUsersByRoom_nonExistentRoom_returnsEmpty(): void
+    {
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getUsersByRoom($userGroupTable, $reservationTable, 9999, null);
+
+        $this->assertSame([], $result);
+    }
+
+    // ----------------------------------------------------------------
+    // getReservationSnapshots — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetReservationSnapshots_zeroRoomId_returnsEmpty(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getReservationSnapshots($reservationTable, 0, ['2099-01-01']);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetReservationSnapshots_emptyDates_returnsEmpty(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getReservationSnapshots($reservationTable, 1, []);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetReservationSnapshots_nonExistentData_returnsEmptyMap(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getReservationSnapshots($reservationTable, 1, ['2099-12-31']);
+
+        $this->assertIsArray($result);
+    }
+
+    // ----------------------------------------------------------------
+    // getUsersByRoomForBulk — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetUsersByRoomForBulk_returnsRequiredKeys(): void
+    {
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getUsersByRoomForBulk($userGroupTable, $reservationTable, 1, null);
+
+        $this->assertArrayHasKey('users', $result);
+        $this->assertArrayHasKey('reservations', $result);
+        $this->assertArrayHasKey('other_room_reservations', $result);
+        $this->assertArrayHasKey('total', $result);
+        $this->assertArrayHasKey('page', $result);
+        $this->assertArrayHasKey('limit', $result);
+        $this->assertArrayHasKey('reservation_snapshot', $result);
+    }
+
+    public function testGetUsersByRoomForBulk_roomWithUsers_returnsUsers(): void
+    {
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getUsersByRoomForBulk($userGroupTable, $reservationTable, 1, null);
+
+        // フィクスチャにroom1にuser1,2,3が存在する
+        $this->assertGreaterThan(0, $result['total']);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationQueryServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationQueryServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\ReservationQueryService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationQueryService テスト。
+ *
+ * hasDuplicateReservation・getUsersByRoom・getReservationSnapshots・getUsersByRoomForBulk の挙動を検証する。
+ */
 class ReservationQueryServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -63,6 +68,7 @@ class ReservationQueryServiceTest extends TestCase
 
         $result = $this->service->getUsersByRoom($userGroupTable, $reservationTable, 1, null);
 
+        $this->assertNotEmpty($result);
         foreach ($result as $entry) {
             $this->assertArrayHasKey('id', $entry);
             $this->assertArrayHasKey('name', $entry);
@@ -112,6 +118,7 @@ class ReservationQueryServiceTest extends TestCase
         $result = $this->service->getReservationSnapshots($reservationTable, 1, ['2099-12-31']);
 
         $this->assertIsArray($result);
+        $this->assertEmpty($result);
     }
 
     // ----------------------------------------------------------------

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationReportServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationReportServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\ReservationReportService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationReportService テスト。
+ *
+ * getMealCounts・buildAllRoomsMealCounts・buildRoomMealCounts・buildExportJson・buildExportJsonRank の挙動を検証する。
+ */
 class ReservationReportServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -57,7 +62,7 @@ class ReservationReportServiceTest extends TestCase
 
         $result = $this->service->buildAllRoomsMealCounts($reservationTable, '2099-01-01', '2099-01-01');
 
-        $this->assertIsArray($result);
+        $this->assertSame([], $result);
     }
 
     // ----------------------------------------------------------------

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationReportServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationReportServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationReportService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationReportServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+        'app.TReservationInfo',
+    ];
+
+    private ReservationReportService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationReportService();
+    }
+
+    // ----------------------------------------------------------------
+    // getMealCounts — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetMealCounts_returnsArray(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->getMealCounts($reservationTable, '2099-12-31');
+
+        $this->assertIsArray($result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildAllRoomsMealCounts — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildAllRoomsMealCounts_returnsArray(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->buildAllRoomsMealCounts($reservationTable, '2099-01-01', '2099-12-31');
+
+        $this->assertIsArray($result);
+    }
+
+    public function testBuildAllRoomsMealCounts_emptyPeriod_returnsEmpty(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->buildAllRoomsMealCounts($reservationTable, '2099-01-01', '2099-01-01');
+
+        $this->assertIsArray($result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildRoomMealCounts — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildRoomMealCounts_returnsArray(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->buildRoomMealCounts($reservationTable, [1], '2099-01-01', '2099-12-31');
+
+        $this->assertIsArray($result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildExportJson — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildExportJson_returnsRequiredKeys(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->buildExportJson($reservationTable, '2099-01-01', '2099-12-31');
+
+        $this->assertArrayHasKey('overall', $result);
+        $this->assertArrayHasKey('rooms', $result);
+    }
+
+    // ----------------------------------------------------------------
+    // buildExportJsonRank — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildExportJsonRank_returnsArray(): void
+    {
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+
+        $result = $this->service->buildExportJsonRank($reservationTable, '2099-01-01', '2099-12-31', 'データなし');
+
+        $this->assertIsArray($result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationRoomDetailServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationRoomDetailServiceTest.php
@@ -8,6 +8,11 @@ use Cake\Http\Exception\NotFoundException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationRoomDetailService テスト。
+ *
+ * getRoomDetails の例外ガード条件と useChangeFlag の日付判定ロジックを検証する。
+ */
 class ReservationRoomDetailServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -120,7 +125,7 @@ class ReservationRoomDetailServiceTest extends TestCase
         $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
 
         // 今日から5日後 -> 14日以内 -> useChangeFlag=true
-        $nearDate = (new \DateTimeImmutable('+5 days'))->format('Y-m-d');
+        $nearDate = (new \DateTimeImmutable('+5 days', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
 
         $result = $this->service->getRoomDetails(
             1,

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationRoomDetailServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationRoomDetailServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationRoomDetailService;
+use Cake\Http\Exception\NotFoundException;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationRoomDetailServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private ReservationRoomDetailService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationRoomDetailService();
+    }
+
+    // ----------------------------------------------------------------
+    // getRoomDetails — 存在しない部屋は例外
+    // ----------------------------------------------------------------
+
+    public function testGetRoomDetails_nonExistentRoom_throwsNotFoundException(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $this->expectException(NotFoundException::class);
+
+        $this->service->getRoomDetails(
+            9999,
+            '2099-01-01',
+            1,
+            $roomTable,
+            $reservationTable,
+            $userGroupTable
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // getRoomDetails — 無効な日付は例外
+    // ----------------------------------------------------------------
+
+    public function testGetRoomDetails_invalidDate_throwsInvalidArgumentException(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->service->getRoomDetails(
+            1,
+            'not-a-date',
+            1,
+            $roomTable,
+            $reservationTable,
+            $userGroupTable
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // getRoomDetails — 有効な部屋IDのハッピーパス
+    // ----------------------------------------------------------------
+
+    public function testGetRoomDetails_validRoom_returnsRequiredKeys(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $result = $this->service->getRoomDetails(
+            1,
+            '2099-01-01',
+            1,
+            $roomTable,
+            $reservationTable,
+            $userGroupTable
+        );
+
+        $this->assertArrayHasKey('room', $result);
+        $this->assertArrayHasKey('eatUsers', $result);
+        $this->assertArrayHasKey('noEatUsers', $result);
+        $this->assertArrayHasKey('otherRoomEaters', $result);
+        $this->assertArrayHasKey('useChangeFlag', $result);
+    }
+
+    public function testGetRoomDetails_farFutureDate_useChangeFlagFalse(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        $result = $this->service->getRoomDetails(
+            1,
+            '2099-12-31', // 14日以上先 -> useChangeFlag=false
+            1,
+            $roomTable,
+            $reservationTable,
+            $userGroupTable
+        );
+
+        $this->assertFalse($result['useChangeFlag']);
+    }
+
+    public function testGetRoomDetails_nearFutureDate_useChangeFlagTrue(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+
+        // 今日から5日後 -> 14日以内 -> useChangeFlag=true
+        $nearDate = (new \DateTimeImmutable('+5 days'))->format('Y-m-d');
+
+        $result = $this->service->getRoomDetails(
+            1,
+            $nearDate,
+            1,
+            $roomTable,
+            $reservationTable,
+            $userGroupTable
+        );
+
+        $this->assertTrue($result['useChangeFlag']);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationViewServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationViewServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\ReservationQueryService;
+use App\Service\ReservationViewService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class ReservationViewServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private ReservationViewService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationViewService();
+    }
+
+    // ----------------------------------------------------------------
+    // buildViewContext — DB使用
+    // ----------------------------------------------------------------
+
+    public function testBuildViewContext_nullUser_returnsRequiredKeys(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $queryService     = new ReservationQueryService();
+
+        $result = $this->service->buildViewContext(
+            null,
+            '2099-01-01',
+            null,
+            $roomTable,
+            $userGroupTable,
+            $reservationTable,
+            $queryService
+        );
+
+        $this->assertArrayHasKey('mealDataArray', $result);
+        $this->assertArrayHasKey('date', $result);
+        $this->assertArrayHasKey('isAdmin', $result);
+        $this->assertArrayHasKey('authorizedRooms', $result);
+        $this->assertArrayHasKey('activeRoomId', $result);
+        $this->assertArrayHasKey('activeRoomName', $result);
+        $this->assertArrayHasKey('roomUsers', $result);
+        $this->assertArrayHasKey('userMealMap', $result);
+    }
+
+    public function testBuildViewContext_nullUser_isAdminFalse(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $queryService     = new ReservationQueryService();
+
+        $result = $this->service->buildViewContext(
+            null,
+            '2099-01-01',
+            null,
+            $roomTable,
+            $userGroupTable,
+            $reservationTable,
+            $queryService
+        );
+
+        $this->assertFalse($result['isAdmin']);
+    }
+
+    public function testBuildViewContext_nullDate_usesToday(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $queryService     = new ReservationQueryService();
+
+        $result = $this->service->buildViewContext(
+            null,
+            null,
+            null,
+            $roomTable,
+            $userGroupTable,
+            $reservationTable,
+            $queryService
+        );
+
+        $today = (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
+        $this->assertSame($today, $result['date']);
+    }
+
+    public function testBuildViewContext_mealDataArrayHasMealTypeKeys(): void
+    {
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $queryService     = new ReservationQueryService();
+
+        $result = $this->service->buildViewContext(
+            null,
+            '2099-01-01',
+            null,
+            $roomTable,
+            $userGroupTable,
+            $reservationTable,
+            $queryService
+        );
+
+        $this->assertIsArray($result['mealDataArray']);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationViewServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationViewServiceTest.php
@@ -8,6 +8,11 @@ use App\Service\ReservationViewService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * ReservationViewService テスト。
+ *
+ * buildViewContext の必須キー・isAdmin 判定・日付フォールバックを検証する。
+ */
 class ReservationViewServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -83,6 +88,8 @@ class ReservationViewServiceTest extends TestCase
         $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
         $queryService     = new ReservationQueryService();
 
+        $today = (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
+
         $result = $this->service->buildViewContext(
             null,
             null,
@@ -93,11 +100,10 @@ class ReservationViewServiceTest extends TestCase
             $queryService
         );
 
-        $today = (new \DateTime('now', new \DateTimeZone('Asia/Tokyo')))->format('Y-m-d');
         $this->assertSame($today, $result['date']);
     }
 
-    public function testBuildViewContext_mealDataArrayHasMealTypeKeys(): void
+    public function testBuildViewContext_mealDataArrayIsArray(): void
     {
         $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
         $userGroupTable   = TableRegistry::getTableLocator()->get('MUserGroup');

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\RoomService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * RoomService テスト。
+ *
+ * nextDisplayNo・getUsersForRoom・softDelete の挙動を検証する。
+ */
 class RoomServiceTest extends TestCase
 {
     protected array $fixtures = [
@@ -78,6 +83,19 @@ class RoomServiceTest extends TestCase
         $result = $this->service->getUsersForRoom($roomInfo);
 
         $this->assertIsArray($result);
+
+        $expectedUserIds = array_map(
+            static fn ($group) => (int)$group->i_id_user,
+            $roomInfo->m_user_group
+        );
+        $actualUserIds = array_map(
+            static fn ($user) => (int)$user->i_id_user,
+            $result
+        );
+        sort($expectedUserIds);
+        sort($actualUserIds);
+        $this->assertNotEmpty($expectedUserIds);
+        $this->assertSame($expectedUserIds, $actualUserIds);
     }
 
     // ----------------------------------------------------------------

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\RoomService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class RoomServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+    ];
+
+    private RoomService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RoomService();
+    }
+
+    // ----------------------------------------------------------------
+    // nextDisplayNo — DB使用
+    // ----------------------------------------------------------------
+
+    public function testNextDisplayNo_returnsInt(): void
+    {
+        $result = $this->service->nextDisplayNo();
+        $this->assertIsInt($result);
+    }
+
+    public function testNextDisplayNo_greaterThanZero(): void
+    {
+        $result = $this->service->nextDisplayNo();
+        $this->assertGreaterThan(0, $result);
+    }
+
+    public function testNextDisplayNo_greaterThanCurrentMax(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $maxRow = $roomTable->find()
+            ->select(['max_no' => 'MAX(i_disp_no)'])
+            ->first();
+        $currentMax = (int)($maxRow->max_no ?? 0);
+
+        $result = $this->service->nextDisplayNo();
+
+        $this->assertSame($currentMax + 1, $result);
+    }
+
+    // ----------------------------------------------------------------
+    // getUsersForRoom — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetUsersForRoom_roomWithNoUsers_returnsEmpty(): void
+    {
+        // m_user_group が空のエンティティを作成するため、実エンティティをロードして上書きする
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $roomInfo  = $roomTable->get(1, contain: ['MUserGroup']);
+
+        // m_user_group を空に設定
+        $roomInfo->m_user_group = [];
+
+        $result = $this->service->getUsersForRoom($roomInfo);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetUsersForRoom_roomWithUsers_returnsArray(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $roomInfo  = $roomTable->get(1, contain: ['MUserGroup']);
+
+        $result = $this->service->getUsersForRoom($roomInfo);
+
+        $this->assertIsArray($result);
+    }
+
+    // ----------------------------------------------------------------
+    // softDelete — DB使用
+    // ----------------------------------------------------------------
+
+    public function testSoftDelete_existingRoom_returnsTrue(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $room = $roomTable->get(1);
+
+        $result = $this->service->softDelete($room, 'test_admin');
+
+        $this->assertTrue($result);
+    }
+
+    public function testSoftDelete_setsDelFlag(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $room = $roomTable->get(1);
+
+        $this->service->softDelete($room, 'test_admin');
+
+        $updated = $roomTable->get(1);
+        $this->assertSame(1, (int)$updated->i_del_flg);
+    }
+
+    public function testSoftDelete_setsUpdateUser(): void
+    {
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+        $room = $roomTable->get(1);
+
+        $this->service->softDelete($room, 'test_admin');
+
+        $updated = $roomTable->get(1);
+        $this->assertSame('test_admin', $updated->c_update_user);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomTransferScheduleServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomTransferScheduleServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\RoomTransferScheduleService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class RoomTransferScheduleServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+        'app.TReservationInfo',
+    ];
+
+    private RoomTransferScheduleService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RoomTransferScheduleService();
+    }
+
+    // ----------------------------------------------------------------
+    // applyPending — DB使用
+    // ----------------------------------------------------------------
+
+    public function testApplyPending_noPendingSchedules_returnsZeroApplied(): void
+    {
+        // m_room_transfer_schedule テーブルがテストDBに存在しない場合はスキップする
+        try {
+            $result = $this->service->applyPending(date('Y-m-d'));
+        } catch (\Cake\Database\Exception\DatabaseException $e) {
+            $this->markTestSkipped('m_room_transfer_schedule テーブルがテストDBに存在しません: ' . $e->getMessage());
+            return;
+        }
+
+        $this->assertArrayHasKey('applied', $result);
+        $this->assertArrayHasKey('errors', $result);
+        $this->assertSame(0, $result['applied']);
+        $this->assertSame([], $result['errors']);
+    }
+
+    public function testApplyPending_dryRun_returnsRequiredKeys(): void
+    {
+        try {
+            $result = $this->service->applyPending(date('Y-m-d'), dryRun: true);
+        } catch (\Cake\Database\Exception\DatabaseException $e) {
+            $this->markTestSkipped('m_room_transfer_schedule テーブルがテストDBに存在しません: ' . $e->getMessage());
+            return;
+        }
+
+        $this->assertArrayHasKey('applied', $result);
+        $this->assertArrayHasKey('errors', $result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomTransferScheduleServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomTransferScheduleServiceTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 namespace App\Test\TestCase\Service;
 
 use App\Service\RoomTransferScheduleService;
-use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * RoomTransferScheduleService テスト。
+ *
+ * applyPending() が保留スケジュールのない状態で正しく動作することを検証する。
+ */
 class RoomTransferScheduleServiceTest extends TestCase
 {
     protected array $fixtures = [
+        'app.MRoomTransferSchedule',
         'app.MUserInfo',
         'app.MUserGroup',
         'app.MRoomInfo',
@@ -26,18 +31,12 @@ class RoomTransferScheduleServiceTest extends TestCase
     }
 
     // ----------------------------------------------------------------
-    // applyPending — DB使用
+    // applyPending — 保留スケジュールなし
     // ----------------------------------------------------------------
 
     public function testApplyPending_noPendingSchedules_returnsZeroApplied(): void
     {
-        // m_room_transfer_schedule テーブルがテストDBに存在しない場合はスキップする
-        try {
-            $result = $this->service->applyPending(date('Y-m-d'));
-        } catch (\Cake\Database\Exception\DatabaseException $e) {
-            $this->markTestSkipped('m_room_transfer_schedule テーブルがテストDBに存在しません: ' . $e->getMessage());
-            return;
-        }
+        $result = $this->service->applyPending(date('Y-m-d'));
 
         $this->assertArrayHasKey('applied', $result);
         $this->assertArrayHasKey('errors', $result);
@@ -47,14 +46,23 @@ class RoomTransferScheduleServiceTest extends TestCase
 
     public function testApplyPending_dryRun_returnsRequiredKeys(): void
     {
-        try {
-            $result = $this->service->applyPending(date('Y-m-d'), dryRun: true);
-        } catch (\Cake\Database\Exception\DatabaseException $e) {
-            $this->markTestSkipped('m_room_transfer_schedule テーブルがテストDBに存在しません: ' . $e->getMessage());
-            return;
-        }
+        $result = $this->service->applyPending(date('Y-m-d'), dryRun: true);
 
         $this->assertArrayHasKey('applied', $result);
         $this->assertArrayHasKey('errors', $result);
+    }
+
+    public function testApplyPending_returnsAppliedAsInteger(): void
+    {
+        $result = $this->service->applyPending(date('Y-m-d'));
+
+        $this->assertIsInt($result['applied']);
+    }
+
+    public function testApplyPending_returnsErrorsAsArray(): void
+    {
+        $result = $this->service->applyPending(date('Y-m-d'));
+
+        $this->assertIsArray($result['errors']);
     }
 }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomUsageServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomUsageServiceTest.php
@@ -6,6 +6,11 @@ namespace App\Test\TestCase\Service;
 use App\Service\RoomUsageService;
 use Cake\TestSuite\TestCase;
 
+/**
+ * RoomUsageService テスト。
+ *
+ * getRoomUsage の戻り値構造・型・範囲と getLowUsageRooms のしきい値フィルタリングを検証する。
+ */
 class RoomUsageServiceTest extends TestCase
 {
     protected array $fixtures = [

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/RoomUsageServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/RoomUsageServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\RoomUsageService;
+use Cake\TestSuite\TestCase;
+
+class RoomUsageServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TIndividualReservationInfo',
+    ];
+
+    private RoomUsageService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new RoomUsageService();
+    }
+
+    // ----------------------------------------------------------------
+    // getRoomUsage — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetRoomUsage_returnsArray(): void
+    {
+        $result = $this->service->getRoomUsage();
+        $this->assertIsArray($result);
+    }
+
+    public function testGetRoomUsage_eachEntryHasRequiredKeys(): void
+    {
+        $result = $this->service->getRoomUsage();
+
+        foreach ($result as $entry) {
+            $this->assertArrayHasKey('room_id', $entry);
+            $this->assertArrayHasKey('room_name', $entry);
+            $this->assertArrayHasKey('user_count', $entry);
+            $this->assertArrayHasKey('capacity', $entry);
+            $this->assertArrayHasKey('eat_count', $entry);
+            $this->assertArrayHasKey('usage_rate', $entry);
+            $this->assertArrayHasKey('staff', $entry);
+        }
+    }
+
+    public function testGetRoomUsage_withDateRange_returnsArray(): void
+    {
+        $from = date('Y-m-01');
+        $to   = date('Y-m-d');
+
+        $result = $this->service->getRoomUsage($from, $to);
+
+        $this->assertIsArray($result);
+    }
+
+    public function testGetRoomUsage_withMealType_returnsArray(): void
+    {
+        $result = $this->service->getRoomUsage(null, null, 1);
+        $this->assertIsArray($result);
+    }
+
+    public function testGetRoomUsage_usageRateIsFloat(): void
+    {
+        $result = $this->service->getRoomUsage();
+
+        foreach ($result as $entry) {
+            $this->assertIsFloat($entry['usage_rate']);
+        }
+    }
+
+    public function testGetRoomUsage_usageRateBetweenZeroAndHundred(): void
+    {
+        $result = $this->service->getRoomUsage();
+
+        foreach ($result as $entry) {
+            $this->assertGreaterThanOrEqual(0.0, $entry['usage_rate']);
+            $this->assertLessThanOrEqual(100.0, $entry['usage_rate']);
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // getLowUsageRooms — DB使用
+    // ----------------------------------------------------------------
+
+    public function testGetLowUsageRooms_returnsArray(): void
+    {
+        $result = $this->service->getLowUsageRooms(50.0);
+        $this->assertIsArray($result);
+    }
+
+    public function testGetLowUsageRooms_allBelowThreshold(): void
+    {
+        $result = $this->service->getLowUsageRooms(50.0);
+
+        foreach ($result as $room) {
+            $this->assertLessThanOrEqual(50.0, $room['usage_rate']);
+        }
+    }
+
+    public function testGetLowUsageRooms_zeroThreshold_returnsOnlyZeroUsage(): void
+    {
+        $result = $this->service->getLowUsageRooms(0.0);
+
+        foreach ($result as $room) {
+            $this->assertSame(0.0, $room['usage_rate']);
+        }
+    }
+
+    public function testGetLowUsageRooms_hundredThreshold_returnsAll(): void
+    {
+        $all    = $this->service->getRoomUsage();
+        $result = $this->service->getLowUsageRooms(100.0);
+
+        $this->assertCount(count($all), $result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserBulkImportServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserBulkImportServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\UserBulkImportService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * UserBulkImportService テスト。
+ *
+ * import のバリデーション・スキップ・作成・エラー処理の挙動を検証する。
+ */
 class UserBulkImportServiceTest extends TestCase
 {
     protected array $fixtures = [

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserBulkImportServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserBulkImportServiceTest.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\UserBulkImportService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class UserBulkImportServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TAuditLog',
+    ];
+
+    private UserBulkImportService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserBulkImportService();
+    }
+
+    // ----------------------------------------------------------------
+    // import — 空レコードのガード条件
+    // ----------------------------------------------------------------
+
+    public function testImport_emptyRecords_returnsZeroCounts(): void
+    {
+        $result = $this->service->import([], 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(0, $result['processed']);
+        $this->assertSame(0, $result['created']);
+        $this->assertSame(0, $result['skipped']);
+        $this->assertSame(0, $result['failed']);
+        $this->assertSame([], $result['errors']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 必須項目が欠けているレコード
+    // ----------------------------------------------------------------
+
+    public function testImport_missingLoginId_incrementsFailedCount(): void
+    {
+        $records = [
+            ['_row' => 1, 'name' => 'テスト太郎', 'role' => '職員', 'staff_id' => 'S001'],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['processed']);
+        $this->assertSame(1, $result['failed']);
+        $this->assertSame(0, $result['created']);
+    }
+
+    public function testImport_missingName_incrementsFailedCount(): void
+    {
+        $records = [
+            ['_row' => 1, 'login_id' => 'test_user_xyz', 'role' => '職員', 'staff_id' => 'S001'],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['processed']);
+        $this->assertSame(1, $result['failed']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 不正なrole値
+    // ----------------------------------------------------------------
+
+    public function testImport_invalidRole_incrementsFailedCount(): void
+    {
+        $records = [
+            ['_row' => 1, 'login_id' => 'new_test_user_abc', 'name' => 'テスト', 'role' => 'invalid_role'],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['failed']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 職員にstaff_idが必須
+    // ----------------------------------------------------------------
+
+    public function testImport_staffWithoutStaffId_incrementsFailedCount(): void
+    {
+        $records = [
+            ['_row' => 1, 'login_id' => 'staff_no_id_xyz', 'name' => '職員', 'role' => '職員'],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['failed']);
+        $this->assertArrayHasKey(1, $result['errors']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 既存login_idはスキップ
+    // ----------------------------------------------------------------
+
+    public function testImport_duplicateLoginId_incrementsSkippedCount(): void
+    {
+        // フィクスチャにある既存アカウントを使用
+        $records = [
+            [
+                '_row' => 1,
+                'login_id' => 'admin_user', // fixtures に存在するアカウント
+                'name'     => 'テスト',
+                'role'     => '職員',
+                'staff_id' => 'S999',
+            ],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['skipped']);
+        $this->assertSame(0, $result['created']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 正常なレコード作成
+    // ----------------------------------------------------------------
+
+    public function testImport_validRecord_createsUser(): void
+    {
+        $records = [
+            [
+                '_row'     => 1,
+                'login_id' => 'bulk_new_user_' . time(),
+                'name'     => '一括テスト太郎',
+                'role'     => '児童',
+                'password' => 'testPass123',
+            ],
+        ];
+
+        $result = $this->service->import($records, 'admin', 1, '127.0.0.1');
+
+        $this->assertSame(1, $result['created']);
+        $this->assertSame(1, $result['processed']);
+        $this->assertSame(0, $result['failed']);
+    }
+
+    // ----------------------------------------------------------------
+    // import — 返却値の構造
+    // ----------------------------------------------------------------
+
+    public function testImport_returnsRequiredResultKeys(): void
+    {
+        $result = $this->service->import([], 'admin');
+
+        $this->assertArrayHasKey('processed', $result);
+        $this->assertArrayHasKey('created', $result);
+        $this->assertArrayHasKey('skipped', $result);
+        $this->assertArrayHasKey('failed', $result);
+        $this->assertArrayHasKey('errors', $result);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserEditServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserEditServiceTest.php
@@ -7,6 +7,11 @@ use App\Service\UserEditService;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
+/**
+ * UserEditService テスト。
+ *
+ * updateWithRooms の正常更新・部屋割り当て・監査ログ記録を検証する。
+ */
 class UserEditServiceTest extends TestCase
 {
     protected array $fixtures = [

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserEditServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserEditServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\UserEditService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class UserEditServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserInfo',
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.TAuditLog',
+    ];
+
+    private UserEditService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserEditService();
+    }
+
+    private function getUserEntity(int $userId): \Cake\Datasource\EntityInterface
+    {
+        $table = TableRegistry::getTableLocator()->get('MUserInfo');
+        return $table->get($userId, contain: ['MUserGroup']);
+    }
+
+    // ----------------------------------------------------------------
+    // updateWithRooms — 正常更新
+    // ----------------------------------------------------------------
+
+    public function testUpdateWithRooms_returnsTrue(): void
+    {
+        $entity = $this->getUserEntity(2); // staff_user (i_del_flag=0)
+
+        $result = $this->service->updateWithRooms(
+            $entity,
+            ['c_user_name' => '更新済み職員'],
+            [1],
+            'admin',
+            1,
+            '127.0.0.1'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithRooms_updatesUserName(): void
+    {
+        $entity = $this->getUserEntity(2);
+
+        $this->service->updateWithRooms(
+            $entity,
+            ['c_user_name' => '更新テスト名前'],
+            [],
+            'admin'
+        );
+
+        $table   = TableRegistry::getTableLocator()->get('MUserInfo');
+        $updated = $table->get(2);
+        $this->assertSame('更新テスト名前', $updated->c_user_name);
+    }
+
+    public function testUpdateWithRooms_emptyRoomIds_deletesExistingGroups(): void
+    {
+        $entity = $this->getUserEntity(2);
+
+        $this->service->updateWithRooms(
+            $entity,
+            ['c_user_name' => '職員ユーザー'],
+            [], // 部屋なし
+            'admin'
+        );
+
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $count = $userGroupTable->find()
+            ->where(['i_id_user' => 2])
+            ->count();
+
+        $this->assertSame(0, $count);
+    }
+
+    public function testUpdateWithRooms_withRoomId_createsUserGroup(): void
+    {
+        $entity = $this->getUserEntity(3);
+
+        $this->service->updateWithRooms(
+            $entity,
+            ['c_user_name' => '一般ユーザー'],
+            [1],
+            'admin'
+        );
+
+        $userGroupTable = TableRegistry::getTableLocator()->get('MUserGroup');
+        $count = $userGroupTable->find()
+            ->where(['i_id_user' => 3, 'i_id_room' => 1])
+            ->count();
+
+        $this->assertSame(1, $count);
+    }
+
+    // ----------------------------------------------------------------
+    // updateWithRooms — 監査ログが記録される
+    // ----------------------------------------------------------------
+
+    public function testUpdateWithRooms_createsAuditLog(): void
+    {
+        $auditTable = TableRegistry::getTableLocator()->get('TAuditLog');
+        $before     = $auditTable->find()->count();
+
+        $entity = $this->getUserEntity(2);
+        $this->service->updateWithRooms($entity, ['c_user_name' => '監査テスト'], [], 'admin', 5);
+
+        $this->assertSame($before + 1, $auditTable->find()->count());
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserRoomAssignmentServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserRoomAssignmentServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Service\UserRoomAssignmentService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * UserRoomAssignmentService テスト。
+ *
+ * assign() が既存所属を無効化し、新しい部屋を登録することを検証する。
+ */
+class UserRoomAssignmentServiceTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.MUserGroup',
+        'app.MRoomInfo',
+        'app.MUserInfo',
+    ];
+
+    private UserRoomAssignmentService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new UserRoomAssignmentService();
+    }
+
+    private function userGroupTable(): \Cake\ORM\Table
+    {
+        return TableRegistry::getTableLocator()->get('MUserGroup');
+    }
+
+    private function findActiveGroups(int $userId): array
+    {
+        return $this->userGroupTable()
+            ->find()
+            ->where(['i_id_user' => $userId, 'active_flag' => 0])
+            ->enableHydration(false)
+            ->toArray();
+    }
+
+    // ----------------------------------------------------------------
+    // 正常系
+    // ----------------------------------------------------------------
+
+    public function testAssignCreatesNewGroupForExistingRoom(): void
+    {
+        $roomName = $this->userGroupTable()
+            ->find()
+            ->join([
+                'r' => [
+                    'table' => 'm_room_info',
+                    'type' => 'INNER',
+                    'conditions' => 'r.i_id_room = MUserGroup.i_id_room',
+                ],
+            ])
+            ->select(['r.c_room_name'])
+            ->where(['MUserGroup.i_id_user' => 1])
+            ->enableHydration(false)
+            ->first()['c_room_name'] ?? 'Lorem ipsum dolor sit amet';
+
+        $result = $this->service->assign(1, [$roomName], 'test_actor');
+
+        $this->assertSame(1, $result['created']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    public function testAssignDeactivatesOldGroups(): void
+    {
+        $roomName = 'Lorem ipsum dolor sit amet';
+
+        $this->service->assign(1, [$roomName], 'test_actor');
+
+        $active = $this->findActiveGroups(1);
+        // 古いグループ(room_id=1)は inactive になり、新しいグループが1件だけ active
+        $this->assertCount(1, $active);
+    }
+
+    public function testAssignReturnsEmptyErrorsOnSuccess(): void
+    {
+        $result = $this->service->assign(1, ['Lorem ipsum dolor sit amet'], 'test_actor');
+
+        $this->assertEmpty($result['errors']);
+    }
+
+    public function testAssignLimitsToTwoRooms(): void
+    {
+        // 3件渡しても最大2件しか処理されない
+        $result = $this->service->assign(
+            1,
+            ['Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet'],
+            'test_actor'
+        );
+
+        // 同じ部屋名が複数回指定されても最大2件
+        $this->assertLessThanOrEqual(2, $result['created'] + count($result['errors']));
+    }
+
+    // ----------------------------------------------------------------
+    // 異常系
+    // ----------------------------------------------------------------
+
+    public function testAssignReturnsErrorForUnknownRoom(): void
+    {
+        $result = $this->service->assign(1, ['存在しない部屋'], 'test_actor');
+
+        $this->assertSame(0, $result['created']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertStringContainsString('存在しない部屋', $result['errors'][0]);
+    }
+
+    public function testAssignWithEmptyRoomNamesDeactivatesOldGroups(): void
+    {
+        $this->service->assign(1, [], 'test_actor');
+
+        // 部屋名が空なので既存グループが無効化されるだけ
+        $active = $this->findActiveGroups(1);
+        $this->assertCount(0, $active);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/UserRoomAssignmentServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/UserRoomAssignmentServiceTest.php
@@ -10,7 +10,7 @@ use Cake\TestSuite\TestCase;
 /**
  * UserRoomAssignmentService テスト。
  *
- * assign() が既存所属を無効化し、新しい部屋を登録することを検証する。
+ * assign の正常割り当て・既存グループ無効化・エラーハンドリングを検証する。
  */
 class UserRoomAssignmentServiceTest extends TestCase
 {
@@ -42,6 +42,23 @@ class UserRoomAssignmentServiceTest extends TestCase
             ->toArray();
     }
 
+    private function getExistingRoomName(int $userId = 1): string
+    {
+        return $this->userGroupTable()
+            ->find()
+            ->join([
+                'r' => [
+                    'table' => 'm_room_info',
+                    'type' => 'INNER',
+                    'conditions' => 'r.i_id_room = MUserGroup.i_id_room',
+                ],
+            ])
+            ->select(['r.c_room_name'])
+            ->where(['MUserGroup.i_id_user' => $userId])
+            ->enableHydration(false)
+            ->first()['c_room_name'] ?? 'Lorem ipsum dolor sit amet';
+    }
+
     // ----------------------------------------------------------------
     // 正常系
     // ----------------------------------------------------------------
@@ -70,7 +87,7 @@ class UserRoomAssignmentServiceTest extends TestCase
 
     public function testAssignDeactivatesOldGroups(): void
     {
-        $roomName = 'Lorem ipsum dolor sit amet';
+        $roomName = $this->getExistingRoomName();
 
         $this->service->assign(1, [$roomName], 'test_actor');
 
@@ -81,17 +98,19 @@ class UserRoomAssignmentServiceTest extends TestCase
 
     public function testAssignReturnsEmptyErrorsOnSuccess(): void
     {
-        $result = $this->service->assign(1, ['Lorem ipsum dolor sit amet'], 'test_actor');
+        $result = $this->service->assign(1, [$this->getExistingRoomName()], 'test_actor');
 
         $this->assertEmpty($result['errors']);
     }
 
     public function testAssignLimitsToTwoRooms(): void
     {
+        $roomName = $this->getExistingRoomName();
+
         // 3件渡しても最大2件しか処理されない
         $result = $this->service->assign(
             1,
-            ['Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet'],
+            [$roomName, $roomName, $roomName],
             'test_actor'
         );
 

--- a/src_web/kamaho-shokusu/tests/schema.php
+++ b/src_web/kamaho-shokusu/tests/schema.php
@@ -198,4 +198,21 @@ return [
             'primary' => ['type' => 'primary', 'columns' => ['i_id_audit']],
         ],
     ],
+    'm_room_transfer_schedule' => [
+        'columns' => [
+            'i_id'           => ['type' => 'integer', 'autoIncrement' => true, 'null' => false],
+            'i_id_user'      => ['type' => 'integer', 'null' => false],
+            'i_id_room_from' => ['type' => 'integer', 'null' => true, 'default' => null],
+            'i_id_room_to'   => ['type' => 'integer', 'null' => false],
+            'd_effective_date' => ['type' => 'date', 'null' => false],
+            'i_status'       => ['type' => 'integer', 'null' => false, 'default' => 0],
+            'c_create_user'  => ['type' => 'string', 'length' => 50, 'null' => true],
+            'dt_create'      => ['type' => 'datetime', 'null' => true],
+            'c_update_user'  => ['type' => 'string', 'length' => 50, 'null' => true],
+            'dt_update'      => ['type' => 'datetime', 'null' => true],
+        ],
+        'constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['i_id']],
+        ],
+    ],
 ];


### PR DESCRIPTION
Closes #474

## 変更内容

### Domain 層テスト（新規）
- `Domain/ValueObject/UserRoleTest` — 定数値・`isAdmin` / `isBlockLeader` / `isSystemAdmin` の全パターンを網羅（13テスト）
- `Domain/Exception/DomainExceptionTest` — `InvalidInputException` / `NotFoundException` / `ConflictException` / `UnauthorizedException` の HTTPステータスコード・メッセージ・継承関係を検証（12テスト）

### Service 層テスト（新規追加）
- `UserRoomAssignmentServiceTest` — 部屋割り当て・既存グループの無効化・存在しない部屋のエラーを検証
- `ReservationCopyServiceTest` — `normalizeCopyParams()` のモード/日付バリデーション・月曜/月初正規化・エイリアス対応を網羅
- `ActualMealManagementServiceTest` — `getAdminOldestAllowedMonday()` の日付計算・DB操作系メソッドの戻り値構造を検証
- `BulkReservationFormServiceTest` — 週データ構造・15日フィルタ・過去日の `is_disabled` フラグを検証（DBなし）
- `NotificationServiceTest` — `userId <= 0` ガード条件・空ID配列のガード条件を検証
- `ReservationCalendarServiceTest` — `getPrimaryRoomId()` / `getUserRoomIds()` / イベント構造を検証
- `ReservationChangeEditServiceTest` — `resolveDefaultRoomId()` ガード条件・ユーザー権限判定ロジックを検証
- `ReservationQueryServiceTest` — `getUsersByRoom` / `hasDuplicateReservation` / スナップショット取得を検証
- `ReservationReportServiceTest` — 各レポートメソッドの戻り値キー構造を検証
- `ReservationRoomDetailServiceTest` — 無効部屋/日付に対する例外・直前編集フラグ判定を検証
- `ReservationViewServiceTest` — コンテキスト構造・未ログイン時の isAdmin=false を検証
- `RoomServiceTest` — `nextDisplayNo()` / `softDelete()` のフラグ設定・ユーザー一覧取得を検証
- `RoomTransferScheduleServiceTest` — 保留スケジュールなし時の `applied=0` 戻り値を検証
- `RoomUsageServiceTest` — `getRoomUsage()` の戻り値構造・`getLowUsageRooms()` の閾値フィルタを検証
- `UserBulkImportServiceTest` — 必須フィールド欠落・不正ロール・重複ログインID・正常作成を検証
- `UserEditServiceTest` — `updateWithRooms()` のユーザー名更新・グループ管理・監査ログ記録を検証

### テストインフラ整備
- `tests/schema.php` に `m_room_transfer_schedule` テーブル定義を追加（テストDBに未定義だったためスキップが発生していた問題を解消）
- `MRoomTransferScheduleFixture` を新規作成

## テスト結果

```
Tests: 529, Assertions: 1122, Skipped: 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 予約・通知・ユーザー/部屋/所属・食事/カレンダー・データ複製/レポートなど、主要機能のテストを多数追加し、戻り値や必須項目、ガード条件、例外の挙動を幅広く確認できるようにしました。
  * 期間や入力の境界（空/不正/無効ケース）に対する安定性を強化しました。
* **Chores**
  * 部屋移動予定に関する新しいテーブル定義とテスト用フィクスチャを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->