### PR TITLE
release: 2026-07-11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,18 +123,28 @@ vendor/bin/phpunit tests/TestCase/Domain/   # 層ごと
 ## 9. ブランチ戦略
 
 ```
-main     ← 本番リリース用（develop からのみマージ）
-develop  ← 統合ブランチ（ブランチの起点・PRのベース）
+main     ← 本番リリース用（release/* からのみマージ）
+release/ ← リリース準備用（develop から作成し main へマージ。マージ後 main→develop を同期）
+develop  ← 統合ブランチ（feature/・fix/ の起点・PRのベース）
 feature/ ← 機能開発
 fix/     ← バグ修正
-hotfix/  ← 緊急本番修正
+hotfix/  ← 緊急本番修正（main から作成し main・develop の両方へ反映）
 ```
 
-**ブランチは必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
+**通常の開発ブランチ（feature/・fix/）は必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
 
 ```bash
 git checkout -b feature/xxx develop
 gh pr create --base develop --title "feat: 機能名" --body "..."
+```
+
+**本番リリースは `release/*` ブランチを介して行うこと。develop から直接 main へはマージしない**（`branch-check` が `release/*` 以外の main 向けPRを弾く）。
+
+```bash
+# リリース時: develop から release ブランチを作成し main へPR
+git checkout -b release/2026-07-11 develop
+gh pr create --base main --title "release: 2026-07-11" --body "..."
+# main へマージ後、release で入れた修正を develop へ戻す（main → develop 同期）
 ```
 
 コミットメッセージは Conventional Commits に従う（`feat:` / `fix:` / `refactor:` / `test:` / `docs:`）。

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
@@ -144,7 +144,10 @@ $JS_MY_DETAILS       = json_encode($myReservationDetails, $jsonFlags);
 $JS_RESERVED_DATES   = json_encode($js_reservedDates, $jsonFlags);
 $JS_EXISTING_EVENTS  = json_encode($events, $jsonFlags);
 $JS_TODAY            = json_encode($today, $jsonFlags);
+// 既存予約に登場する部屋名（カレンダー上の予約部屋ラベル表示用）
 $JS_ROOM_NAMES       = json_encode($reservationRoomNames, $jsonFlags);
+// このユーザーが新規予約できる部屋名（カレンダークリック時の部屋選択ピッカー用）
+$JS_AVAILABLE_ROOM_NAMES = json_encode($rooms ?? [], $jsonFlags);
 
 // 子供用: トグルURLテンプレートと初期room
 $JS_TOGGLE_BASE      = json_encode($toggleBase ?? '', $jsonFlags);
@@ -173,6 +176,7 @@ $jsConfigVars = compact(
     'JS_CURRENT_ROOM',
     'JS_TOGGLE_BASE',
     'JS_ROOM_NAMES',
+    'JS_AVAILABLE_ROOM_NAMES',
     'csrfToken',
     'serverToday',
     'copyApi',

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
@@ -29,6 +29,7 @@ $pastDateUnavailableMessage = (string)Configure::read(
         },
         myDetails: <?= $JS_MY_DETAILS ?>,
         roomNames: <?= $JS_ROOM_NAMES ?? '{}' ?>,
+        availableRoomNames: <?= $JS_AVAILABLE_ROOM_NAMES ?? '{}' ?>,
         currentRoom: <?= $JS_CURRENT_ROOM ?>,
         toggleBase: <?= $JS_TOGGLE_BASE ?>,
         directRegisterUrl: <?= json_encode($this->Url->build('/TReservationInfo/direct-register'), JSON_UNESCAPED_SLASHES) ?>,

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1111,7 +1111,8 @@ function openModalById(id){
                         var dateStr = info.dateStr;
 
                         // 部屋選択 → 食事選択 → 登録（他の人が予約済みの日も同様に動作）
-                        var roomNames = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         if (Object.keys(roomNames).length === 0) {
                             if (window.pageToast) window.pageToast('利用可能な部屋がありません。', 'warning');
                             return;
@@ -1184,7 +1185,8 @@ function openModalById(id){
 
                     if (newVal) {
                         // 予約ON → 部屋選択ドロップダウンを経由して登録
-                        var roomNames    = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames    = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         var defaultRoomId = (window.__TRESP && window.__TRESP.calRoomId != null)
                             ? window.__TRESP.calRoomId : null;
                         if (Object.keys(roomNames).length === 0) {


### PR DESCRIPTION
## リリース概要

develop の内容を本番 main へリリースする（`release/2026-07-11 → main`）。

## 含まれる変更

- **fix (#528)**: カレンダークリック登録で「利用可能な部屋がありません」が誤表示される問題を修正
  - 部屋選択ピッカーを既存予約由来の `roomNames` から、予約可能な部屋 `availableRoomNames`（`getRoomsForUser`）参照に変更
- **docs (#527)**: 本番リリースフローを `release/* → main` に明文化（CLAUDE.md）

## リリース後の作業

- main へマージ後、必要に応じて `main → develop` を同期（本リリースでは develop 起点のため差分なしの見込み）

## 補足

- 本フロー（release/* → main）は今回から正式適用
- `branch-check` は release/* → main を許可（通過見込み）