### PR TITLE
fix: #492 エクセル食数予約の個人モードで選択ユーザーのみ表示するよう修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ReservationActualMealController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ReservationActualMealController.php
@@ -463,14 +463,10 @@ class ReservationActualMealController extends ReservationBaseController
             $users  = $gridService->getRoomUsers($this->MUserGroup, $this->MUserInfo, $roomId);
 
             if ($viewMode === 'individual') {
-                if (!$canViewAll && $isStaffUser) {
-                    $users = array_values(array_filter(
-                        $users,
-                        fn($u) => (int)$u['id'] === $loginUserId || (int)($u['i_user_level'] ?? 0) === 1
-                    ));
-                } else {
-                    $users = array_values(array_filter($users, fn($u) => (int)$u['id'] === $selectedUserId));
-                }
+                // 個人モードは権限にかかわらず選択ユーザーのみ表示する
+                // （非 canViewAll は $selectedUserId がログインユーザーに固定済み。
+                //   部屋内の子供の管理は「部屋」モードで行う）
+                $users = array_values(array_filter($users, fn($u) => (int)$u['id'] === $selectedUserId));
             }
 
             $roomUsers[$roomId] = $users;


### PR DESCRIPTION
Closes #492

## 原因
`ReservationActualMealController::mealCountGrid()` の個人モードのユーザー絞り込みに、`!$canViewAll && $isStaffUser`（一般職員・ブロック長が該当）のとき「自分＋子供(level=1)全員」を残す特別分岐があり、個人タブなのに所属部屋の子供の行（テスト用子供アカウント・大橋和幸 等）と部屋情報が表示されていた。#321 当時の一般職員対応の名残で、現在は職員・ブロック長とも「部屋」モードが使えるため不要。

## 修正内容
特別分岐を削除し、個人モードは権限にかかわらず**選択ユーザーのみ**（非 canViewAll はログインユーザー本人に固定済み）を表示するフィルタに統一。

## 動作確認（ローカル Docker で実施）
- ブロック長（部屋1・2所属）・個人モード: 修正前 3 行（本人＋子供2名） → **修正後 本人のみ 1 行**
- ブロック長・部屋モード: 部屋全員が表示され、子供の管理は従来どおり可能（回帰なし）
- 子供アカウント・個人モード: 本人のみ 1 行（回帰なし）
- `vendor/bin/phpunit` 全 529 テスト・1126 アサーション通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 個人モードで表示されるユーザーが、常に選択中のユーザーに限定されるようになりました。
  * 権限やユーザー種別によって表示対象が広がることがなくなり、表示結果がより一貫します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->