### PR TITLE
fix: main へのPRで develop ブランチも許可する

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Check source branch for PR to main
         if: github.base_ref == 'main'
         run: |
-          if [[ "${{ github.head_ref }}" != release/* ]]; then
-            echo "ERROR: main へのPRは release/* ブランチからのみ許可されています。"
+          if [[ "${{ github.head_ref }}" != release/* ]] && \
+             [[ "${{ github.head_ref }}" != develop ]]; then
+            echo "ERROR: main へのPRは develop または release/* ブランチからのみ許可されています。"
             echo "現在のブランチ: ${{ github.head_ref }}"
             exit 1
           fi


### PR DESCRIPTION
## 背景

リリースPR #518（`develop → main`）の `branch-check` が失敗している。
原因は `branch-check.yml` が「main への PR は `release/*` のみ許可」としているため。

一方 CLAUDE.md のブランチ戦略では **「main ← 本番リリース用（develop からのみマージ）」** と定めており、
ワークフローと文書化された方針が矛盾していた。

## 変更内容

- `.github/workflows/branch-check.yml`
  - main への PR で `release/*` に加えて `develop` ブランチも許可する
  - これにより CLAUDE.md の方針どおり `develop → main` のリリースPRが通るようになる

## 反映後の流れ

このPRを develop にマージすると、PR #518（develop→main）の `branch-check` が再実行され通過する。