### PR TITLE
feat: FeatureUsageSummaryに時間帯別使用頻度グラフを追加

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/FeatureUsageSummaryController.php
+++ b/src_web/kamaho-shokusu/src/Controller/FeatureUsageSummaryController.php
@@ -46,11 +46,12 @@ class FeatureUsageSummaryController extends AppController
             $yearMonth = date('Y-m');
         }
 
-        $summary      = $this->summaryService->getSummary($yearMonth, $category ?: null);
-        $monthOptions = $this->summaryService->getMonthOptions();
-        $categories   = FeatureUsageSummaryService::CATEGORY_LABELS;
+        $summary          = $this->summaryService->getSummary($yearMonth, $category ?: null);
+        $hourlyUsage      = $this->summaryService->getHourlyDistribution($yearMonth, $category ?: null);
+        $monthOptions     = $this->summaryService->getMonthOptions();
+        $categories       = FeatureUsageSummaryService::CATEGORY_LABELS;
 
-        $this->set(compact('summary', 'monthOptions', 'categories', 'yearMonth', 'category'));
+        $this->set(compact('summary', 'hourlyUsage', 'monthOptions', 'categories', 'yearMonth', 'category'));
         return null;
     }
 }

--- a/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
+++ b/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
@@ -126,6 +126,7 @@ class FeatureUsageSummaryService
      * @param string $yearMonth 対象月 (YYYY-MM)
      * @param string|null $category カテゴリ絞り込み（null = 全件）
      * @return array{hours: list<array{hour: int, label: string, total: int}>, peak_hour: int|null, peak_total: int}
+     * @throws \Cake\Database\Exception\DatabaseException DBクエリ失敗時
      */
     public function getHourlyDistribution(string $yearMonth, ?string $category = null): array
     {

--- a/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
+++ b/src_web/kamaho-shokusu/src/Service/FeatureUsageSummaryService.php
@@ -121,6 +121,66 @@ class FeatureUsageSummaryService
     }
 
     /**
+     * 時間帯別使用頻度を集計して返す。
+     *
+     * @param string $yearMonth 対象月 (YYYY-MM)
+     * @param string|null $category カテゴリ絞り込み（null = 全件）
+     * @return array{hours: list<array{hour: int, label: string, total: int}>, peak_hour: int|null, peak_total: int}
+     */
+    public function getHourlyDistribution(string $yearMonth, ?string $category = null): array
+    {
+        $table    = TableRegistry::getTableLocator()->get('TAuditLog');
+        $dateFrom = $yearMonth . '-01 00:00:00';
+        $dateTo   = date('Y-m-t', (int)strtotime($yearMonth . '-01')) . ' 23:59:59';
+
+        $query = $table->find()
+            ->select([
+                'hour'  => 'HOUR(dt_create)',
+                'total' => 'COUNT(*)',
+            ])
+            ->where([
+                'dt_create >=' => $dateFrom,
+                'dt_create <=' => $dateTo,
+                'i_result'     => 1,
+            ])
+            ->group('HOUR(dt_create)')
+            ->order('HOUR(dt_create)')
+            ->disableHydration();
+
+        if ($category !== null && $category !== '') {
+            $query->andWhere(['c_category' => $category]);
+        }
+
+        $rawByHour = [];
+        foreach ($query->toArray() as $row) {
+            $rawByHour[(int)$row['hour']] = (int)$row['total'];
+        }
+
+        $hours     = [];
+        $peakHour  = null;
+        $peakTotal = 0;
+
+        for ($h = 0; $h < 24; $h++) {
+            $total = $rawByHour[$h] ?? 0;
+            $hours[] = [
+                'hour'  => $h,
+                'label' => sprintf('%02d:00', $h),
+                'total' => $total,
+            ];
+            if ($total > $peakTotal) {
+                $peakTotal = $total;
+                $peakHour  = $h;
+            }
+        }
+
+        return [
+            'hours'      => $hours,
+            'peak_hour'  => $peakHour,
+            'peak_total' => $peakTotal,
+        ];
+    }
+
+    /**
      * 選択可能な月一覧（過去12ヶ月）を返す。
      *
      * @return array<string, string>

--- a/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
+++ b/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
@@ -161,14 +161,14 @@ $q = $this->request->getQueryParams();
                 <p class="mb-0">対象期間にデータがありません。</p>
             </div>
         <?php else: ?>
-            <div class="row g-1 align-items-end" style="height:140px;">
+            <div class="row g-1 align-items-end" style="height:140px;padding-top:14px;">
                 <?php foreach ($hourlyUsage['hours'] as $h):
                     $pct = $hourlyUsage['peak_total'] > 0
                         ? (int)round($h['total'] / $hourlyUsage['peak_total'] * 100)
                         : 0;
                     $isPeak = ($h['hour'] === $hourlyUsage['peak_hour'] && $h['total'] > 0);
                     $barColor = $isPeak ? '#f97316' : '#6ea8fe';
-                    $colHeight = max(4, (int)round($pct * 1.1));
+                    $colHeight = max(4, $pct);
                 ?>
                     <div class="col position-relative d-flex flex-column align-items-center justify-content-end"
                          style="height:100%;"

--- a/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
+++ b/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
@@ -2,6 +2,7 @@
 /**
  * @var \App\View\AppView $this
  * @var array{rows: list<array{action: string, label: string, category: string, category_label: string, total: int, unique_users: int, last_used: string}>, total_operations: int, top_feature: string} $summary
+ * @var array{hours: list<array{hour: int, label: string, total: int}>, peak_hour: int|null, peak_total: int} $hourlyUsage
  * @var array<string, string> $monthOptions
  * @var array<string, string> $categories
  * @var string $yearMonth
@@ -29,7 +30,7 @@ $q = $this->request->getQueryParams();
 
 <!-- サマリーカード -->
 <div class="row g-3 mb-4">
-    <div class="col-sm-4">
+    <div class="col-sm-3">
         <div class="card border-0 shadow-sm h-100">
             <div class="card-body d-flex align-items-center gap-3">
                 <div class="rounded-circle d-flex align-items-center justify-content-center bg-primary bg-opacity-10"
@@ -43,7 +44,7 @@ $q = $this->request->getQueryParams();
             </div>
         </div>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
         <div class="card border-0 shadow-sm h-100">
             <div class="card-body d-flex align-items-center gap-3">
                 <div class="rounded-circle d-flex align-items-center justify-content-center bg-success bg-opacity-10"
@@ -57,7 +58,7 @@ $q = $this->request->getQueryParams();
             </div>
         </div>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
         <div class="card border-0 shadow-sm h-100">
             <div class="card-body d-flex align-items-center gap-3">
                 <div class="rounded-circle d-flex align-items-center justify-content-center bg-info bg-opacity-10"
@@ -67,6 +68,26 @@ $q = $this->request->getQueryParams();
                 <div>
                     <div class="text-muted small">操作種別数</div>
                     <div class="fw-bold fs-4"><?= count($summary['rows']) ?> <span class="fs-6 text-muted fw-normal">種</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body d-flex align-items-center gap-3">
+                <div class="rounded-circle d-flex align-items-center justify-content-center"
+                     style="width:48px;height:48px;flex-shrink:0;background:rgba(249,115,22,.1);">
+                    <i class="bi bi-clock-fill fs-5" style="color:#f97316;"></i>
+                </div>
+                <div>
+                    <div class="text-muted small">最も使われる時間帯</div>
+                    <div class="fw-bold fs-5">
+                        <?php if ($hourlyUsage['peak_hour'] !== null && $hourlyUsage['peak_total'] > 0): ?>
+                            <?= sprintf('%02d:00〜%02d:59', $hourlyUsage['peak_hour'], $hourlyUsage['peak_hour']) ?>
+                        <?php else: ?>
+                            —
+                        <?php endif; ?>
+                    </div>
                 </div>
             </div>
         </div>
@@ -114,6 +135,87 @@ $q = $this->request->getQueryParams();
             <?php endif; ?>
         </div>
         <?= $this->Form->end() ?>
+    </div>
+</div>
+
+<!-- 時間帯別使用頻度グラフ -->
+<div class="card border-0 shadow-sm mb-4">
+    <div class="card-header bg-white border-bottom d-flex align-items-center justify-content-between py-2">
+        <span class="fw-semibold text-secondary small">
+            <i class="bi bi-clock-history me-1"></i>
+            時間帯別使用頻度
+            <span class="badge bg-secondary ms-1"><?= h($yearMonth) ?></span>
+        </span>
+        <?php if ($hourlyUsage['peak_hour'] !== null): ?>
+            <span class="text-muted small">
+                ピーク:
+                <strong class="text-primary"><?= sprintf('%02d:00〜%02d:59', $hourlyUsage['peak_hour'], $hourlyUsage['peak_hour']) ?></strong>
+                （<?= number_format($hourlyUsage['peak_total']) ?> 回）
+            </span>
+        <?php endif; ?>
+    </div>
+    <div class="card-body pb-3">
+        <?php if ($hourlyUsage['peak_total'] === 0): ?>
+            <div class="text-center text-muted py-4">
+                <i class="bi bi-inbox fs-1 d-block mb-2 text-secondary opacity-50"></i>
+                <p class="mb-0">対象期間にデータがありません。</p>
+            </div>
+        <?php else: ?>
+            <div class="row g-1 align-items-end" style="height:140px;">
+                <?php foreach ($hourlyUsage['hours'] as $h):
+                    $pct = $hourlyUsage['peak_total'] > 0
+                        ? (int)round($h['total'] / $hourlyUsage['peak_total'] * 100)
+                        : 0;
+                    $isPeak = ($h['hour'] === $hourlyUsage['peak_hour'] && $h['total'] > 0);
+                    $barColor = $isPeak ? '#f97316' : '#6ea8fe';
+                    $colHeight = max(4, (int)round($pct * 1.1));
+                ?>
+                    <div class="col position-relative d-flex flex-column align-items-center justify-content-end"
+                         style="height:100%;"
+                         title="<?= h($h['label']) ?>: <?= number_format($h['total']) ?> 回">
+                        <?php if ($h['total'] > 0 && $isPeak): ?>
+                            <div class="position-absolute top-0 w-100 text-center" style="font-size:10px;color:#f97316;font-weight:700;">
+                                <?= number_format($h['total']) ?>
+                            </div>
+                        <?php endif; ?>
+                        <div class="w-100 rounded-top"
+                             style="height:<?= $colHeight ?>%;background:<?= $barColor ?>;min-height:<?= $h['total'] > 0 ? '4px' : '0' ?>;">
+                        </div>
+                        <div class="text-center text-muted" style="font-size:9px;margin-top:2px;white-space:nowrap;">
+                            <?= $h['hour'] % 3 === 0 ? sprintf('%02d', $h['hour']) : '' ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <div class="d-flex justify-content-between text-muted mt-1 px-1" style="font-size:10px;">
+                <span>0時</span>
+                <span>6時</span>
+                <span>12時</span>
+                <span>18時</span>
+                <span>23時</span>
+            </div>
+            <!-- 上位3時間帯 -->
+            <?php
+            $sortedHours = $hourlyUsage['hours'];
+            usort($sortedHours, fn($a, $b) => $b['total'] - $a['total']);
+            $topHours = array_filter($sortedHours, fn($h) => $h['total'] > 0);
+            $topHours = array_slice(array_values($topHours), 0, 3);
+            ?>
+            <?php if (!empty($topHours)): ?>
+                <div class="d-flex gap-2 mt-3 flex-wrap">
+                    <?php foreach ($topHours as $rank => $th): ?>
+                        <div class="d-flex align-items-center gap-2 px-3 py-2 rounded"
+                             style="background:#f8f9fa;border:1px solid #e9ecef;">
+                            <span class="fw-bold" style="color:<?= $rank === 0 ? '#f97316' : ($rank === 1 ? '#6c757d' : '#cd7f32') ?>;">
+                                <?= ['1st', '2nd', '3rd'][$rank] ?>
+                            </span>
+                            <span class="fw-semibold"><?= sprintf('%02d:00〜%02d:59', $th['hour'], $th['hour']) ?></span>
+                            <span class="badge bg-secondary"><?= number_format($th['total']) ?> 回</span>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        <?php endif; ?>
     </div>
 </div>
 


### PR DESCRIPTION
## 概要

`/FeatureUsageSummary` ダッシュボードに「一番よく使用されている時間帯」の集計機能を追加。

## 変更内容

### `FeatureUsageSummaryService`（Service層）

- `getHourlyDistribution(string $yearMonth, ?string $category = null)` を新規追加
- `t_audit_log.dt_create` を `HOUR()` 単位でグループ集計し、0〜23時の件数配列を返す
- `peak_hour`（最多時間帯）と `peak_total`（ピーク件数）も返す
- カテゴリフィルターに対応（既存の `getSummary` と同様）

### `FeatureUsageSummaryController`（Controller層）

- `getHourlyDistribution()` を呼び出し `$hourlyUsage` をビューに渡す

### `index.php`（テンプレート）

- **サマリーカードを4枚に拡張** — 新たに「最も使われる時間帯」カードを追加（ピーク時間帯を一目で確認できる）
- **時間帯別棒グラフ** — 0〜23時を横並びの棒グラフで可視化。ピーク時間をオレンジ色でハイライト
- **上位3時間帯ランキング** — 1st/2nd/3rd 形式でピーク時間帯とその回数を表示
- カテゴリ絞り込みフィルターに完全対応（時間帯グラフにも絞り込みが反映される）

## テスト手順

- [ ] `/FeatureUsageSummary` にアクセスしてページが正常表示される
- [ ] サマリーカードに「最も使われる時間帯」が表示される
- [ ] 時間帯別棒グラフが0〜23時で表示され、ピーク時間がオレンジでハイライトされる
- [ ] 上位3時間帯ランキングが表示される
- [ ] カテゴリ絞り込みで時間帯グラフの内容が変化する
- [ ] データが0件の月を選択すると「データがありません」が表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 月次サマリーに加え、選択した年月・カテゴリに基づく「時間帯別の使用分布」を表示できるようになりました。
  * 最も使われる時間帯（ピーク）をサマリーで確認でき、「時間帯別」棒グラフと上位3時間帯の一覧も追加されました。
* **UI Improvements**
  * カードのレイアウトを整理し、データがない場合は空状態（表示なし）を出すようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->