### PR TITLE
fix: リリースフローを release ブランチ運用に変更（develop → release → main）

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Check source branch for PR to main
         if: github.base_ref == 'main'
         run: |
-          if [[ "${{ github.head_ref }}" != release/* ]]; then
-            echo "ERROR: main へのPRは release/* ブランチからのみ許可されています。"
+          if [[ "${{ github.head_ref }}" != release ]] && \
+             [[ "${{ github.head_ref }}" != release/* ]]; then
+            echo "ERROR: main へのPRは release または release/* ブランチからのみ許可されています。"
             echo "現在のブランチ: ${{ github.head_ref }}"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,8 @@ vendor/bin/phpunit tests/TestCase/Domain/   # 層ごと
 ## 9. ブランチ戦略
 
 ```
-main     ← 本番リリース用（release/* からのみマージ）
-release/ ← リリース準備用（develop から作成し main へマージ。マージ後 main→develop を同期）
+main     ← 本番リリース用（release からのみマージ）
+release  ← リリース準備用ブランチ（develop → release → main の順に昇格）
 develop  ← 統合ブランチ（feature/・fix/ の起点・PRのベース）
 feature/ ← 機能開発
 fix/     ← バグ修正
@@ -138,13 +138,14 @@ git checkout -b feature/xxx develop
 gh pr create --base develop --title "feat: 機能名" --body "..."
 ```
 
-**本番リリースは `release/*` ブランチを介して行うこと。develop から直接 main へはマージしない**（`branch-check` が `release/*` 以外の main 向けPRを弾く）。
+**本番リリースは `release` ブランチを介して行うこと（develop → release → main）。develop から直接 main へはマージしない**（`branch-check` が `release`・`release/*` 以外の main 向けPRを弾く）。
 
 ```bash
-# リリース時: develop から release ブランチを作成し main へPR
-git checkout -b release/2026-07-11 develop
-gh pr create --base main --title "release: 2026-07-11" --body "..."
-# main へマージ後、release で入れた修正を develop へ戻す（main → develop 同期）
+# ① develop の内容を release へ昇格
+gh pr create --base release --head develop --title "release: promote develop" --body "..."
+# ② release を本番 main へ昇格
+gh pr create --base main --head release --title "release: YYYY-MM-DD" --body "..."
+# main へマージ後、必要に応じて main → develop を同期
 ```
 
 コミットメッセージは Conventional Commits に従う（`feat:` / `fix:` / `refactor:` / `test:` / `docs:`）。


### PR DESCRIPTION
## 概要

リリース運用を `release/*`（日付付き）ではなく、単一の `release` ブランチ（`develop → release → main`）に変更する。

## 変更内容

- `.github/workflows/branch-check.yml`
  - main への PR で bare `release` ブランチも許可（従来の `release/*` に加える）
- `CLAUDE.md`
  - ブランチ戦略を `release` ブランチ運用に更新（develop → release → main の2段昇格）

## 背景

`develop → release` のPRで内容を昇格し、`release → main` で本番反映する運用にするため。
branch-check が `release`（スラッシュ無し）を弾いていたので許可する。