### PR TITLE
fix: ステージングデプロイのcomposer installにキャッシュ指定とリトライを追加

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -205,15 +205,25 @@ jobs:
             docker exec stg_web php -r "if (function_exists('opcache_reset')) { opcache_reset(); echo 'OPcache cleared'; } else { echo 'OPcache not enabled'; }" || true
 
             # ── Composer install (composer.lock が変わった時のみ実行) ─────────
+            # コンテナ内の /root/.composer が書き込み不可でキャッシュなし実行になり、
+            # アーカイブ展開が一過性に失敗した実績があるため（2026-07-05 の laminas-diactoros）、
+            # キャッシュ先を /tmp に明示し、失敗時は 1 回だけリトライする。
             LOCK_FILE="${DEPLOY_PATH}/src_web/kamaho-shokusu/composer.lock"
             HASH_CACHE="/tmp/shokusuu1_composer_lock_hash"
             CURR_HASH="$(sha256sum "${LOCK_FILE}" | awk '{print $1}')"
             PREV_HASH="$(cat "${HASH_CACHE}" 2>/dev/null || echo '')"
             if [ "${CURR_HASH}" != "${PREV_HASH}" ]; then
               echo "[Composer] composer.lock changed — running install"
-              docker exec stg_web composer install \
-                --no-interaction --optimize-autoloader \
-                --working-dir=/var/www/html/kamaho-shokusu
+              composer_install() {
+                docker exec -e COMPOSER_CACHE_DIR=/tmp/composer-cache stg_web composer install \
+                  --no-interaction --optimize-autoloader \
+                  --working-dir=/var/www/html/kamaho-shokusu
+              }
+              if ! composer_install; then
+                echo "[Composer] install failed — retrying once"
+                sleep 5
+                composer_install
+              fi
               printf '%s' "${CURR_HASH}" > "${HASH_CACHE}"
             else
               echo "[Composer] composer.lock unchanged — skipping install"


### PR DESCRIPTION
## 背景
2026-07-05 のステージングデプロイ（run 28739878263）で、composer install 中に `laminas-diactoros` のアーカイブ展開が一過性に失敗しデプロイが fail した。コンテナ内の `/root/.composer` が書き込み不可のため毎回**キャッシュなしダウンロード**になっており、ネットワーク起因の失敗に弱い状態だった（再実行では成功）。

## 変更内容
`deploy-staging.yml` の composer ステップに以下を追加:
1. `COMPOSER_CACHE_DIR=/tmp/composer-cache` を明示し、キャッシュを有効化（書き込み不可警告の解消＋リトライ時の再ダウンロード回避）
2. install 失敗時に 5 秒待って **1 回だけ自動リトライ**

lock ハッシュによるスキップ判定・ハッシュ保存のタイミング（成功後のみ）は従来どおり。

## 備考
本番側 `deployment.yml` には composer install ステップが存在しないため対象外。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ステージングデプロイ時の依存関係インストールを改善し、失敗時に自動で1回だけ再試行するようになりました。
  * キャッシュの扱いを見直し、前回と同じ状態では不要なインストールを避けやすくなりました。
  * インストール実行時のキャッシュ保存方法を調整し、安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->