### PR TITLE
fix: 承認画面の戻るボタンの表示崩れを修正

### DIFF
--- a/src_web/kamaho-shokusu/webroot/css/pages/approval_admin_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/approval_admin_index.css
@@ -183,10 +183,16 @@ body {
 .meal-chip.skip { background: #f1f5f9; color: #475569; }
 
 .mui-btn {
+    /* a タグはボタンと違い自動で垂直中央揃えされないため inline-flex で中央寄せする */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     min-height: 38px;
     border-radius: 12px;
     padding: 0 16px;
     font-weight: 700;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .badge-status { font-size: .75rem; padding: .3em .6em; border-radius: .4rem; }

--- a/src_web/kamaho-shokusu/webroot/css/pages/approval_block_leader_index.css
+++ b/src_web/kamaho-shokusu/webroot/css/pages/approval_block_leader_index.css
@@ -211,11 +211,17 @@ body {
 }
 
 .mui-btn {
+    /* a タグはボタンと違い自動で垂直中央揃えされないため inline-flex で中央寄せする */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     min-height: 38px;
     border-radius: 12px;
     padding: 0 16px;
     font-weight: 700;
     letter-spacing: .01em;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .badge-status { font-size: .75rem; padding: .3em .6em; border-radius: .4rem; }


### PR DESCRIPTION
## 現象
承認管理画面（管理者・ブロック長）ヘッダー右上の「戻る」ボタンの表示が崩れる。

## 原因
`.mui-btn` が `padding: 0 16px`（上下パディング0）＋ `min-height: 38px` の指定で、`<button>` 要素は中身が自動で垂直中央揃えされるが、「戻る」だけは **`<a>` タグ**のためテキストがボタン上端に張り付いて崩れて見える。また `.page-head` が flex レイアウトのため、タイトル・サブタイトルが長い場合にボタンが押し潰される余地もあった。

## 修正内容
`.mui-btn`（approval_admin_index.css / approval_block_leader_index.css の両方）に以下を追加:
- `display: inline-flex; align-items: center; justify-content: center;` — a タグでも垂直中央揃え
- `white-space: nowrap; flex-shrink: 0;` — flex 内での押し潰し・折返し防止

同クラスを使う他のボタン（承認・差し戻し等の `<button>`）は元々中央揃えのため見た目への影響なし。

## 動作確認
ローカル Docker で管理者ログインし、承認管理画面が正常表示されること・配信 CSS に修正が反映されていることを確認。