### PR TITLE
docs: 本番リリースフローを release/* → main に明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,18 +123,28 @@ vendor/bin/phpunit tests/TestCase/Domain/   # 層ごと
 ## 9. ブランチ戦略
 
 ```
-main     ← 本番リリース用（develop からのみマージ）
-develop  ← 統合ブランチ（ブランチの起点・PRのベース）
+main     ← 本番リリース用（release/* からのみマージ）
+release/ ← リリース準備用（develop から作成し main へマージ。マージ後 main→develop を同期）
+develop  ← 統合ブランチ（feature/・fix/ の起点・PRのベース）
 feature/ ← 機能開発
 fix/     ← バグ修正
-hotfix/  ← 緊急本番修正
+hotfix/  ← 緊急本番修正（main から作成し main・develop の両方へ反映）
 ```
 
-**ブランチは必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
+**通常の開発ブランチ（feature/・fix/）は必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
 
 ```bash
 git checkout -b feature/xxx develop
 gh pr create --base develop --title "feat: 機能名" --body "..."
+```
+
+**本番リリースは `release/*` ブランチを介して行うこと。develop から直接 main へはマージしない**（`branch-check` が `release/*` 以外の main 向けPRを弾く）。
+
+```bash
+# リリース時: develop から release ブランチを作成し main へPR
+git checkout -b release/2026-07-11 develop
+gh pr create --base main --title "release: 2026-07-11" --body "..."
+# main へマージ後、release で入れた修正を develop へ戻す（main → develop 同期）
 ```
 
 コミットメッセージは Conventional Commits に従う（`feat:` / `fix:` / `refactor:` / `test:` / `docs:`）。


### PR DESCRIPTION
## 概要

本番リリースフローを `release/* → main` に統一し、CLAUDE.md へ明文化する。

## 背景

- `branch-check.yml` は main へのPRを **`release/*` ブランチのみ許可**する設計
- 一方 CLAUDE.md は「main ← develop からのみマージ」と記載しており、ワークフローと矛盾していた
- 本番稼働システムのため、リリース内容を凍結できる `release/*` 運用を正式採用する

## 変更内容

- `CLAUDE.md` セクション9「ブランチ戦略」を更新
  - `main ← release/* からのみマージ` に変更
  - `release/` ブランチ（develop から作成 → main へマージ → main→develop 同期）を追記
  - `hotfix/` は main から作成し main・develop 双方へ反映する旨を明記
  - develop から直接 main へマージしない運用を明記

## 補足

- `branch-check.yml` は既存のまま（`release/*` のみ許可）で変更なし
- 直近のリリース（PR #518）は既に develop の内容が main へ反映済み。今後のリリースから本フローを適用する