### PR TITLE
fix: 全画面のSP表示崩れ・表示バグの修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ApprovalController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Domain\ValueObject\UserRole;
 use App\Service\ApprovalService;
 use App\Service\RoomAccessService;
 use Cake\Http\Response;

--- a/src_web/kamaho-shokusu/templates/Approval/admin_index.php
+++ b/src_web/kamaho-shokusu/templates/Approval/admin_index.php
@@ -235,11 +235,11 @@ foreach ($summary as $row) {
         </table>
         </div>
 
-        <div class="d-flex justify-content-between align-items-center mt-2">
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-2">
             <div>
                 <label class="small text-secondary fw-semibold"><input type="checkbox" id="check-all-bottom"> 全選択</label>
             </div>
-            <div class="d-flex gap-2">
+            <div class="d-flex flex-wrap gap-2 approval-action-btns">
                 <button type="button" id="reject-btn"  class="btn btn-outline-danger mui-btn">差し戻し</button>
                 <button type="button" id="approve-block-leader-btn" class="btn btn-outline-success mui-btn">ブロック長承認済を承認</button>
                 <button type="button" id="approve-btn" class="btn btn-primary mui-btn">選択項目を一括承認</button>

--- a/src_web/kamaho-shokusu/templates/Approval/approval_log.php
+++ b/src_web/kamaho-shokusu/templates/Approval/approval_log.php
@@ -15,7 +15,7 @@ $mealTypes = [1 => '朝', 2 => '昼', 3 => '夜', 4 => '弁'];
 ?>
 
 <div class="container-fluid py-4">
-    <div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
         <h1 class="h3 mb-0">承認履歴</h1>
         <a href="<?= $this->Url->build(['action' => 'adminIndex']) ?>" class="btn btn-outline-secondary btn-sm">承認管理へ戻る</a>
     </div>

--- a/src_web/kamaho-shokusu/templates/AuditLog/index.php
+++ b/src_web/kamaho-shokusu/templates/AuditLog/index.php
@@ -13,7 +13,7 @@ $hasFilter = !empty($q['category']) || !empty($q['action']) || !empty($q['actor'
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
 <!-- ページヘッダー -->
-<div class="rounded-3 shadow-sm mb-4 px-4 py-3 d-flex align-items-center justify-content-between"
+<div class="rounded-3 shadow-sm mb-4 px-4 py-3 d-flex flex-wrap align-items-center justify-content-between gap-2"
      style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%); color:#fff;">
     <div class="d-flex align-items-center gap-3">
         <div class="d-flex align-items-center justify-content-center rounded-circle bg-danger shadow"
@@ -112,7 +112,7 @@ $hasFilter = !empty($q['category']) || !empty($q['action']) || !empty($q['actor'
 </div>
 
 <!-- 件数 & 上部ページネーション -->
-<div class="d-flex justify-content-between align-items-center mb-2">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
     <p class="text-muted small mb-0">
         <i class="bi bi-list-ul me-1"></i>
         <?= $this->Paginator->counter('全 {{count}} 件中 {{start}}〜{{end}} 件を表示') ?>

--- a/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
+++ b/src_web/kamaho-shokusu/templates/FeatureUsageSummary/index.php
@@ -14,7 +14,7 @@ $q = $this->request->getQueryParams();
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
 <!-- ページヘッダー -->
-<div class="rounded-3 shadow-sm mb-4 px-4 py-3 d-flex align-items-center justify-content-between"
+<div class="rounded-3 shadow-sm mb-4 px-4 py-3 d-flex flex-wrap align-items-center justify-content-between gap-2"
      style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%); color:#fff;">
     <div class="d-flex align-items-center gap-3">
         <div class="d-flex align-items-center justify-content-center rounded-circle shadow"

--- a/src_web/kamaho-shokusu/templates/MMealPriceInfo/get_meal_summary.php
+++ b/src_web/kamaho-shokusu/templates/MMealPriceInfo/get_meal_summary.php
@@ -218,7 +218,7 @@ $exportSummaryPreviewUrl = $this->Url->build(['controller' => 'MMealPriceInfo', 
 
                     // APIからデータを取得
                     const response = await fetch(
-                        `<?= h($exportSummaryUrl) ?>?year=${selectedYear}&month=${selectedMonth}`
+                        `<?= h($exportSummaryUrl) ?>?year=${encodeURIComponent(selectedYear)}&month=${encodeURIComponent(selectedMonth)}`
                     );
                     if (!response.ok) throw new Error(`APIエラー: ${response.status}`);
 
@@ -358,7 +358,7 @@ $exportSummaryPreviewUrl = $this->Url->build(['controller' => 'MMealPriceInfo', 
 
                 try {
                     const response = await fetch(
-                        `<?= h($exportSummaryPreviewUrl) ?>?year=${selectedYear}&month=${selectedMonth}`
+                        `<?= h($exportSummaryPreviewUrl) ?>?year=${encodeURIComponent(selectedYear)}&month=${encodeURIComponent(selectedMonth)}`
                     );
                     if (!response.ok) throw new Error(`APIエラー: ${response.status}`);
 

--- a/src_web/kamaho-shokusu/templates/MMealPriceInfo/get_meal_summary.php
+++ b/src_web/kamaho-shokusu/templates/MMealPriceInfo/get_meal_summary.php
@@ -6,6 +6,8 @@
  * @var array $mealDataArray 食数データの配列
  */
 $this->assign('title', __('食事給与控除データエクスポート'));
+$exportSummaryUrl        = $this->Url->build(['controller' => 'MMealPriceInfo', 'action' => 'exportMealSummary']);
+$exportSummaryPreviewUrl = $this->Url->build(['controller' => 'MMealPriceInfo', 'action' => 'exportMealSummaryPreview']);
 ?>
 <!-- Example Form with Bootstrap -->
 <div class="container mt-5">
@@ -216,7 +218,7 @@ $this->assign('title', __('食事給与控除データエクスポート'));
 
                     // APIからデータを取得
                     const response = await fetch(
-                        `/kamaho-shokusu/MMealPriceInfo/exportMealSummary?year=${selectedYear}&month=${selectedMonth}`
+                        `<?= h($exportSummaryUrl) ?>?year=${selectedYear}&month=${selectedMonth}`
                     );
                     if (!response.ok) throw new Error(`APIエラー: ${response.status}`);
 
@@ -356,7 +358,7 @@ $this->assign('title', __('食事給与控除データエクスポート'));
 
                 try {
                     const response = await fetch(
-                        `/kamaho-shokusu/MMealPriceInfo/exportMealSummaryPreview?year=${selectedYear}&month=${selectedMonth}`
+                        `<?= h($exportSummaryPreviewUrl) ?>?year=${selectedYear}&month=${selectedMonth}`
                     );
                     if (!response.ok) throw new Error(`APIエラー: ${response.status}`);
 

--- a/src_web/kamaho-shokusu/templates/MMealPriceInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/MMealPriceInfo/view.php
@@ -23,6 +23,7 @@ $this->assign('title', __('食事単価情報表示'));
                 <h3 class="card-title"><?= h($mMealPriceInfo->i_id) ?> <?= __('詳細') ?></h3>
             </div>
             <div class="card-body">
+                <div class="table-responsive">
                 <table class="table table-bordered table-striped">
                     <tr>
                         <th><?= __('対象年度') ?></th>
@@ -46,6 +47,7 @@ $this->assign('title', __('食事単価情報表示'));
                     </tr>
 
                 </table>
+                </div>
             </div>
         </div>
     </div>

--- a/src_web/kamaho-shokusu/templates/MNotice/index.php
+++ b/src_web/kamaho-shokusu/templates/MNotice/index.php
@@ -19,7 +19,7 @@ $typeLabels = [
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 
 <div class="content">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h3 class="mb-0">
             <i class="bi bi-megaphone"></i> お知らせ管理
         </h3>

--- a/src_web/kamaho-shokusu/templates/MRoomInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomInfo/index.php
@@ -11,7 +11,7 @@ $this->Html->css('pages/m_room_info_index.css', ['block' => true]);
 $isAdmin = in_array((int)$user->get('i_admin'), [1, 3]);
 ?>
 <div class="mRoomInfo index content">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h3 class="mb-0"><?= __('部屋情報一覧') ?></h3>
         <?php if ($isAdmin): ?>
         <?= $this->Html->link(__('+ 新しい部屋を追加'), ['action' => 'add'], ['class' => 'btn btn-success']) ?>

--- a/src_web/kamaho-shokusu/templates/MRoomInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/MRoomInfo/view.php
@@ -23,6 +23,7 @@ $this->assign('title', __('部屋情報') . ' ' . h($mRoomInfo->c_room_name));
         <div class="card">
             <h5 class="card-header"><?= __('部屋情報') . ' ' . h($mRoomInfo->c_room_name) ?></h5>
             <div class="card-body">
+                <div class="table-responsive">
                 <table class="table table-striped">
                     <tr>
                         <th><?= __('部屋名') ?></th>
@@ -33,6 +34,7 @@ $this->assign('title', __('部屋情報') . ' ' . h($mRoomInfo->c_room_name));
                         <td><?= $this->Number->format($mRoomInfo->i_id_room) ?></td>
                     </tr>
                 </table>
+                </div>
 
                 <?php if (!empty($users)): ?>
                     <h4><?= __('所属メンバー') ?></h4>

--- a/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
+++ b/src_web/kamaho-shokusu/templates/MRoomTransferSchedule/index.php
@@ -22,7 +22,7 @@ $dayNames = ['日', '月', '火', '水', '木', '金', '土'];
 
 
 <div class="content">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
         <h3 class="mb-0">
             <i class="bi bi-arrow-left-right"></i> 部屋異動予約一覧
         </h3>

--- a/src_web/kamaho-shokusu/templates/MUserInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/index.php
@@ -21,7 +21,7 @@ $csrfToken = $this->request->getAttribute('csrfToken');
 
 <div class="mUserInfo index content">
     <?php if ($isAdmin || $user->get('i_user_level') === 0): ?>
-        <div class="d-flex gap-2 mb-3">
+        <div class="d-flex flex-wrap gap-2 mb-3">
             <?= $this->Html->link(__('新しくユーザを追加'), ['action' => 'add'], ['class' => 'btn btn-success']) ?>
             <?= $this->Html->link(__('一括ユーザー登録'), ['action' => 'importForm'], ['class' => 'btn btn-primary']) ?>
         </div>

--- a/src_web/kamaho-shokusu/templates/MUserInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/MUserInfo/view.php
@@ -25,6 +25,7 @@ $currentUserId = $user->get('i_id_user');
                 <h3><?= 'ユーザー情報:'.h($mUserInfo->c_user_name) ?></h3>
             </div>
             <div class="card-body">
+                <div class="table-responsive">
                 <table class="table table-striped">
                     <?php if($mUserInfo->i_id_user === $currentUserId || in_array((int)$user->get('i_admin'), [1, 3])): ?>
                     <tr>
@@ -46,6 +47,7 @@ $currentUserId = $user->get('i_id_user');
 
 
                 </table>
+                </div>
             </div>
         </div>
     </div>

--- a/src_web/kamaho-shokusu/templates/Notifications/index.php
+++ b/src_web/kamaho-shokusu/templates/Notifications/index.php
@@ -4,7 +4,7 @@ $this->assign('title', '通知一覧');
 $notifications = $notifications ?? [];
 ?>
 
-<div class="d-flex justify-content-between align-items-center mb-3">
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
     <div>
         <h2 class="mb-1">通知一覧</h2>
         <div class="text-muted small">差し戻し通知などのアプリ内通知を表示します。</div>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/edit.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/edit.php
@@ -11,6 +11,7 @@ $loginUser = $this->request->getAttribute('identity');
         <?= $this->Form->create(null, ['url' => ['action' => 'edit', $room->i_id_room ?? '0', $date, $mealType]]) ?>
         <fieldset>
             <legend><?= __('利用者と予約情報') ?></legend>
+            <div class="table-responsive">
             <table class="table table-bordered">
                 <thead>
                 <tr>
@@ -163,6 +164,7 @@ $loginUser = $this->request->getAttribute('identity');
                 <?php endforeach; ?>
                 </tbody>
             </table>
+            </div>
         </fieldset>
         <?= $this->Form->button(__('保存'), ['class' => 'btn btn-primary']) ?>
         <?= $this->Form->end() ?>

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/view.php
@@ -148,5 +148,4 @@ echo $this->Html->css('pages/t_reservation_view.css');
                 <a class="btn-teal" href="<?= $this->Url->build('/') ?>">ダッシュボードへ戻る</a>
             </div>
         </div>
-    </div>
 </div>

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/biz_section.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/biz_section.php
@@ -81,7 +81,7 @@ $copyModalVars = [
             <hr class="my-3">
 
             <div class="d-flex flex-wrap align-items-center gap-2">
-                <div class="小さな text-muted"><i class="bi bi-info-circle"></i> 選択中の期間：</div>
+                <div class="small text-muted"><i class="bi bi-info-circle"></i> 選択中の期間：</div>
                 <span class="badge rounded-pill text-bg-light" id="rangeChip"><?= date('Y-m-01') ?> 〜 <?= date('Y-m-t') ?></span>
             </div>
         </div>

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/kid_section.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/kid_section.php
@@ -77,7 +77,7 @@ $kidMeals = [
 <?= $this->Flash->render() ?>
 
 <!-- ★ モード切替（自動 / 直前 / 通常） -->
-<div class="mode-bar d-flex align-items-center justify-content-between mb-3">
+<div class="mode-bar d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
     <div class="small text-muted">
         <i class="bi bi-sliders"></i>
         モードを切り替えると、クリック時の挙動を切り替えられます（<u>画面表示のみ切替</u>）。

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/toolbar.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/toolbar.php
@@ -1,5 +1,5 @@
-<div class="d-flex align-items-center justify-content-between mt-2 mb-2">
-    <h1 class="m-0"><?= $useKidUI ? '🍚 食数予約（中高生向け）' : '食数予約（業務）' ?></h1>
+<div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mt-2 mb-2">
+    <h1 class="m-0 fs-3"><?= $useKidUI ? '🍚 食数予約（中高生向け）' : '食数予約（業務）' ?></h1>
     <?php if (!$useKidUI || ($useKidUI && $isStaff)): ?>
         <div class="d-flex align-items-center gap-2">
             <span class="text-muted small d-none d-md-inline">表示モード:</span>

--- a/src_web/kamaho-shokusu/templates/layout/default.php
+++ b/src_web/kamaho-shokusu/templates/layout/default.php
@@ -131,7 +131,7 @@ $recentNotifications     = $recentNotifications ?? [];
                                     </span>
                                 <?php endif; ?>
                             </a>
-                            <ul class="dropdown-menu dropdown-menu-end border-0 shadow animate__animated animate__fadeIn" aria-labelledby="notificationMenu" style="min-width: 24rem;">
+                            <ul class="dropdown-menu dropdown-menu-end border-0 shadow animate__animated animate__fadeIn notification-dropdown" aria-labelledby="notificationMenu">
                                 <?php if (empty($recentNotifications)): ?>
                                     <li><span class="dropdown-item-text text-muted">未読通知はありません</span></li>
                                 <?php else: ?>

--- a/src_web/kamaho-shokusu/webroot/css/layout-header.css
+++ b/src_web/kamaho-shokusu/webroot/css/layout-header.css
@@ -111,6 +111,12 @@ body {
     padding: 0.25em 0.5em;
 }
 
+/* Notification Dropdown — SPでは画面幅を超えない */
+.notification-dropdown {
+    min-width: min(24rem, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+}
+
 /* Responsive Adjustments */
 @media (max-width: 991.98px) {
     .navbar-custom {

--- a/src_web/kamaho-shokusu/webroot/css/pages/approval_admin_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/approval_admin_index.css
@@ -296,4 +296,6 @@ body {
 @media (max-width: 760px) {
     .summary-grid { grid-template-columns: 1fr; }
     .page-shell { padding-inline: 14px; }
+    .approval-action-btns { width: 100%; flex-direction: column; }
+    .approval-action-btns .mui-btn { width: 100%; }
 }

--- a/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/home.pc.css
@@ -166,6 +166,8 @@ main.container { max-width: 100%; padding: 0; }
 
 @media (max-width: 992px) {
     .dash-main { padding: 24px 20px 40px; }
+    .dash-header { flex-wrap: wrap; }
+    .date-pill { font-size: .85rem; padding: 6px 10px; }
     .card-grid { grid-template-columns: 1fr; }
     .alert-card { grid-template-columns: 1fr; }
     .alert-actions { justify-content: flex-start; }

--- a/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/treservation_index.css
@@ -117,6 +117,14 @@
         .late-notice-agree { background:#fff; }
         .late-notice-agree .form-text { color:#5a5f64; font-size:.82rem; }
 
+        /* SPで直前警告モーダルを全幅表示（modals.php の modal-sm-fullwidth と対） */
+        @media (max-width: 575.98px) {
+            .modal-dialog.modal-sm-fullwidth {
+                max-width: none;
+                margin: .5rem;
+            }
+        }
+
         /* ネストモーダル（quickDayModal内から開く場合）のz-index対応 */
         #lateNoticeModal { z-index: 1065; }
         #lateNoticeModal + .modal-backdrop { z-index: 1060; }


### PR DESCRIPTION
## 概要
全画面を対象にバグ・表示崩れ・SP（スマートフォン）対応の不備を監査し、修正しました。

## 変更内容

### バグ修正
- **承認履歴画面の500エラー修正**: `ApprovalController` で `UserRole` クラスの `use` 文が欠落しており、承認履歴（`/Approval/approval_log`）が Class not found で常に500エラーになっていた問題を修正
- **食事控除表エクスポートのパス修正**: API URL にベースパス `/kamaho-shokusu/` がハードコードされていた2箇所を `Url->build()` 生成に変更（デプロイパス変更に追従可能に）
- **食数状況確認画面のHTML構造崩れ修正**: 余分な閉じタグ `</div>` によりレイアウトの `<main>` が早期に閉じられていた問題を修正
- **biz_section のCSSクラス名タイポ修正**: `class="小さな text-muted"` → `class="small text-muted"`

### SP対応
- **通知ドロップダウン**: 固定 `min-width: 24rem`（384px）が幅375px以下のスマホで画面外にはみ出す問題を `min(24rem, calc(100vw - 2rem))` でキャップ
- **table-responsive 追加**: MMealPriceInfo/view・MUserInfo/view・MRoomInfo/view・TReservationInfo/edit のテーブルに横スクロールラッパーを追加
- **ヘッダー行の折返し対応**: 監査ログ・機能使用頻度・お知らせ管理・部屋情報一覧・部屋異動予約・通知一覧・承認履歴・ユーザー一覧の各画面のタイトル＋ボタン行に `flex-wrap` を追加
- **承認管理画面**: 一括操作ボタン4つがSPで横溢れするため、760px以下で縦積み・全幅化
- **予約画面**: ツールバー・モードバーの折返し対応、未定義のまま参照されていた `modal-sm-fullwidth` クラスを定義（SPでモーダル全幅表示）
- **ダッシュボード**: ヘッダー行の折返しと日付ピルのSP向け縮小

## 検証
- 変更した全PHPファイルの `php -l` 構文チェック通過
- 食数状況確認画面のdivタグバランス一致を検証（29:29）
- 承認履歴画面が500 → 正常応答（302リダイレクト）になることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 通知メニューが画面幅に合わせて収まりやすくなりました。
  * 一部の一覧・詳細画面で、表がスマホでも見やすくなるよう改善しました。
* **改善**
  * 各ページのヘッダーや操作ボタンが、狭い画面で折り返して表示されるようになりました。
  * 予約編集画面のモーダルが小さい画面で横幅いっぱいに表示されやすくなりました。
  * 一部の出力処理で、より安定したURL参照に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->