### PR TITLE
fix: #522 統計AIがSecurity.saltを取得できず500エラーになる問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/composer.lock
+++ b/src_web/kamaho-shokusu/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c40558af0b18e603909b00ba66a3aa8",
+    "content-hash": "80c872345705fc532cf244a7577e92ee",
     "packages": [
         {
             "name": "cakephp/authentication",

--- a/src_web/kamaho-shokusu/src/Infrastructure/AI/UserTokenizer.php
+++ b/src_web/kamaho-shokusu/src/Infrastructure/AI/UserTokenizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\AI;
 
 use Cake\Core\Configure;
+use Cake\Utility\Security;
 
 /**
  * 利用者IDを外部AIへ渡すための仮名トークンへ変換する。
@@ -23,14 +24,19 @@ final class UserTokenizer
     private readonly string $salt;
 
     /**
-     * @param string|null $salt 省略時は Security.salt を使用する
-     * @throws \RuntimeException Security.salt が未設定または空の場合
+     * @param string|null $salt 省略時はアプリの Security ソルトを使用する
+     * @throws \RuntimeException Security ソルトが未設定または空の場合
      */
     public function __construct(?string $salt = null)
     {
-        $resolved = $salt ?? (string)Configure::read('Security.salt');
+        // CakePHP は bootstrap で Security.salt を Configure::consume() し、
+        // Cake\Utility\Security へ移し替える。そのため実行時に
+        // Configure::read('Security.salt') は空になる。まず Security::getSalt()
+        // を参照し、（bootstrap 前の CLI 等の）フォールバックとして Configure を見る。
+        $resolved = $salt
+            ?? (Security::getSalt() ?: (string)Configure::read('Security.salt'));
         if ($resolved === '') {
-            throw new \RuntimeException('UserTokenizer: Security.salt が設定されていません。');
+            throw new \RuntimeException('UserTokenizer: Security ソルトが設定されていません。');
         }
         $this->salt = $resolved;
     }


### PR DESCRIPTION
Closes #522

## 原因

CakePHP の `config/bootstrap.php` は起動時に `Security::setSalt(Configure::consume('Security.salt'))` を実行する。`Configure::consume()` は値を読むと同時に Configure から**削除**するため、コントローラー実行時には `Configure::read('Security.salt')` が常に空になる。

`UserTokenizer::__construct` が `Configure::read('Security.salt')` を参照していたため、DI で生成される `StatsAiController` / `AiStatsContextService` が必ず `RuntimeException` を投げ、統計AI画面が500エラーになっていた。

ステージング実測:
| 取得方法 | 値の長さ |
|---------|---------|
| `Configure::read('Security.salt')` | 0（空） |
| `Security::getSalt()` | 64 |

## 変更内容

- `UserTokenizer` で `Cake\Utility\Security::getSalt()` を参照するよう変更
- bootstrap を通さない CLI 等のフォールバックとして `Configure::read('Security.salt')` も残す

## 確認

ステージングコンテナ上で `Security::getSalt()` が正しい64文字の salt を返すことを確認済み。