### PR TITLE
fix: #494 ブロック長に所属全部屋を表示するようgetRoomsForUserを拡張

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/ReservationActualMealController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ReservationActualMealController.php
@@ -41,11 +41,12 @@ class ReservationActualMealController extends ReservationBaseController
 
         $userId  = (int)$authUser->get('i_id_user');
         $isAdmin = UserRole::isAdmin((int)($authUser->get('i_admin') ?? 0));
+        $isBlockLeader = UserRole::isBlockLeader((int)($authUser->get('i_admin') ?? 0));
         $isOfficeUser = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, $userId);
         $canViewAllRooms = $isAdmin || $isOfficeUser;
 
         $userRoomIds    = $this->calendarService->getUserRoomIds($this->MUserGroup, $userId);
-        $rooms          = $this->calendarService->getRoomsForUser($this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser);
+        $rooms          = $this->calendarService->getRoomsForUser($this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser, $isBlockLeader);
 
         $selectedRoomId = $this->request->getQuery('room_id')
             ? (int)$this->request->getQuery('room_id')
@@ -413,7 +414,8 @@ class ReservationActualMealController extends ReservationBaseController
             $this->MRoomInfo,
             $userRoomIds,
             $canViewAll,
-            $isOfficeUser
+            $isOfficeUser,
+            $isBlockLeader
         );
 
         if (!$isAdmin && ($viewMode === 'room' || $viewMode === 'all')) {

--- a/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/TReservationInfoController.php
@@ -84,9 +84,10 @@ class TReservationInfoController extends ReservationBaseController
         $userRoomId  = $this->calendarService->getPrimaryRoomId($userRoomIds);
 
         $isAdmin       = UserRole::isAdmin((int)($user->i_admin ?? 0));
+        $isBlockLeader = UserRole::isBlockLeader((int)($user->i_admin ?? 0));
         $isOfficeUser  = $this->calendarService->isOfficeUser($this->MUserGroup, $this->MRoomInfo, (int)$userId);
         $canViewAllRooms = $isAdmin || $isOfficeUser;
-        $rooms         = $this->calendarService->getRoomsForUser($this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser);
+        $rooms         = $this->calendarService->getRoomsForUser($this->MRoomInfo, $userRoomIds, $isAdmin, $isOfficeUser, $isBlockLeader);
 
         $calRoomIdQuery = $this->request->getQuery('cal_room_id');
         $calRoomId = null;

--- a/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationCalendarService.php
@@ -56,7 +56,7 @@ class ReservationCalendarService
             ->count() > 0;
     }
 
-    public function getRoomsForUser(Table $roomTable, array $userRoomIds, bool $isAdmin, bool $isOfficeUser = false): array
+    public function getRoomsForUser(Table $roomTable, array $userRoomIds, bool $isAdmin, bool $isOfficeUser = false, bool $isBlockLeader = false): array
     {
         if ($isAdmin) {
             $roomOrder = ['i_id_room' => 'ASC'];
@@ -99,6 +99,24 @@ class ReservationCalendarService
                     'c_room_name LIKE' => '%事務所%',
                 ])
                 ->orderBy(['c_room_name' => 'ASC', 'i_id_room' => 'ASC'])
+                ->toArray();
+        }
+
+        // ブロック長は複数部屋に所属しうるため、所属している全部屋を返す
+        if ($isBlockLeader) {
+            if (empty($userRoomIds)) {
+                return [];
+            }
+
+            return $roomTable->find('list', [
+                'keyField'   => 'i_id_room',
+                'valueField' => 'c_room_name',
+            ])
+                ->where([
+                    'i_id_room IN' => $userRoomIds,
+                    'i_del_flg'    => 0,
+                ])
+                ->orderBy(['i_disp_no' => 'ASC', 'i_id_room' => 'ASC'])
                 ->toArray();
         }
 

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCalendarServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Test\TestCase\Service;
 
 use App\Service\ReservationCalendarService;
+use Cake\Datasource\ConnectionManager;
 use Cake\I18n\Date;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -174,5 +175,49 @@ class ReservationCalendarServiceTest extends TestCase
         $result = $this->service->getRoomsForUser($roomTable, [], isAdmin: false);
 
         $this->assertSame([], $result);
+    }
+
+    /** 複数部屋所属のブロック長には所属している全部屋を返す */
+    public function testGetRoomsForUser_blockLeaderReturnsAllBelongingRooms(): void
+    {
+        $this->insertRoom(2, '第二の部屋', 0);
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsForUser($roomTable, [1, 2], isAdmin: false, isOfficeUser: false, isBlockLeader: true);
+
+        $this->assertSame([1, 2], array_keys($result));
+    }
+
+    /** ブロック長でも削除済みの部屋は返さない */
+    public function testGetRoomsForUser_blockLeaderExcludesDeletedRooms(): void
+    {
+        $this->insertRoom(3, '削除済みの部屋', 1);
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsForUser($roomTable, [1, 3], isAdmin: false, isOfficeUser: false, isBlockLeader: true);
+
+        $this->assertSame([1], array_keys($result));
+    }
+
+    /** ブロック長以外の一般ユーザーは従来どおり primary room のみ */
+    public function testGetRoomsForUser_regularUserReturnsPrimaryRoomOnly(): void
+    {
+        $this->insertRoom(2, '第二の部屋', 0);
+        $roomTable = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $result = $this->service->getRoomsForUser($roomTable, [1, 2], isAdmin: false);
+
+        $this->assertSame([1], array_keys($result));
+    }
+
+    private function insertRoom(int $roomId, string $roomName, int $delFlg): void
+    {
+        ConnectionManager::get('test')->insert('m_room_info', [
+            'i_id_room'   => $roomId,
+            'c_room_name' => $roomName,
+            'i_disp_no'   => $roomId,
+            'i_enable'    => 1,
+            'i_del_flg'   => $delFlg,
+        ]);
     }
 }


### PR DESCRIPTION
Closes #494

## 原因
共通処理 `ReservationCalendarService::getRoomsForUser()` は、管理者（全部屋）・事務所ユーザー（事務所部屋）以外には `getPrimaryRoomId()`＝所属部屋配列の**先頭1件のみ**を返す設計だった。「一般ユーザーは1部屋所属」の前提のため、複数部屋に所属するブロック長はエクセル食数予約・予約カレンダー・実食確認管理のいずれでも1部屋しか表示されなかった。

## 修正内容
- `getRoomsForUser()` に `isBlockLeader` 引数を追加し、ブロック長には所属している全部屋（削除済み `i_del_flg=1` を除く、`i_disp_no` 順）を返す分岐を追加
- 呼び出し元3箇所（`mealCountGrid` / `actualMealManagement` / `TReservationInfoController::index`）で `UserRole::isBlockLeader()` を渡すよう変更
- 一般ユーザー（子供等）は従来どおり primary room のみで挙動変更なし

## テスト
`ReservationCalendarServiceTest` に3件追加（全532テスト・1129アサーション通過）:
- ブロック長は所属全部屋を返す
- ブロック長でも削除済み部屋は除外する
- 一般ユーザーは従来どおり primary room のみ

## 動作確認（ローカル Docker・2部屋所属のブロック長で実測）
- エクセル食数予約 個人モード: 修正前は部屋1のみ → **修正後は部屋1・2両方の行が表示**
- 部屋モード: 部屋切替ボタンに両部屋（ナザレの部屋・シオンの部屋）が表示され、部屋2への切替・表示も正常

## 備考
個人モードに部屋内の子供が表示される件は別PR #493（#492）で対応済み。両方マージされると、ブロック長の個人モードは「本人の行 × 所属部屋数」の表示になる。