### PR TITLE
release: 2026-07-11 本番リリース

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Check source branch for PR to main
         if: github.base_ref == 'main'
         run: |
-          if [[ "${{ github.head_ref }}" != release/* ]]; then
-            echo "ERROR: main へのPRは release/* ブランチからのみ許可されています。"
+          if [[ "${{ github.head_ref }}" != release ]] && \
+             [[ "${{ github.head_ref }}" != release/* ]]; then
+            echo "ERROR: main へのPRは release または release/* ブランチからのみ許可されています。"
             echo "現在のブランチ: ${{ github.head_ref }}"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,8 @@ vendor/bin/phpunit tests/TestCase/Domain/   # 層ごと
 ## 9. ブランチ戦略
 
 ```
-main     ← 本番リリース用（release/* からのみマージ）
-release/ ← リリース準備用（develop から作成し main へマージ。マージ後 main→develop を同期）
+main     ← 本番リリース用（release からのみマージ）
+release  ← リリース準備用ブランチ（develop → release → main の順に昇格）
 develop  ← 統合ブランチ（feature/・fix/ の起点・PRのベース）
 feature/ ← 機能開発
 fix/     ← バグ修正
@@ -138,13 +138,14 @@ git checkout -b feature/xxx develop
 gh pr create --base develop --title "feat: 機能名" --body "..."
 ```
 
-**本番リリースは `release/*` ブランチを介して行うこと。develop から直接 main へはマージしない**（`branch-check` が `release/*` 以外の main 向けPRを弾く）。
+**本番リリースは `release` ブランチを介して行うこと（develop → release → main）。develop から直接 main へはマージしない**（`branch-check` が `release`・`release/*` 以外の main 向けPRを弾く）。
 
 ```bash
-# リリース時: develop から release ブランチを作成し main へPR
-git checkout -b release/2026-07-11 develop
-gh pr create --base main --title "release: 2026-07-11" --body "..."
-# main へマージ後、release で入れた修正を develop へ戻す（main → develop 同期）
+# ① develop の内容を release へ昇格
+gh pr create --base release --head develop --title "release: promote develop" --body "..."
+# ② release を本番 main へ昇格
+gh pr create --base main --head release --title "release: YYYY-MM-DD" --body "..."
+# main へマージ後、必要に応じて main → develop を同期
 ```
 
 コミットメッセージは Conventional Commits に従う（`feat:` / `fix:` / `refactor:` / `test:` / `docs:`）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,18 +123,28 @@ vendor/bin/phpunit tests/TestCase/Domain/   # 層ごと
 ## 9. ブランチ戦略
 
 ```
-main     ← 本番リリース用（develop からのみマージ）
-develop  ← 統合ブランチ（ブランチの起点・PRのベース）
+main     ← 本番リリース用（release/* からのみマージ）
+release/ ← リリース準備用（develop から作成し main へマージ。マージ後 main→develop を同期）
+develop  ← 統合ブランチ（feature/・fix/ の起点・PRのベース）
 feature/ ← 機能開発
 fix/     ← バグ修正
-hotfix/  ← 緊急本番修正
+hotfix/  ← 緊急本番修正（main から作成し main・develop の両方へ反映）
 ```
 
-**ブランチは必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
+**通常の開発ブランチ（feature/・fix/）は必ず `develop` から切ること。PRのベースブランチは必ず `develop` を指定すること。**
 
 ```bash
 git checkout -b feature/xxx develop
 gh pr create --base develop --title "feat: 機能名" --body "..."
+```
+
+**本番リリースは `release/*` ブランチを介して行うこと。develop から直接 main へはマージしない**（`branch-check` が `release/*` 以外の main 向けPRを弾く）。
+
+```bash
+# リリース時: develop から release ブランチを作成し main へPR
+git checkout -b release/2026-07-11 develop
+gh pr create --base main --title "release: 2026-07-11" --body "..."
+# main へマージ後、release で入れた修正を develop へ戻す（main → develop 同期）
 ```
 
 コミットメッセージは Conventional Commits に従う（`feat:` / `fix:` / `refactor:` / `test:` / `docs:`）。

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/index.php
@@ -144,7 +144,10 @@ $JS_MY_DETAILS       = json_encode($myReservationDetails, $jsonFlags);
 $JS_RESERVED_DATES   = json_encode($js_reservedDates, $jsonFlags);
 $JS_EXISTING_EVENTS  = json_encode($events, $jsonFlags);
 $JS_TODAY            = json_encode($today, $jsonFlags);
+// 既存予約に登場する部屋名（カレンダー上の予約部屋ラベル表示用）
 $JS_ROOM_NAMES       = json_encode($reservationRoomNames, $jsonFlags);
+// このユーザーが新規予約できる部屋名（カレンダークリック時の部屋選択ピッカー用）
+$JS_AVAILABLE_ROOM_NAMES = json_encode($rooms ?? [], $jsonFlags);
 
 // 子供用: トグルURLテンプレートと初期room
 $JS_TOGGLE_BASE      = json_encode($toggleBase ?? '', $jsonFlags);
@@ -173,6 +176,7 @@ $jsConfigVars = compact(
     'JS_CURRENT_ROOM',
     'JS_TOGGLE_BASE',
     'JS_ROOM_NAMES',
+    'JS_AVAILABLE_ROOM_NAMES',
     'csrfToken',
     'serverToday',
     'copyApi',

--- a/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
+++ b/src_web/kamaho-shokusu/templates/element/TReservationInfo/js_config.php
@@ -29,6 +29,7 @@ $pastDateUnavailableMessage = (string)Configure::read(
         },
         myDetails: <?= $JS_MY_DETAILS ?>,
         roomNames: <?= $JS_ROOM_NAMES ?? '{}' ?>,
+        availableRoomNames: <?= $JS_AVAILABLE_ROOM_NAMES ?? '{}' ?>,
         currentRoom: <?= $JS_CURRENT_ROOM ?>,
         toggleBase: <?= $JS_TOGGLE_BASE ?>,
         directRegisterUrl: <?= json_encode($this->Url->build('/TReservationInfo/direct-register'), JSON_UNESCAPED_SLASHES) ?>,

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1111,7 +1111,8 @@ function openModalById(id){
                         var dateStr = info.dateStr;
 
                         // 部屋選択 → 食事選択 → 登録（他の人が予約済みの日も同様に動作）
-                        var roomNames = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         if (Object.keys(roomNames).length === 0) {
                             if (window.pageToast) window.pageToast('利用可能な部屋がありません。', 'warning');
                             return;
@@ -1184,7 +1185,8 @@ function openModalById(id){
 
                     if (newVal) {
                         // 予約ON → 部屋選択ドロップダウンを経由して登録
-                        var roomNames    = (window.__TRESP && window.__TRESP.roomNames) || {};
+                        // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
+                        var roomNames    = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
                         var defaultRoomId = (window.__TRESP && window.__TRESP.calRoomId != null)
                             ? window.__TRESP.calRoomId : null;
                         if (Object.keys(roomNames).length === 0) {


### PR DESCRIPTION
## リリース概要

`release` ブランチの内容を本番 main へ反映する（`release → main`）。

## 含まれる主な変更

- **fix (#528)**: カレンダークリック登録で「利用可能な部屋がありません」誤表示を修正
- **docs (#527)**: リリースフローの明文化
- **fix (#530)**: リリースフローを release ブランチ運用（develop → release → main）に変更（branch-check・CLAUDE.md）

## リリース後

- main へマージで本番デプロイ（さくらVPS）が実行される
- 必要に応じて main → develop を同期