### PR TITLE
feat: #500 AIお問い合わせの質問・回答本文を監査ログに記録する

### DIFF
--- a/src_web/kamaho-shokusu/src/Controller/AiAssistantController.php
+++ b/src_web/kamaho-shokusu/src/Controller/AiAssistantController.php
@@ -25,6 +25,9 @@ class AiAssistantController extends AppController
     private const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
     private const HTTP_REFERER        = 'https://github.com/kamaho-source/shokusuu1';
     private const MESSAGE_LIMIT       = 20;
+    /** 監査ログに保存する質問・回答の最大文字数（c_detail の肥大化防止） */
+    private const LOG_QUESTION_MAX    = 2000;
+    private const LOG_ANSWER_MAX      = 4000;
 
     public function __construct(
         private readonly SystemPromptProviderInterface $systemPromptProvider,
@@ -68,16 +71,51 @@ class AiAssistantController extends AppController
         $prompt = $this->buildPrompt($question, $context);
         $role   = $this->resolveAiUserRole();
 
+        $identity  = $this->request->getAttribute('identity');
+        $actorName = (string)($identity?->get('c_user_name') ?? 'unknown');
+        $actorId   = (int)($identity?->get('i_id_user') ?? 0);
+        $ipAddress = $this->request->clientIp();
+
         try {
             $answer = $this->callOpenRouter([
                 ['role' => 'system', 'content' => $this->systemPromptProvider->get($role)],
                 ['role' => 'user',   'content' => $prompt],
             ], $apiKey);
 
+            AuditLogService::record(
+                'system',
+                'ai_assistant_ask',
+                $actorName,
+                $actorId,
+                null,
+                null,
+                [
+                    'question' => mb_substr((string)$question, 0, self::LOG_QUESTION_MAX),
+                    'answer'   => mb_substr((string)$answer, 0, self::LOG_ANSWER_MAX),
+                    'role'     => $role,
+                ],
+                $ipAddress
+            );
+
             return $this->response->withType('application/json')
                 ->withStringBody(json_encode(['ok' => true, 'answer' => $answer]));
         } catch (\Exception $e) {
             Log::error('AI Assistant error: ' . $e->getMessage());
+            AuditLogService::record(
+                'system',
+                'ai_assistant_ask',
+                $actorName,
+                $actorId,
+                null,
+                null,
+                [
+                    'question' => mb_substr((string)$question, 0, self::LOG_QUESTION_MAX),
+                    'error'    => mb_substr($e->getMessage(), 0, 500),
+                    'role'     => $role,
+                ],
+                $ipAddress,
+                0
+            );
             throw new InternalErrorException('通信エラーが発生しました。');
         }
     }
@@ -162,11 +200,14 @@ class AiAssistantController extends AppController
             null,
             null,
             [
+                'question'        => mb_substr($lastQuestion, 0, self::LOG_QUESTION_MAX),
+                'answer'          => mb_substr($fullResponse, 0, self::LOG_ANSWER_MAX),
                 'question_length' => mb_strlen($lastQuestion),
                 'response_length' => mb_strlen($fullResponse),
                 'role'            => $role,
             ],
-            $ipAddress
+            $ipAddress,
+            $success ? 1 : 0
         );
 
         exit(0);


### PR DESCRIPTION
Closes #500

## 背景
#479 マージ後の `askStream()` は監査ログに**文字数のみ**（question_length / response_length）を記録しており、「誰が何を質問しどう回答されたか」の記録が残らなかった。また非ストリーミングの `ask()` には記録自体がなかった。

## 変更内容
- `ask()`: 成功時に質問・回答本文（切り詰めあり）・ロールを記録、失敗時は質問＋エラー概要を `i_result=0` で記録
- `askStream()`: 既存の文字数記録に加えて質問・回答本文を記録し、ストリーミング失敗時は `i_result=0` を渡すよう修正（従来は失敗でも 1 だった）
- 切り詰め上限は定数化（質問 2,000 字 / 回答 4,000 字、`c_detail` TEXT の肥大化防止）

カテゴリ・アクション名は既存の `system` / `ai_assistant_ask` を維持（機能利用状況サマリーのラベル「AI問い合わせ」で集計済みのため、過去データとの連続性を優先）。

## 動作確認（ローカル Docker）
- 管理者で `/AiAssistant/ask` に質問を POST → 200 応答
- `t_audit_log` に `{"question":"...","answer":"...","role":"admin"}` を含む行が `i_result=1` で記録されることを確認
- 全 532 テスト・1129 アサーション通過