### PR TITLE
feat: #539 CI/CDパイプラインを整備する（テスト→デプロイ→Playwright確認）

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,9 +7,10 @@ on:
     types: [completed]
   workflow_dispatch:
 
-# workflow_run 経由の場合は head_branch を、手動実行の場合は ref_name を使う
+# workflow_run 経由の場合は head_branch / head_sha を、手動実行の場合は ref_name / sha を使う
 env:
   DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 concurrency:
   group: deploy-to-staging
@@ -90,8 +91,12 @@ jobs:
     name: Deploy to Staging (stg.kamaho-shokusu.jp)
     runs-on: ubuntu-latest
     needs: [check-dockerfile, build]
-    # build がスキップされた場合（Dockerfile 未変更）でも deploy は必ず実行する
-    if: always() && !failure() && !cancelled()
+    # check-dockerfile 成功かつ build が成功またはスキップ（Dockerfile 未変更）の場合のみ実行
+    if: >-
+      always() &&
+      needs.check-dockerfile.result == 'success' &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+      !cancelled()
     timeout-minutes: 40
     env:
       SLACK_USERNAME: DeployBot
@@ -112,6 +117,7 @@ jobs:
           SLACK_CONTACT_WEBHOOK: ${{ secrets.SLACK_CONTACT_WEBHOOK }}
           REPO_URL:              ${{ secrets.REPO_URL }}
           BRANCH:                ${{ env.DEPLOY_BRANCH }}
+          DEPLOY_SHA:            ${{ env.DEPLOY_SHA }}
           DEPLOY_KEY:            ${{ secrets.STG_SSH_PRIVATE_KEY }}
           GHCR_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER:             ${{ github.actor }}
@@ -120,7 +126,7 @@ jobs:
           username: ubuntu
           key:      ${{ secrets.STG_SSH_PRIVATE_KEY }}
           port:     22
-          envs:     APP_SALT,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,OPENROUTER_API_KEY,RESEND_API_KEY,SLACK_CONTACT_WEBHOOK,REPO_URL,BRANCH,DEPLOY_KEY,GHCR_TOKEN,GHCR_USER
+          envs:     APP_SALT,DB_NAME,DB_USER,DB_PASS,DB_ROOT_PASS,OPENROUTER_API_KEY,RESEND_API_KEY,SLACK_CONTACT_WEBHOOK,REPO_URL,BRANCH,DEPLOY_SHA,DEPLOY_KEY,GHCR_TOKEN,GHCR_USER
           timeout:  60s
           command_timeout: 35m
           script: |
@@ -145,14 +151,19 @@ jobs:
 
             # ── リポジトリ取得 ─────────────────────────────────────────────
             if [ ! -d .git ]; then
-              echo "[INIT] cloning $REPO_URL (branch: $BRANCH)"
-              git clone --branch "$BRANCH" "$REPO_URL" .
+              echo "[INIT] cloning $REPO_URL"
+              git clone "$REPO_URL" .
             else
-              echo "[UPDATE] fetching & resetting to origin/$BRANCH"
+              echo "[UPDATE] fetching from origin"
               git fetch origin --prune
-              git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH" "origin/$BRANCH"
-              git reset --hard "origin/$BRANCH"
             fi
+
+            # PHPUnit がテストした正確な SHA をチェックアウト（ブランチ最新とのズレを防ぐ）
+            if ! git cat-file -e "${DEPLOY_SHA}" 2>/dev/null; then
+              echo "[ERROR] Deploy SHA ${DEPLOY_SHA} not found. The commit may not be pushed yet." >&2
+              exit 1
+            fi
+            git checkout "$DEPLOY_SHA"
 
             # ── .env 生成 (アプリ用) ────────────────────────────────────────
             printf 'OPENROUTER_API_KEY=%s\nSLACK_CONTACT_WEBHOOK=%s\n' \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,10 +1,15 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches:
-      - 'develop'
+  workflow_run:
+    workflows: ["PHPUnit"]
+    branches: [develop]
+    types: [completed]
   workflow_dispatch:
+
+# workflow_run 経由の場合は head_branch を、手動実行の場合は ref_name を使う
+env:
+  DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
 
 concurrency:
   group: deploy-to-staging
@@ -19,12 +24,15 @@ jobs:
   check-dockerfile:
     name: Check if Dockerfile changed
     runs-on: ubuntu-latest
+    # workflow_run 経由の場合は PHPUnit が成功した場合のみ実行、手動は常に実行
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       changed: ${{ steps.filter.outputs.dockerfile }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
 
       - name: Check Dockerfile diff
@@ -103,7 +111,7 @@ jobs:
           RESEND_API_KEY:        ${{ secrets.RESEND_API_KEY }}
           SLACK_CONTACT_WEBHOOK: ${{ secrets.SLACK_CONTACT_WEBHOOK }}
           REPO_URL:              ${{ secrets.REPO_URL }}
-          BRANCH:                ${{ github.ref_name }}
+          BRANCH:                ${{ env.DEPLOY_BRANCH }}
           DEPLOY_KEY:            ${{ secrets.STG_SSH_PRIVATE_KEY }}
           GHCR_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER:             ${{ github.actor }}
@@ -288,18 +296,76 @@ jobs:
 
             echo "✅ Staging deployed: $(git rev-parse --short HEAD) @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-      - name: Slack Notification on Success
-        uses: rtCamp/action-slack-notify@v2
-        if: ${{ success() }}
-        env:
-          SLACK_TITLE: Staging Deploy / Success
-          SLACK_COLOR: good
-          SLACK_MESSAGE: "ステージングへのデプロイ完了🚀 branch: ${{ github.ref_name }}"
-
-      - name: Slack Notification on Failure
+      - name: Slack Notification on Deploy Failure
         uses: rtCamp/action-slack-notify@v2
         if: ${{ failure() }}
         env:
           SLACK_TITLE: Staging Deploy / Failure
           SLACK_COLOR: danger
-          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> ステージングデプロイ失敗しました😢 branch: ${{ github.ref_name }}"
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> ステージングデプロイ失敗しました😢 branch: ${{ env.DEPLOY_BRANCH }}"
+
+  # ── ④ Staging Deploy後にPlaywrightスモークテストを実行 ──────────────────
+  e2e:
+    name: Playwright Smoke Test
+    runs-on: ubuntu-latest
+    needs: deploy
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          E2E_USER: ${{ vars.E2E_USER }}
+          E2E_PASS: ${{ secrets.E2E_PASS }}
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: playwright-report/
+          retention-days: 14
+
+  # ── ⑤ 全ジョブ完了後にSlack通知 ────────────────────────────────────────
+  notify:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [deploy, e2e]
+    if: always() && needs.deploy.result != 'skipped'
+    env:
+      SLACK_USERNAME: DeployBot
+      SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    steps:
+      - name: Slack on Success
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ needs.deploy.result == 'success' && needs.e2e.result == 'success' }}
+        env:
+          SLACK_TITLE: Staging Deploy & Smoke Test / Success
+          SLACK_COLOR: good
+          SLACK_MESSAGE: "ステージングへのデプロイ＆スモークテスト完了🚀 branch: ${{ env.DEPLOY_BRANCH }}"
+
+      - name: Slack on Playwright Failure
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ needs.deploy.result == 'success' && needs.e2e.result == 'failure' }}
+        env:
+          SLACK_TITLE: Playwright Smoke Test / Failure
+          SLACK_COLOR: danger
+          SLACK_MESSAGE: "<@${{ secrets.SLACK_MENTION_USER_ID }}> Playwrightスモークテストが失敗しました😢 branch: ${{ env.DEPLOY_BRANCH }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,8 +12,36 @@ permissions:
   contents: read
 
 jobs:
+  phpunit:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src_web/kamaho-shokusu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, pdo_sqlite
+          coverage: none
+          tools: composer:2
+
+      - name: Validate Composer
+        run: composer validate --no-check-publish
+
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --configuration phpunit.xml.dist tests/TestCase/Policy tests/TestCase/Service --colors=never
+
   deploy:
     name: Deploy to VPS
+    needs: phpunit
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
## 対応Issue

closes #539

## 変更概要

「テスト成功 → デプロイ → デプロイ後確認」の一般的なCI/CDパイプラインへ整備する。

---

## 変更内容

### `deploy-staging.yml`（Staging）

**① PHPUnit成功後のみStagingDeployを実行**

```diff
- on:
-   push:
-     branches: ['develop']
+ on:
+   workflow_run:
+     workflows: ["PHPUnit"]
+     branches: [develop]
+     types: [completed]
```

`workflow_run` で PHPUnit の完了を待つよう変更。`check-dockerfile` ジョブに `if` 条件を追加し、PHPUnit が失敗した場合はDeployが開始されない。

**② StagingDeploy後にPlaywrightスモークテストを自動実行**

`e2e` ジョブを追加し `needs: deploy` で依存。Deployが成功した場合のみ自動でPlaywrightが実行される。

**③④ Playwright成功/失敗でSlack通知を分岐**

`notify` ジョブを追加（`if: always()`）。

- Deploy成功 & Playwright成功 → 「Deploy & Smoke Test 完了🚀」
- Deploy成功 & Playwright失敗 → 「Playwrightスモークテストが失敗しました😢」（Workflow Fail）
- Deploy失敗 → 「ステージングデプロイ失敗しました😢」（既存の通知を維持）

---

### `deployment.yml`（本番）

**⑤ 本番Deploy前にPHPUnitを必ず実行**

`phpunit` ジョブを追加し、`deploy` ジョブに `needs: phpunit` を設定。PHPUnit失敗時は本番デプロイが実行されない。

---

## フロー図

### develop（変更後）

```
developへPush
    │
    ▼
PHPUnit（失敗時はここで停止）← 既存 phpunit.yml
    │
    ▼（workflow_run で受け取る）
check-dockerfile
    │
    ▼
Docker Build（Dockerfile変更時のみ）
    │
    ▼
Staging Deploy
    │
    ▼
Playwright Smoke Test（新規）
    │
    ├── 成功 → Slack「Deploy & Smoke Test 完了」
    └── 失敗 → Workflow Fail + Slack通知
```

### main（変更後）

```
release → main
    │
    ▼
PHPUnit（新規・失敗時はここで停止）
    │
    ▼
本番Deploy
    │
    ▼
Slack通知
```

---

## Branch Protectionについて

Issue #539 の⑥（Branch Protection必須化）はGitHubリポジトリのAdmin設定が必要なため、本PRには含まれない。
PRマージ後に以下のコマンドで設定すること。

```bash
# develop ブランチ
gh api repos/kamaho-source/shokusuu1/branches/develop/protection \
  --method PUT \
  --input - <<'JSON'
{
  "required_status_checks": {"strict": true, "contexts": ["PHPUnit"]},
  "enforce_admins": true,
  "required_pull_request_reviews": {"required_approving_review_count": 1},
  "restrictions": null
}
JSON

# main ブランチ
gh api repos/kamaho-source/shokusuu1/branches/main/protection \
  --method PUT \
  --input - <<'JSON'
{
  "required_status_checks": {"strict": true, "contexts": ["PHPUnit"]},
  "enforce_admins": true,
  "required_pull_request_reviews": {"required_approving_review_count": 1},
  "restrictions": null
}
JSON
```

## テスト確認項目

- [ ] developへのPushでPHPUnit → deploy-staging の順に実行されることを確認
- [ ] PHPUnit失敗時にdeploy-stagingが実行されないことを確認
- [ ] StagingDeployが成功した後にPlaywrightが自動実行されることを確認
- [ ] Playwright成功時にSlackへ「Smoke Test完了」通知が届くことを確認
- [ ] mainへのPushでPHPUnit → deployment の順に実行されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - デプロイ前にPHPUnitテストを実行し、テスト成功時のみデプロイされるようになりました。
  - ステージング環境へのデプロイ条件が整理され、手動実行にも対応しました。
  - デプロイ後にPlaywrightによるスモークテストを自動実行し、結果を確認できるようになりました。
  - デプロイおよびスモークテストの成功・失敗をSlackで個別に通知します。
  - テスト結果やデプロイ状況を確認しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->