### PR TITLE
fix: ステージングデプロイがサーバー上の生成物と衝突して失敗する問題を修正

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -163,7 +163,11 @@ jobs:
               echo "[ERROR] Deploy SHA ${DEPLOY_SHA} not found. The commit may not be pushed yet." >&2
               exit 1
             fi
-            git checkout "$DEPLOY_SHA"
+            # サーバー上でマイグレーション実行時に再生成される生成物
+            # （config/Migrations/schema-dump-default.lock 等）が残っていると
+            # checkout が中断するため、追跡ファイルのローカル変更は破棄する
+            # （.env などの未追跡ファイルには影響しない）
+            git checkout --force "$DEPLOY_SHA"
 
             # ── .env 生成 (アプリ用) ────────────────────────────────────────
             printf 'OPENROUTER_API_KEY=%s\nSLACK_CONTACT_WEBHOOK=%s\n' \


### PR DESCRIPTION
## 背景

release → main マージ後のステージングデプロイ（deploy-staging.yml / run 29497985230）が以下のエラーで失敗した。

```
error: Your local changes to the following files would be overwritten by checkout:
    src_web/kamaho-shokusu/config/Migrations/schema-dump-default.lock
Please commit your changes or stash them before you switch branches.
```

## 原因

デプロイ先サーバーで `bin/cake migrations migrate` を実行すると `config/Migrations/schema-dump-default.lock`（スキーマダンプ）が再生成され、追跡ファイルのローカル変更として残る。`deploy-staging.yml` は素の `git checkout "$DEPLOY_SHA"` を使っているため、次回デプロイ時にこの変更と衝突して中断する。

（本番用の `deployment.yml` は `git reset --hard` を使用しており同問題は起きない）

## 修正内容

- `git checkout "$DEPLOY_SHA"` → `git checkout --force "$DEPLOY_SHA"` に変更し、サーバー上で再生成された追跡ファイルのローカル変更を破棄してからチェックアウトする
- `.env` や `config/plugins.php` などの未追跡ファイルには影響しない

## 応急対応（実施済み）

- ステージングサーバー上で該当ファイルの変更を破棄（`git checkout -- <file>`）
- 失敗した run 29497985230 を再実行し、デプロイ成功を確認済み