### PR TITLE
fix: 一括編集で他ユーザーの既存予約により保存が拒否される問題を修正

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
@@ -264,6 +264,7 @@ class ReservationBulkService
         ];
         $skippedMessages = [];
         $rowsToActivate = [];
+        $rowsToDeactivate = [];
         $dayUsers = [];
         $roomId = 0;
         $users = [];
@@ -534,6 +535,8 @@ class ReservationBulkService
                             }
 
                             // チェックOFF: 既存の有効予約を非活性化（eat_flag=0, i_change_flag=0）
+                            // 後続行の権限拒否時に部分更新が残らないよう、書き込みは
+                            // 走査完了後のトランザクション内でまとめて行う
                             if (!(int)$checked) {
                                 $activeRow = $existingActiveMap[$date][(int)$targetUserId][$mealType] ?? null;
                                 if ($activeRow !== null) {
@@ -543,15 +546,8 @@ class ReservationBulkService
                                             'message' => '他ユーザーの予約を更新する権限がありません。',
                                         ];
                                     }
-                                    $ok = $this->updateReservationRowWithVersion($reservationTable, $activeRow, [
-                                        'eat_flag'       => 0,
-                                        'i_change_flag'  => 0,
-                                        'c_update_user'  => $userName,
-                                        'dt_update'      => DateTime::now('Asia/Tokyo'),
-                                    ]);
-                                    if (!$ok) {
-                                        throw new \RuntimeException('optimistic_conflict');
-                                    }
+                                    $deactivateKey = implode(':', [$date, (int)$targetUserId, $mealType, (int)$activeRow->i_id_room]);
+                                    $rowsToDeactivate[$deactivateKey] = $activeRow;
                                 }
                                 continue;
                             }
@@ -713,10 +709,22 @@ class ReservationBulkService
             ];
         }
 
-        if (!empty($rowsToActivate) || !empty($reservations)) {
+        if (!empty($rowsToDeactivate) || !empty($rowsToActivate) || !empty($reservations)) {
             $connection = $reservationTable->getConnection();
             $connection->begin();
             try {
+                foreach ($rowsToDeactivate as $row) {
+                    $ok = $this->updateReservationRowWithVersion($reservationTable, $row, [
+                        'eat_flag'       => 0,
+                        'i_change_flag'  => 0,
+                        'c_update_user'  => $userName,
+                        'dt_update'      => DateTime::now('Asia/Tokyo'),
+                    ]);
+                    if (!$ok) {
+                        throw new \RuntimeException('optimistic_conflict');
+                    }
+                }
+
                 foreach ($rowsToActivate as $row) {
                     $ok = $this->updateReservationRowWithVersion($reservationTable, $row, [
                         'eat_flag' => 1,

--- a/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationBulkService.php
@@ -94,18 +94,6 @@ class ReservationBulkService
                     'i_id_room' => $roomId,
                 ]);
             }
-            foreach ($userIds as $targetUserId) {
-                $targetUserLevel = $userLevels[$targetUserId] ?? 0;
-                $canEditOther    = $isAdmin || ($isLoginStaff && $targetUserLevel === 1) || $blockLeaderInRoom;
-                if ($targetUserId !== $loginUserId && !$canEditOther) {
-                    $connection->rollback();
-                    return [
-                        'ok'      => false,
-                        'message' => '他ユーザーの予約を更新する権限がありません。',
-                    ];
-                }
-            }
-
             $existingMap = [];
             if (!empty($dates) && !empty($userIds)) {
                 $existingRows = $reservationTable->find()
@@ -149,6 +137,15 @@ class ReservationBulkService
                                 continue;
                             }
                             if ((int)$existing->i_change_flag !== $changeFlag) {
+                                // 画面は部屋内全ユーザーの既存予約を送信するため、
+                                // 権限チェックは値が実際に変わる行に限定する
+                                if (!$this->canEditTargetUser($userId, $loginUserId, $isAdmin, $isLoginStaff, (int)($targetUserLevel ?? 0), $blockLeaderInRoom)) {
+                                    $connection->rollback();
+                                    return [
+                                        'ok'      => false,
+                                        'message' => '他ユーザーの予約を更新する権限がありません。',
+                                    ];
+                                }
                                 $ok = $this->updateReservationRowWithVersion($reservationTable, $existing, [
                                     'i_change_flag' => $changeFlag,
                                     'c_update_user' => $loginName,
@@ -162,6 +159,13 @@ class ReservationBulkService
                         } else {
                             if ($changeFlag === 0) {
                                 continue;
+                            }
+                            if (!$this->canEditTargetUser($userId, $loginUserId, $isAdmin, $isLoginStaff, (int)($targetUserLevel ?? 0), $blockLeaderInRoom)) {
+                                $connection->rollback();
+                                return [
+                                    'ok'      => false,
+                                    'message' => '他ユーザーの予約を更新する権限がありません。',
+                                ];
                             }
                             $newRows[] = [
                                 'i_id_user'          => $userId,
@@ -502,16 +506,6 @@ class ReservationBulkService
                         'i_id_room' => (int)$roomId,
                     ]);
                 }
-                foreach ($userIds as $targetUserId) {
-                    $targetLevel  = $userLevelMapBulk[$targetUserId] ?? 0;
-                    $canEditOther = $isAdmin || ($isLoginStaff && $targetLevel === 1) || $blockLeaderInRoom;
-                    if ($targetUserId !== $userId && !$canEditOther) {
-                        return [
-                            'ok'      => false,
-                            'message' => '他ユーザーの予約を更新する権限がありません。',
-                        ];
-                    }
-                }
             }
 
             if (!empty($dayUsers)) {
@@ -523,6 +517,16 @@ class ReservationBulkService
                         if (!is_array($mealData)) {
                             continue;
                         }
+                        // 画面は部屋内全ユーザーの既存予約を送信するため、
+                        // 権限チェックは実際に書き込みが発生する行に限定する
+                        $canEditTarget = $this->canEditTargetUser(
+                            (int)$targetUserId,
+                            $userId,
+                            $isAdmin,
+                            $isLoginStaff,
+                            (int)($userLevelMapBulk[(int)$targetUserId] ?? 0),
+                            $blockLeaderInRoom
+                        );
                         foreach ($mealData as $mealType => $checked) {
                             $mealType = (int)$mealType;
                             if (!in_array($mealType, [1, 2, 3, 4], true)) {
@@ -533,6 +537,12 @@ class ReservationBulkService
                             if (!(int)$checked) {
                                 $activeRow = $existingActiveMap[$date][(int)$targetUserId][$mealType] ?? null;
                                 if ($activeRow !== null) {
+                                    if (!$canEditTarget) {
+                                        return [
+                                            'ok'      => false,
+                                            'message' => '他ユーザーの予約を更新する権限がありません。',
+                                        ];
+                                    }
                                     $ok = $this->updateReservationRowWithVersion($reservationTable, $activeRow, [
                                         'eat_flag'       => 0,
                                         'i_change_flag'  => 0,
@@ -559,6 +569,12 @@ class ReservationBulkService
                                     $userNameDisp
                                 );
                                 continue;
+                            }
+                            if (!$canEditTarget) {
+                                return [
+                                    'ok'      => false,
+                                    'message' => '他ユーザーの予約を更新する権限がありません。',
+                                ];
                             }
                             if ($roomRow !== null) {
                                 $activateKey = implode(':', [$date, (int)$targetUserId, $mealType, (int)$roomId]);
@@ -633,22 +649,21 @@ class ReservationBulkService
                         'i_id_room' => (int)$roomId,
                     ]);
                 }
-                foreach ($userIds as $targetUserId) {
-                    $targetLevel  = $userLevelMapBulk[(int)$targetUserId] ?? 0;
-                    $canEditOther = $isAdmin || ($isLoginStaff && $targetLevel === 1) || $blockLeaderInRoom;
-                    if ((int)$targetUserId !== $userId && !$canEditOther) {
-                        return [
-                            'ok'      => false,
-                            'message' => '他ユーザーの予約を更新する権限がありません。',
-                        ];
-                    }
-                }
-
                 foreach ($dates as $date => $checkedDate) {
                     if (!$checkedDate) {
                         continue;
                     }
                     foreach ($users as $targetUserId => $mealData) {
+                        // 画面は部屋内全ユーザーの既存予約を送信するため、
+                        // 権限チェックは実際に書き込みが発生する行に限定する
+                        $canEditTarget = $this->canEditTargetUser(
+                            (int)$targetUserId,
+                            $userId,
+                            $isAdmin,
+                            $isLoginStaff,
+                            (int)($userLevelMapBulk[(int)$targetUserId] ?? 0),
+                            $blockLeaderInRoom
+                        );
                         foreach ($mealTimeDisplayNames as $mealTime => $disp) {
                             if (isset($mealData[$mealTime]) && (int)$mealData[$mealTime] === 1) {
                                 $mealType = (int)$mealTimeRevMap[$mealTime];
@@ -663,6 +678,12 @@ class ReservationBulkService
                                         $userNameDisp
                                     );
                                     continue;
+                                }
+                                if (!$canEditTarget) {
+                                    return [
+                                        'ok'      => false,
+                                        'message' => '他ユーザーの予約を更新する権限がありません。',
+                                    ];
                                 }
                                 if ($roomRow !== null) {
                                     $activateKey = implode(':', [$date, (int)$targetUserId, $mealType, (int)$roomId]);
@@ -782,6 +803,34 @@ class ReservationBulkService
                 : "すべての予約が正常に登録されました。",
             'redirect_url' => './',
         ];
+    }
+
+    /**
+     * ログインユーザーが対象ユーザーの予約を変更できるかを返す。
+     *
+     * 自分自身・管理者・（職員→子供）・対象部屋のブロック長のいずれかであれば変更可。
+     *
+     * @param int  $targetUserId      変更対象ユーザーID
+     * @param int  $loginUserId       ログインユーザーID
+     * @param bool $isAdmin           ログインユーザーが管理者かどうか
+     * @param bool $isLoginStaff      ログインユーザーが職員（i_user_level 0 or 7）かどうか
+     * @param int  $targetUserLevel   対象ユーザーの i_user_level
+     * @param bool $blockLeaderInRoom 対象部屋に所属するブロック長かどうか
+     * @return bool
+     */
+    private function canEditTargetUser(
+        int $targetUserId,
+        int $loginUserId,
+        bool $isAdmin,
+        bool $isLoginStaff,
+        int $targetUserLevel,
+        bool $blockLeaderInRoom
+    ): bool {
+        if ($targetUserId === $loginUserId) {
+            return true;
+        }
+
+        return $isAdmin || ($isLoginStaff && $targetUserLevel === 1) || $blockLeaderInRoom;
     }
 
     private function validateNormalReservationDates(array $dates, bool $enforceNormalRule): string|bool

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_add_form.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_add_form.php
@@ -26,6 +26,7 @@ $canGroup = $canGroup ?? false;
         window.__ROOM_ID = <?= json_encode($selectedRoomId, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__BASE_WEEK = <?= json_encode($baseWeek->format('Y-m-d'), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_USER_ID = <?= json_encode($user?->get('i_id_user') ?? null, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+        window.__LOGIN_USER_LEVEL = <?= json_encode((int)($user?->get('i_user_level') ?? -1), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__IS_ADMIN = <?= json_encode($isAdmin, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__IS_BLOCK_LEADER = <?= json_encode($isBlockLeader ?? false, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_ROOM_IDS = <?= json_encode(array_map('intval', $loginRoomIds ?? []), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;

--- a/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
+++ b/src_web/kamaho-shokusu/templates/TReservationInfo/bulk_change_edit_form.php
@@ -26,6 +26,7 @@ $days = $days ?? [];
         window.__ROOM_ID = <?= json_encode($selectedRoomId, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__BASE_WEEK = <?= json_encode($baseWeek->format('Y-m-d'), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_USER_ID = <?= json_encode($user?->get('i_id_user') ?? null, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+        window.__LOGIN_USER_LEVEL = <?= json_encode((int)($user?->get('i_user_level') ?? -1), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__IS_ADMIN = <?= json_encode($isAdmin, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__IS_BLOCK_LEADER = <?= json_encode($isBlockLeader ?? false, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
         window.__LOGIN_ROOM_IDS = <?= json_encode(array_map('intval', $loginRoomIds ?? []), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
@@ -391,4 +391,71 @@ class ReservationBulkServiceTest extends TestCase
         $this->assertNotNull($row);
         $this->assertSame(1, (int)$row->eat_flag, '権限がないのに予約が取り消されている');
     }
+
+    /**
+     * 週次一括登録: 後続行が権限拒否された場合、先行行の非活性化も保存されない（原子性）
+     */
+    public function testBulkAddPermissionRejectionLeavesNoPartialWrites(): void
+    {
+        // user 3（子供・編集可）と user 1（他の職員・編集不可）の両方に有効予約
+        $this->insertReservation([
+            'i_id_user'          => 3,
+            'd_reservation_date' => '2026-06-13',
+            'i_reservation_type' => 1,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+        $this->insertReservation([
+            'i_id_user'          => 1,
+            'd_reservation_date' => '2026-06-13',
+            'i_reservation_type' => 2,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+
+        // 子供の取り消し（許可）→ 職員の取り消し（拒否）の順で処理される
+        $result = $this->callBulkAdd(
+            ['2026-06-13' => ['3' => ['1' => '0'], '1' => ['2' => '0']]],
+            1,
+            false  // isAdmin = false
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('権限がありません', $result['message']);
+
+        // 拒否時は先行して処理された子供の予約も取り消されていないこと
+        $child = $this->fetchReservation(3, '2026-06-13', 1, 1);
+        $this->assertNotNull($child);
+        $this->assertSame(1, (int)$child->eat_flag, '権限拒否時に先行行だけが非活性化されている');
+    }
+
+    /**
+     * 週次一括登録: 編集可能な行のみの場合、取り消しは正しく保存される
+     */
+    public function testBulkAddDeactivationStillWorksWithinTransaction(): void
+    {
+        $this->insertReservation([
+            'i_id_user'          => 3,
+            'd_reservation_date' => '2026-06-14',
+            'i_reservation_type' => 1,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+
+        $result = $this->callBulkAdd(
+            ['2026-06-14' => ['3' => ['1' => '0']]],
+            1,
+            false  // isAdmin = false（職員→子供は許可）
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+
+        $row = $this->fetchReservation(3, '2026-06-14', 1, 1);
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int)$row->eat_flag, '取り消しが保存されていない');
+        $this->assertSame(0, (int)$row->i_change_flag);
+    }
 }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationBulkServiceTest.php
@@ -257,4 +257,138 @@ class ReservationBulkServiceTest extends TestCase
 
         $this->assertTrue($result['ok'], $result['message'] ?? '');
     }
+
+    /** processBulkChangeEdit を呼び出す共通ヘルパー（ログイン: user 2 = 非管理者職員） */
+    private function callBulkChangeEdit(array $dayUsers, bool $isAdmin = false, int $loginUserId = 2): array
+    {
+        return $this->service->processBulkChangeEdit(
+            $dayUsers,
+            1,
+            'tester',
+            $this->reservationTable,
+            $this->userTable,
+            [],
+            $loginUserId,
+            $isAdmin,
+            0,     // loginUserLevel = 0（職員）
+            false  // isBlockLeader
+        );
+    }
+
+    /**
+     * 直前一括編集: 他ユーザーの「値が変わらない行」がペイロードに含まれていても
+     * 保存が拒否されない（画面が部屋内全ユーザーの既存予約を自動送信するための回帰テスト）
+     */
+    public function testBulkChangeEditIgnoresUnchangedRowsOfOtherUsers(): void
+    {
+        // user 1（別の職員）の既存予約（i_change_flag=1）
+        $this->insertReservation([
+            'i_id_user'          => 1,
+            'd_reservation_date' => '2026-06-10',
+            'i_reservation_type' => 3,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+
+        // user 1 の行は値の変わらない no-op、user 2（自分）の行のみ実変更
+        $result = $this->callBulkChangeEdit([
+            '2026-06-10' => [
+                '1' => ['3' => '1'],
+                '2' => ['1' => '1'],
+            ],
+        ]);
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $this->assertSame(1, $result['created'], '自分の予約が作成されていない');
+        $this->assertSame(0, $result['updated']);
+
+        // user 1 の既存予約は更新されていない
+        $other = $this->fetchReservation(1, '2026-06-10', 3, 1);
+        $this->assertNotNull($other);
+        $this->assertSame(1, (int)$other->i_version, '他ユーザーの予約が更新されている');
+    }
+
+    /**
+     * 直前一括編集: 他の職員ユーザーへの実変更（新規作成）は引き続き拒否される
+     */
+    public function testBulkChangeEditRejectsActualChangeToOtherStaff(): void
+    {
+        $result = $this->callBulkChangeEdit([
+            '2026-06-10' => ['1' => ['1' => '1']],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('権限がありません', $result['message']);
+        $this->assertNull($this->fetchReservation(1, '2026-06-10', 1, 1), '権限のない予約が作成されている');
+    }
+
+    /**
+     * 直前一括編集: 職員は子供（i_user_level=1）の予約を変更できる
+     */
+    public function testBulkChangeEditStaffCanEditChildReservation(): void
+    {
+        $result = $this->callBulkChangeEdit([
+            '2026-06-10' => ['3' => ['1' => '1']],
+        ]);
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $this->assertSame(1, $result['created']);
+    }
+
+    /**
+     * 週次一括登録: 他ユーザーの既存有効予約（＝スキップされる行）がペイロードに
+     * 含まれていても保存が拒否されない（回帰テスト）
+     */
+    public function testBulkAddIgnoresExistingActiveReservationOfOtherUsers(): void
+    {
+        // user 1（別の職員）の既存有効予約
+        $this->insertReservation([
+            'i_id_user'          => 1,
+            'd_reservation_date' => '2026-06-11',
+            'i_reservation_type' => 1,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+
+        // user 1 の行は既存予約ありでスキップ対象、user 3（子供）の行のみ実変更
+        $result = $this->callBulkAdd(
+            ['2026-06-11' => ['1' => ['1' => '1'], '3' => ['2' => '1']]],
+            1,
+            false  // isAdmin = false
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? '');
+        $this->assertStringContainsString('スキップ', $result['message']);
+        $this->assertNotNull($this->fetchReservation(3, '2026-06-11', 2, 1), '子供の予約が作成されていない');
+    }
+
+    /**
+     * 週次一括登録: 他の職員ユーザーの有効予約の取り消し（実変更）は引き続き拒否される
+     */
+    public function testBulkAddRejectsDeactivatingOtherStaffReservation(): void
+    {
+        $this->insertReservation([
+            'i_id_user'          => 1,
+            'd_reservation_date' => '2026-06-12',
+            'i_reservation_type' => 1,
+            'i_id_room'          => 1,
+            'eat_flag'           => 1,
+            'i_change_flag'      => 1,
+        ]);
+
+        $result = $this->callBulkAdd(
+            ['2026-06-12' => ['1' => ['1' => '0']]],
+            1,
+            false  // isAdmin = false
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('権限がありません', $result['message']);
+
+        $row = $this->fetchReservation(1, '2026-06-12', 1, 1);
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int)$row->eat_flag, '権限がないのに予約が取り消されている');
+    }
 }

--- a/src_web/kamaho-shokusu/webroot/js/bulk_add_form.js
+++ b/src_web/kamaho-shokusu/webroot/js/bulk_add_form.js
@@ -290,6 +290,7 @@ document.addEventListener('DOMContentLoaded', () => {
             let checked = 0;
             currentUsers.forEach((u) => {
                 const uid = u.id;
+                if (!canEditUser(roomId, uid)) return;
                 const isLocked = !!(lockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
                 const isOtherRoomLocked = !!(otherRoomLockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
                 if (isLocked || isOtherRoomLocked) return;
@@ -313,30 +314,36 @@ document.addEventListener('DOMContentLoaded', () => {
         return btn?.dataset.disabled === '1';
     }
 
+    // サーバー側 ReservationBulkService::canEditTargetUser と同一の編集可否判定。
+    // 判定外のユーザーは画面上で無効化し、保存時の送信対象からも除外する。
+    function canEditUser(roomId, uid) {
+        const uidNum = Number(uid);
+        if (uidNum === Number(window.__LOGIN_USER_ID)) return true;
+        if (window.__IS_ADMIN) return true;
+        // roomId は select の value 由来で文字列のため、数値化してから所属部屋と照合する
+        const blockLeaderInRoom = !!window.__IS_BLOCK_LEADER
+            && (window.__LOGIN_ROOM_IDS || []).includes(parseInt(roomId, 10));
+        if (blockLeaderInRoom) return true;
+        const isLoginStaff = [0, 7].includes(Number(window.__LOGIN_USER_LEVEL));
+        return isLoginStaff && userLevelsByRoom[roomId]?.[uidNum] === 1;
+    }
+
     function buildMealCell(roomId, uid, type) {
         const isChecked = !!(selectionsByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
         const isLocked = !!(lockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
         const isOtherRoomLocked = !!(otherRoomLockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
         const disabledByDate = isActiveDisabled();
 
-        const isAdminUser = !!(window.__IS_ADMIN);
-        const loginUserId = window.__LOGIN_USER_ID;
-        const isBlockLeader = !!(window.__IS_BLOCK_LEADER);
-        const loginRoomIds = window.__LOGIN_ROOM_IDS || [];
-        // roomId は select の value 由来で文字列のため、数値化してから所属部屋と照合する
-        const blockLeaderInRoom = isBlockLeader && loginRoomIds.includes(parseInt(roomId, 10));
-        const targetLevel = userLevelsByRoom[roomId]?.[uid];
-        const isStaff = targetLevel === 0 || targetLevel === 7;
-        const isOtherStaff = !isAdminUser && !blockLeaderInRoom && isStaff && uid !== loginUserId;
+        const cannotEditOther = !canEditUser(roomId, uid);
 
         // 弁当↔朝昼夜の排他はチェック変更イベントで自動解除するため、ここでは disabled にしない
         let disabledReason = '';
         if (isOtherRoomLocked) disabledReason = '他の部屋で予約されています。';
-        if (!disabledReason && isOtherStaff) disabledReason = '他の職員の予約は操作できません。';
+        if (!disabledReason && cannotEditOther) disabledReason = '他のユーザーの予約は操作できません。';
 
         const id = `cb-${activeDate}-${uid}-${type}`;
         const lockedClass = isLocked ? 'locked' : '';
-        const isDisabled = isLocked || isOtherRoomLocked || disabledByDate || isOtherStaff;
+        const isDisabled = isLocked || isOtherRoomLocked || disabledByDate || cannotEditOther;
         return `
             <label class="d-inline-flex align-items-center justify-content-center">
                 <input class="meal-toggle" type="checkbox" id="${id}" data-uid="${uid}" data-type="${type}"
@@ -628,6 +635,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ensureState(roomId, activeDate);
         currentUsers.forEach((u) => {
             const uid = u.id;
+            if (!canEditUser(roomId, uid)) return;
             const isLocked = !!(lockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
             const isOtherRoomLocked = !!(otherRoomLockedByRoom[roomId]?.[activeDate]?.[uid]?.[type]);
             if (isLocked || isOtherRoomLocked) return;
@@ -751,6 +759,9 @@ document.addEventListener('DOMContentLoaded', () => {
             dateList.forEach((date) => {
                 const users = (roomId && selectionsByRoom[roomId]?.[date]) || {};
                 Object.keys(users).forEach((uid) => {
+                    // 編集権限のないユーザーは送信しない（既存予約の自動反映分が
+                    // サーバー側の権限エラーを誘発するのを防ぐ）
+                    if (!canEditUser(roomId, uid)) return;
                     const meals = users[uid] || {};
                     mealTypes.forEach((type) => {
                         const isChecked = !!meals[type];

--- a/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
+++ b/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
@@ -287,6 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
             let checked = 0;
             currentUsers.forEach((u) => {
                 const uid = u.id;
+                if (!canEditUser(uid)) return;
                 const isLocked = !!(locked[activeDate]?.[uid]?.[type]);
                 const isOtherRoomLocked = !!(otherRoomLocked[activeDate]?.[uid]?.[type]);
                 if (isLocked || isOtherRoomLocked) return;
@@ -303,6 +304,20 @@ document.addEventListener('DOMContentLoaded', () => {
             toggle.checked = (checked === selectable);
             toggle.indeterminate = (checked > 0 && checked < selectable);
         });
+    }
+
+    // サーバー側 ReservationBulkService::canEditTargetUser と同一の編集可否判定。
+    // 判定外のユーザーは画面上で無効化し、保存時の送信対象からも除外する。
+    function canEditUser(uid) {
+        const uidNum = Number(uid);
+        if (uidNum === Number(window.__LOGIN_USER_ID)) return true;
+        if (window.__IS_ADMIN) return true;
+        const currentRoomId = parseInt(roomSelect?.value, 10) || 0;
+        const blockLeaderInRoom = !!window.__IS_BLOCK_LEADER
+            && (window.__LOGIN_ROOM_IDS || []).includes(currentRoomId);
+        if (blockLeaderInRoom) return true;
+        const isLoginStaff = [0, 7].includes(Number(window.__LOGIN_USER_LEVEL));
+        return isLoginStaff && userLevels[uidNum] === 1;
     }
 
     function buildMealCell(uid, type) {
@@ -323,13 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
         );
         const staffMealBlocksBento = (type === 4) && hasMealLocked;
 
-        const loginUserId = window.__LOGIN_USER_ID;
-        const isAdminUser = !!(window.__IS_ADMIN);
-        const isBlockLeader = !!(window.__IS_BLOCK_LEADER);
-        const loginRoomIds = window.__LOGIN_ROOM_IDS || [];
-        const currentRoomId = parseInt(roomSelect?.value) || 0;
-        const blockLeaderInRoom = isBlockLeader && loginRoomIds.includes(currentRoomId);
-        const isOtherStaff = !isAdminUser && !blockLeaderInRoom && isStaff && uid !== loginUserId;
+        const cannotEditOther = !canEditUser(uid);
 
         const id = `cb-${activeDate}-${uid}-${type}`;
         const lockedClass = isLocked ? 'locked' : '';
@@ -339,8 +348,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!disabledReason && disabledByDate) disabledReason = '過去日付のため編集できません。';
         if (!disabledReason && bentoBlocksNoon) disabledReason = 'お弁当が予約済みのためお昼は予約できません。';
         if (!disabledReason && staffMealBlocksBento) disabledReason = '朝・昼・夜が予約済みのためお弁当は予約できません。';
-        if (!disabledReason && isOtherStaff) disabledReason = '他の職員の予約は操作できません。';
-        const isDisabled = isLocked || isOtherRoomLocked || disabledByDate || bentoBlocksNoon || staffMealBlocksBento || isOtherStaff;
+        if (!disabledReason && cannotEditOther) disabledReason = '他のユーザーの予約は操作できません。';
+        const isDisabled = isLocked || isOtherRoomLocked || disabledByDate || bentoBlocksNoon || staffMealBlocksBento || cannotEditOther;
         return `
             <label class="d-inline-flex align-items-center justify-content-center">
                 <input class="meal-toggle" type="checkbox" id="${id}" data-uid="${uid}" data-type="${type}"
@@ -641,6 +650,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ensureState(activeDate);
         currentUsers.forEach((u) => {
             const uid = u.id;
+            if (!canEditUser(uid)) return;
             const isLocked = !!(locked[activeDate]?.[uid]?.[type]);
             const isOtherRoomLocked = !!(otherRoomLocked[activeDate]?.[uid]?.[type]);
             if (isLocked || isOtherRoomLocked) return;
@@ -763,6 +773,9 @@ document.addEventListener('DOMContentLoaded', () => {
             dateList.forEach((date) => {
                 const users = selections[date] || {};
                 Object.keys(users).forEach((uid) => {
+                    // 編集権限のないユーザーは送信しない（既存予約の自動反映分が
+                    // サーバー側の権限エラーを誘発するのを防ぐ）
+                    if (!canEditUser(uid)) return;
                     const meals = users[uid] || {};
                     mealTypes.forEach((type) => {
                         if (otherRoomLocked[date]?.[uid]?.[type]) return;

--- a/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
+++ b/src_web/kamaho-shokusu/webroot/js/bulk_change_edit_form.js
@@ -622,8 +622,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 pageLimit = Number(payload.limit || pageLimit);
                 currentPage = Number(payload.page || currentPage);
                 currentUsers.forEach((u) => {
-                    // i_user_level 未取得時は「子供(1)」扱いにしてロック過多を防ぐ
-                    userLevels[u.id] = (u.i_user_level == null) ? 1 : Number(u.i_user_level);
+                    // i_user_level 未取得時は -1（編集不可・ロックなし）に倒す。
+                    // サーバー側は未取得を職員(0)扱いで拒否するため、子供(1)扱いにすると
+                    // 画面では編集できるのに保存で権限エラーになる不整合が生じる
+                    userLevels[u.id] = (u.i_user_level == null) ? -1 : Number(u.i_user_level);
                 });
                 ensureState(activeDate);
                 if (payload.reservation_snapshot) {


### PR DESCRIPTION
## 背景（ユーザー問い合わせ）

直前一括編集画面（`/TReservationInfo/bulk-change-edit-form`）で、一般ユーザーから「他のユーザの予約を更新する権限がないと警告がでる」という問い合わせがあった。

調査の結果、**自分の予約しか変更していなくても保存全体が拒否される**アプリ側のバグであることを確認（権限設定の問題ではない）。

## 原因

1. 画面 JS（`applyLocks`）が部屋内**全ユーザー**の既存予約を `selections` に「チェック済み」として自動反映する
2. 保存時に `selections` 全体から `day_users` を組み立てるため、触っていない他ユーザーの行がペイロードに混入する
3. サーバー側（`ReservationBulkService`）の権限チェックが、値が変わるかどうかに関係なく**ペイロード内の全ユーザー ID** に対して実行され、1 件でも権限のないユーザーがいるとリクエスト全体を 422 で拒否する

このため、一般ユーザー（非管理者・非ブロック長）は「同室の他職員に既存予約がある日」に保存すると必ず失敗していた。週次一括登録（`bulk-add-form` / `processBulkAdd`）にも同一パターンが存在。

## 修正内容

### サーバー側（`src/Service/ReservationBulkService.php`）
- 事前の一括権限チェックを廃止し、**実際に書き込みが発生する行**（作成・更新・非活性化）に限定して権限チェックする
- 値の変わらない no-op 行は権限不要。権限のないユーザーへの**実変更は引き続き拒否**（fail-closed 維持）
- 判定を `canEditTargetUser()` に集約（自分自身・管理者・職員→子供・対象部屋のブロック長）

### クライアント側（`webroot/js/bulk_change_edit_form.js` / `bulk_add_form.js`）
- サーバーと同一の `canEditUser()` 判定を追加し、編集権限のないユーザーを **送信対象・一括トグル・選択可能数カウント** から除外
- セル無効化判定を `isOtherStaff`（職員のみ）からサーバー権限準拠に変更（level 1 以外の他ユーザーも正しく無効化される）
- テンプレート 2 件に `window.__LOGIN_USER_LEVEL` を追加

## テスト

- 回帰テスト 5 件を `ReservationBulkServiceTest` に追加（no-op 混入時に保存成功／実変更は拒否／職員→子供は許可 等）
- `tests/TestCase/Policy` + `tests/TestCase/Service` 全 400 件パス
- ローカル Docker 環境 + Playwright 実ブラウザで検証:
  - 修正前: 自分の朝のみチェック → 他職員の既存予約が混入し 422「他ユーザーの予約を更新する権限がありません。」
  - 修正後: ペイロードは自分の行のみ → 200 で保存成功、他職員の行は DB 上無変更

## 補足

問い合わせに対する AI チャットボットの回答（「管理者に権限付与を依頼」）は誤案内。回答文にも文字化け（「他אַפּユーザ」等）があり、回答品質は別途確認を推奨。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 一括予約の変更・追加で、編集権限のない対象は画面表示と送信の両方から除外し、変更のない行は影響しません。
  - 権限判定を更新直前に反映し、拒否時は途中反映を防いで安全に失敗します。
  - 職員は許可された子どもの予約を編集できるようになりました。
- **テスト**
  - 一括編集・追加の権限判定、スキップ挙動、原子性を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->