### PR TITLE
fix: カレンダークリック登録で「利用可能な部屋がありません」が誤表示される問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
@@ -144,7 +144,10 @@ $JS_MY_DETAILS       = json_encode($myReservationDetails, $jsonFlags);
 $JS_RESERVED_DATES   = json_encode($js_reservedDates, $jsonFlags);
 $JS_EXISTING_EVENTS  = json_encode($events, $jsonFlags);
 $JS_TODAY            = json_encode($today, $jsonFlags);
+// 既存予約に登場する部屋名（カレンダー上の予約部屋ラベル表示用）
 $JS_ROOM_NAMES       = json_encode($reservationRoomNames, $jsonFlags);
+// このユーザーが新規予約できる部屋名（カレンダークリック時の部屋選択ピッカー用）
+$JS_AVAILABLE_ROOM_NAMES = json_encode($rooms ?? [], $jsonFlags);
 
 // 子供用: トグルURLテンプレートと初期room
 $JS_TOGGLE_BASE      = json_encode($toggleBase ?? '', $jsonFlags);
@@ -173,6 +176,7 @@ $jsConfigVars = compact(
     'JS_CURRENT_ROOM',
     'JS_TOGGLE_BASE',
     'JS_ROOM_NAMES',
+    'JS_AVAILABLE_ROOM_NAMES',
     'csrfToken',
     'serverToday',
     'copyApi',

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
@@ -29,6 +29,7 @@ $pastDateUnavailableMessage = (string)Configure::read(
         },
         myDetails: <?= $JS_MY_DETAILS ?>,
         roomNames: <?= $JS_ROOM_NAMES ?? '{}' ?>,
+        availableRoomNames: <?= $JS_AVAILABLE_ROOM_NAMES ?? '{}' ?>,
         currentRoom: <?= $JS_CURRENT_ROOM ?>,
         toggleBase: <?= $JS_TOGGLE_BASE ?>,
         directRegisterUrl: <?= json_encode($this->Url->build('/TReservationInfo/direct-register'), JSON_UNESCAPED_SLASHES) ?>,

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1111,7 +1111,8 @@ function openModalById(id){
                         var dateStr = info.dateStr;
 
                         // 部屋選択 → 食事選択 → 登録（他の人が予約済みの日も同様に動作）
-                        var roomNames = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         if (Object.keys(roomNames).length === 0) {
                             if (window.pageToast) window.pageToast('利用可能な部屋がありません。', 'warning');
                             return;
@@ -1184,7 +1185,8 @@ function openModalById(id){
 
                     if (newVal) {
                         // 予約ON → 部屋選択ドロップダウンを経由して登録
-                        var roomNames    = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames    = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         var defaultRoomId = (window.__TRESP && window.__TRESP.calRoomId != null)
                             ? window.__TRESP.calRoomId : null;
                         if (Object.keys(roomNames).length === 0) {


### PR DESCRIPTION
## 事象

カレンダーの日付/食数をクリックして予約登録しようとすると、部屋が使えるはずのユーザーでも **「利用可能な部屋がありません。」** と表示され登録できない。

## 原因

部屋選択ピッカー（`dateClick` / `eventClick` の予約ON時）が `window.__TRESP.roomNames` を参照していた。

`roomNames` は controller の `reservationRoomNames` に由来し、これは **ログイン中ユーザー自身の「食べる」予約に登場する部屋のみ**から構築される（`buildMyReservationDetails` は `effective === 1` のときだけ `breakfastRoom` 等をセットする）。

そのため以下のユーザーでは `roomNames` が空になり、部屋が割り当てられていても誤って「利用可能な部屋がありません」と出ていた:
- 表示範囲（前月〜翌2ヶ月）に自分の食べる予約が無いユーザー
- 新規/テスト用アカウント（最初の1件をクリック登録できない鶏卵問題）
- 「食べない」申告しかしていないユーザー

`roomNames` は本来、既存予約がどの部屋かを**表示**するためのデータであり、新規登録の部屋候補には不適切だった。

## 修正

新規登録ピッカーには「そのユーザーが予約できる部屋」= controller の `$rooms`（`getRoomsForUser` の結果）を **`availableRoomNames`** として渡し、ピッカーはこちらを参照するよう変更。既存予約の部屋名 `roomNames` は表示ラベル用途としてそのまま維持。

- `templates/TReservationInfo/index.php`: `$JS_AVAILABLE_ROOM_NAMES = json_encode($rooms, ...)` を追加し `$jsConfigVars` に含める
- `templates/element/TReservationInfo/js_config.php`: `availableRoomNames` を追加
- `webroot/js/pages/treservation_index.js`: `dateClick`・`eventClick`(予約ON) の2箇所で `availableRoomNames` を参照

## 効果

- 管理者/事務所ユーザー: 常に全部屋が候補に出る
- 一般ユーザー/ブロック長: 所属部屋が候補に出る
- 真に部屋が無いユーザーのみ「利用可能な部屋がありません」が出る（正しい挙動）

## 検証

- PHP/JS 構文チェック済み
- ステージングDBで `reservationRoomNames` が「自分の食べる予約の部屋」限定であること、`getRoomsForUser` が管理者=全部屋/一般=所属部屋を返すことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新規予約時に、選択可能な部屋のみを部屋選択画面に表示するようになりました。
  - カレンダーからの新規予約、既存予約からの追加操作のいずれでも、利用可能な部屋を正しく選択できます。
  - 既存予約で表示される部屋情報には影響ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->