### PR TITLE
feat: Backlog-GitHub Issue双方向連携を追加

### DIFF
--- a/.github/scripts/backlog_client.py
+++ b/.github/scripts/backlog_client.py
@@ -1,0 +1,114 @@
+"""Backlog API共通クライアント"""
+import os
+import sys
+import time
+import urllib.parse
+import urllib.request
+import urllib.error
+import json
+
+
+def load_backlog_env() -> tuple[str, str, str, str]:
+    """API_KEY, SPACE_ID, PROJECT_KEY, DOMAINを返す。"""
+    api_key     = os.environ.get("BACKLOG_API_KEY", "")
+    space_id    = os.environ.get("BACKLOG_SPACE_ID", "")
+    project_key = os.environ.get("BACKLOG_PROJECT_KEY", "")
+    domain      = os.environ.get("BACKLOG_DOMAIN", "backlog.com")
+
+    missing = [k for k, v in {
+        "BACKLOG_API_KEY": api_key,
+        "BACKLOG_SPACE_ID": space_id,
+        "BACKLOG_PROJECT_KEY": project_key,
+    }.items() if not v]
+
+    if missing:
+        print(f"[ERROR] 必須環境変数が未設定です: {', '.join(missing)}")
+        sys.exit(1)
+
+    print(f"Backlog設定: space={space_id}, project={project_key}, domain={domain}")
+    print(f"apiKey configured={'true' if api_key else 'false'}")
+    return api_key, space_id.strip(), project_key.strip(), domain.strip()
+
+
+def resolve_bl_base(space_id: str, domain: str = "backlog.com") -> str:
+    """Backlog APIのベースURLを返す。"""
+    return f"https://{space_id}.{domain}/api/v2"
+
+
+def bl_request(
+    base: str,
+    api_key: str,
+    method: str,
+    path: str,
+    data: dict | None = None,
+    *,
+    fatal: bool = True,
+    max_retries: int = 3,
+):
+    """Backlog APIへリクエストする。再試行付き。"""
+    url = f"{base}{path}"
+    if "?" in url:
+        url += f"&apiKey={api_key}"
+    else:
+        url += f"?apiKey={api_key}"
+
+    # GETパラメータをURLに付与
+    if method == "GET" and data:
+        params = []
+        for k, v in data.items():
+            if isinstance(v, list):
+                for item in v:
+                    params.append((k, str(item)))
+            else:
+                params.append((k, str(v)))
+        url += "&" + urllib.parse.urlencode(params)
+        body = None
+    elif data:
+        body = urllib.parse.urlencode(data).encode("utf-8")
+    else:
+        body = None
+
+    for attempt in range(max_retries):
+        try:
+            req = urllib.request.Request(url, data=body, method=method)
+            if body:
+                req.add_header("Content-Type", "application/x-www-form-urlencoded")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            status = e.code
+            body_txt = e.read().decode("utf-8", errors="replace")
+
+            if status == 401:
+                print("[ERROR] Backlog APIの認証に失敗しました。")
+                print("確認項目:")
+                print("- BACKLOG_API_KEYが正しいか")
+                print("- Secretの前後に空白や改行がないか")
+                print(f"- BACKLOG_SPACE_IDが正しいか")
+                print(f"- BACKLOG_DOMAINが正しいか")
+                if fatal:
+                    sys.exit(1)
+                return None
+
+            if status in (429, 500, 502, 503, 504) and attempt < max_retries - 1:
+                wait = 2 ** attempt
+                print(f"[WARN] HTTP {status} - {wait}秒後に再試行 ({attempt+1}/{max_retries})")
+                time.sleep(wait)
+                continue
+
+            print(f"[ERROR] Backlog API {method} {path} → HTTP {status}: {body_txt[:200]}")
+            if fatal:
+                sys.exit(1)
+            return None
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait = 2 ** attempt
+                print(f"[WARN] リクエスト失敗: {e} - {wait}秒後に再試行")
+                time.sleep(wait)
+                continue
+            print(f"[ERROR] Backlog APIリクエスト失敗: {e}")
+            if fatal:
+                sys.exit(1)
+            return None
+
+    return None

--- a/.github/scripts/backlog_to_github.py
+++ b/.github/scripts/backlog_to_github.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Backlog課題 → GitHub Issue 同期スクリプト
+
+- 15分ごとのスケジュール実行 or 手動実行
+- Backlogで更新された課題をGitHub Issueに反映
+- 重複作成防止: タイトル[KEY]とbodyマーカーで確認
+- 無限ループ防止: GitHub起源課題("GitHub Issue: ...")はスキップ
+"""
+
+import os
+import sys
+import re
+import json
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from sync_utils import get_gh_token, get_gh_repo, gh_request, update_sync_section
+
+GITHUB_ISSUE_URL_PATTERN = r"GitHub Issue: https://github\.com/"
+
+def get_project_id(base: str, api_key: str, project_key: str) -> int:
+    proj = bl_request(base, api_key, "GET", f"/projects/{project_key}")
+    if not proj:
+        print(f"[ERROR] プロジェクト {project_key} が見つかりません")
+        sys.exit(1)
+    print(f"Backlogプロジェクトを取得しました: {project_key} (id={proj['id']})")
+    return proj["id"]
+
+
+def get_updated_issues(base: str, api_key: str, project_id: int, updated_since: str, minutes_back: int) -> list:
+    """ページングしながら更新済み課題を取得する。"""
+    threshold = datetime.now(timezone.utc) - timedelta(minutes=minutes_back)
+    offset = 0
+    count  = 100
+    all_issues = []
+
+    while True:
+        issues = bl_request(base, api_key, "GET", "/issues", {
+            "projectId[]": project_id,
+            "updatedSince": updated_since,
+            "count":  count,
+            "offset": offset,
+            "sort":   "updated",
+            "order":  "desc",
+        })
+        if not issues:
+            break
+
+        for iss in issues:
+            updated_str = iss.get("updated", "")
+            try:
+                # Backlog日時: "2026-07-18T12:34:56Z"
+                updated_dt = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
+                if updated_dt >= threshold:
+                    all_issues.append(iss)
+            except Exception:
+                all_issues.append(iss)
+
+        if len(issues) < count:
+            break
+        offset += count
+
+    return all_issues
+
+
+def find_github_issue(token: str, repo: str, backlog_key: str) -> dict | None:
+    """Backlog課題キーに対応するGitHub Issueを検索する (open+closed)。"""
+    query = f"[{backlog_key}] repo:{repo} in:title is:issue"
+    result = gh_request(token, "GET", f"/search/issues?q={query.replace(' ', '+')}&per_page=5")
+    if result and result.get("items"):
+        for item in result["items"]:
+            title = item.get("title", "")
+            body  = item.get("body", "") or ""
+            if title.startswith(f"[{backlog_key}]") or f"<!-- backlog-key:{backlog_key} -->" in body:
+                return item
+    return None
+
+
+def is_github_origin(description: str) -> bool:
+    """GitHub起源の課題かどうかを判定する（無限ループ防止）。"""
+    return bool(re.search(GITHUB_ISSUE_URL_PATTERN, description or ""))
+
+
+def backlog_status_to_gh_state(status_name: str) -> str:
+    """Backlogステータス名 → GitHub Issue状態。"""
+    closed_names = {"完了", "resolved", "closed", "done", "完了済み"}
+    return "closed" if status_name.lower() in {s.lower() for s in closed_names} else "open"
+
+
+def create_github_issue(token: str, repo: str, backlog_key: str, title: str, description: str, space_id: str, domain: str) -> dict | None:
+    backlog_url = f"https://{space_id}.{domain}/view/{backlog_key}"
+    body = (
+        f"<!-- backlog-synced -->\n"
+        f"<!-- backlog-key:{backlog_key} -->\n\n"
+        f"**Backlog課題:** [{backlog_key}]({backlog_url})\n\n"
+        f"---\n\n"
+        f"{description or ''}"
+    )
+    issue = gh_request(token, "POST", f"/repos/{repo}/issues", {
+        "title": f"[{backlog_key}] {title}",
+        "body": body,
+    })
+    return issue
+
+
+def update_github_issue(token: str, repo: str, issue_number: int, backlog_key: str,
+                        title: str, description: str, space_id: str, domain: str,
+                        target_state: str, current_issue: dict) -> bool:
+    current_title = current_issue.get("title", "")
+    current_body  = current_issue.get("body", "") or ""
+    current_state = current_issue.get("state", "open")
+
+    new_title = f"[{backlog_key}] {title}"
+    backlog_url = f"https://{space_id}.{domain}/view/{backlog_key}"
+    new_body = (
+        f"<!-- backlog-synced -->\n"
+        f"<!-- backlog-key:{backlog_key} -->\n\n"
+        f"**Backlog課題:** [{backlog_key}]({backlog_url})\n\n"
+        f"---\n\n"
+        f"{description or ''}"
+    )
+
+    update_data = {}
+    if current_title != new_title:
+        update_data["title"] = new_title
+    if current_body != new_body:
+        update_data["body"] = new_body
+    if current_state != target_state:
+        update_data["state"] = target_state
+
+    if not update_data:
+        return False  # 差分なし
+
+    gh_request(token, "PATCH", f"/repos/{repo}/issues/{issue_number}", update_data)
+    return True
+
+
+def main():
+    api_key, space_id, project_key, domain = load_backlog_env()
+    token = get_gh_token()
+    repo  = get_gh_repo()
+    base  = resolve_bl_base(space_id, domain)
+
+    minutes_back = int(os.environ.get("MINUTES_BACK", "20"))
+    updated_since = (datetime.now(timezone.utc) - timedelta(minutes=minutes_back)).strftime("%Y-%m-%d")
+
+    project_id = get_project_id(base, api_key, project_key)
+    issues = get_updated_issues(base, api_key, project_id, updated_since, minutes_back)
+    print(f"更新対象のBacklog課題: {len(issues)}件")
+
+    created = updated = closed = skipped = failed = 0
+
+    for iss in issues:
+        backlog_key  = iss.get("issueKey", "")
+        title        = iss.get("summary", "")
+        description  = iss.get("description", "") or ""
+        status_name  = iss.get("status", {}).get("name", "未対応")
+        target_state = backlog_status_to_gh_state(status_name)
+
+        if not backlog_key:
+            skipped += 1
+            continue
+
+        # 無限ループ防止: GitHub起源の課題は新規作成しない
+        if is_github_origin(description):
+            # ただしクローズ/再オープンは反映する
+            existing = find_github_issue(token, repo, backlog_key)
+            if existing and existing.get("state") != target_state:
+                gh_request(token, "PATCH", f"/repos/{repo}/issues/{existing['number']}", {"state": target_state})
+                print(f"GitHub Issue状態を更新しました: #{existing['number']} ← {backlog_key} ({target_state})")
+                updated += 1
+            else:
+                skipped += 1
+            continue
+
+        existing = find_github_issue(token, repo, backlog_key)
+
+        if not existing:
+            result = create_github_issue(token, repo, backlog_key, title, description, space_id, domain)
+            if result:
+                num = result.get("number")
+                print(f"GitHub Issueを作成しました: #{num} ← {backlog_key}")
+                if target_state == "closed":
+                    gh_request(token, "PATCH", f"/repos/{repo}/issues/{num}", {"state": "closed"})
+                created += 1
+            else:
+                print(f"[ERROR] GitHub Issue作成失敗: {backlog_key}")
+                failed += 1
+        else:
+            changed = update_github_issue(
+                token, repo, existing["number"], backlog_key,
+                title, description, space_id, domain, target_state, existing
+            )
+            action = "クローズ" if target_state == "closed" and existing.get("state") == "open" else \
+                     "再オープン" if target_state == "open" and existing.get("state") == "closed" else "更新"
+            if changed:
+                print(f"GitHub Issueを{action}しました: #{existing['number']} ← {backlog_key}")
+                updated += 1
+            else:
+                skipped += 1
+
+    print(f"同期完了: created={created}, updated={updated}, closed={closed}, skipped={skipped}, failed={failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/github_comment_to_backlog.py
+++ b/.github/scripts/github_comment_to_backlog.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+GitHub Issueコメント → Backlogコメント 同期スクリプト
+
+- created/edited イベントを受けて Backlog へコメントを追加
+- コメントIDマーカーで重複防止
+- PRコメントは除外
+"""
+
+import os
+import sys
+import re
+import json
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from sync_utils import get_gh_token, get_gh_repo, gh_request, extract_backlog_key
+
+
+def comment_already_synced(base: str, api_key: str, backlog_key: str, comment_id: str) -> bool:
+    """同じGitHubコメントIDが既にBacklogに存在するか確認する。"""
+    marker = f"<!-- github-comment-id:{comment_id} -->"
+    # 最新コメントを取得して確認
+    comments = bl_request(base, api_key, "GET", f"/issues/{backlog_key}/comments",
+                           {"count": 100, "order": "desc"}, fatal=False)
+    if not comments:
+        return False
+    for c in comments:
+        if marker in (c.get("content", "") or ""):
+            return True
+    return False
+
+
+def main():
+    api_key, space_id, project_key, domain = load_backlog_env()
+    base = resolve_bl_base(space_id, domain)
+
+    issue_number  = os.environ.get("GH_ISSUE_NUMBER", "")
+    issue_body    = os.environ.get("GH_ISSUE_BODY", "")
+    comment_id    = os.environ.get("GH_COMMENT_ID", "")
+    comment_body  = os.environ.get("GH_COMMENT_BODY", "")
+    comment_user  = os.environ.get("GH_COMMENT_USER", "")
+    comment_url   = os.environ.get("GH_COMMENT_URL", "")
+    event_action  = os.environ.get("GH_EVENT_ACTION", "created")
+    repo          = os.environ.get("GH_REPO", "")
+
+    backlog_key = extract_backlog_key(issue_body, project_key)
+    if not backlog_key:
+        print(f"Issue #{issue_number} にBacklog課題キーがありません。スキップします")
+        return
+
+    # 重複防止
+    if comment_already_synced(base, api_key, backlog_key, comment_id):
+        print(f"コメントID {comment_id} は既にBacklogに同期済みです。スキップします")
+        return
+
+    issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+    action_text = "追加" if event_action == "created" else "編集"
+    content = (
+        f"<!-- github-comment-id:{comment_id} -->\n\n"
+        f"GitHub Issue #{issue_number} のコメントが{action_text}されました。\n\n"
+        f"- 投稿者: @{comment_user}\n"
+        f"- GitHub Issue: {issue_url}\n"
+        f"- GitHubコメント: {comment_url}\n\n"
+        f"---\n\n"
+        f"{comment_body}"
+    )
+
+    result = bl_request(base, api_key, "POST", f"/issues/{backlog_key}/comments",
+                        {"content": content}, fatal=False)
+    if result:
+        print(f"Backlogコメントを追加しました: {backlog_key} ← GitHub Issue #{issue_number}")
+    else:
+        print(f"[ERROR] Backlogコメントの追加に失敗しました: {backlog_key}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/github_to_backlog.py
+++ b/.github/scripts/github_to_backlog.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+GitHub Issue → Backlog課題 同期スクリプト
+
+- opened:   Backlog課題を新規作成（Backlog起源Issueはスキップ）
+- edited:   Backlog課題タイトル・説明を更新
+- closed:   Backlog課題を完了に
+- reopened: Backlog課題を未対応に
+"""
+
+import os
+import sys
+import re
+import json
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from sync_utils import get_gh_token, get_gh_repo, gh_request, extract_backlog_key, is_backlog_synced, update_sync_section
+
+
+def get_issue_type_id(base: str, api_key: str, project_key: str) -> int:
+    types = bl_request(base, api_key, "GET", f"/projects/{project_key}/issueTypes")
+    if not types:
+        print("[WARN] 課題種別取得失敗。デフォルトIDを使用できません")
+        sys.exit(1)
+    # 「タスク」を優先検索
+    for t in types:
+        if t.get("name") == "タスク":
+            print(f"課題種別を使用: {t['name']} (id={t['id']})")
+            return t["id"]
+    print(f"課題種別を使用: {types[0]['name']} (id={types[0]['id']})")
+    return types[0]["id"]
+
+
+def get_status_id(base: str, api_key: str, project_key: str, status_name: str) -> int:
+    statuses = bl_request(base, api_key, "GET", f"/projects/{project_key}/statuses")
+    if statuses:
+        for s in statuses:
+            if s.get("name") == status_name:
+                return s["id"]
+    # フォールバック
+    return 1 if status_name == "未対応" else 4
+
+
+def create_backlog_issue(base: str, api_key: str, project_id: int, issue_type_id: int,
+                         title: str, description: str) -> dict | None:
+    priority_id = 3  # Backlog標準の優先度「中」
+    return bl_request(base, api_key, "POST", "/issues", {
+        "projectId":    project_id,
+        "summary":      title,
+        "issueTypeId":  issue_type_id,
+        "priorityId":   priority_id,
+        "description":  description,
+    })
+
+
+def update_github_issue_with_backlog_key(token: str, repo: str, issue_number: int,
+                                          original_title: str, original_body: str,
+                                          backlog_key: str) -> None:
+    new_title = f"[{backlog_key}] {original_title}"
+    marker = f"<!-- backlog-key:{backlog_key} -->"
+    if marker not in (original_body or ""):
+        new_body = f"{marker}\n\n{original_body or ''}"
+    else:
+        new_body = original_body
+
+    gh_request(token, "PATCH", f"/repos/{repo}/issues/{issue_number}", {
+        "title": new_title,
+        "body":  new_body,
+    })
+
+
+def main():
+    api_key, space_id, project_key, domain = load_backlog_env()
+    token  = get_gh_token()
+    repo   = get_gh_repo()
+    base   = resolve_bl_base(space_id, domain)
+
+    event_name   = os.environ.get("GITHUB_EVENT_NAME", "")
+    event_action = os.environ.get("GH_EVENT_ACTION", "")
+    issue_number = int(os.environ.get("GH_ISSUE_NUMBER", "0"))
+    issue_title  = os.environ.get("GH_ISSUE_TITLE", "")
+    issue_body   = os.environ.get("GH_ISSUE_BODY", "")
+    issue_url    = os.environ.get("GH_ISSUE_URL", "")
+    issue_user   = os.environ.get("GH_ISSUE_USER", "")
+
+    if not issue_number:
+        print("[ERROR] Issue番号が取得できません")
+        sys.exit(1)
+
+    print(f"GitHub Issue #{issue_number} の処理: action={event_action}")
+
+    proj = bl_request(base, api_key, "GET", f"/projects/{project_key}")
+    if not proj:
+        print(f"[ERROR] プロジェクト {project_key} が見つかりません")
+        sys.exit(1)
+    project_id = proj["id"]
+
+    # タイトルから [KEY] プレフィックスを除去
+    clean_title = re.sub(rf"^\[{re.escape(project_key)}-\d+\]\s*", "", issue_title)
+
+    if event_action == "opened":
+        # Backlog起源Issueは新規作成しない
+        if is_backlog_synced(issue_body):
+            print(f"Backlog起源のIssueのためスキップします: #{issue_number}")
+            return
+
+        issue_type_id = get_issue_type_id(base, api_key, project_key)
+        github_issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+        start_marker = "<!-- github-sync:start -->"
+        end_marker   = "<!-- github-sync:end -->"
+        description = (
+            f"GitHub Issue: {github_issue_url}\n\n"
+            f"{start_marker}\n\n"
+            f"{issue_body or ''}\n\n"
+            f"{end_marker}"
+        )
+
+        result = create_backlog_issue(base, api_key, project_id, issue_type_id, clean_title, description)
+        if not result:
+            print(f"[ERROR] Backlog課題の作成に失敗しました")
+            sys.exit(1)
+
+        backlog_key = result.get("issueKey", "")
+        print(f"Backlog課題を作成しました: {backlog_key} ← GitHub Issue #{issue_number}")
+
+        # GitHub IssueにBacklog課題キーを反映
+        update_github_issue_with_backlog_key(token, repo, issue_number, clean_title, issue_body, backlog_key)
+
+    elif event_action == "edited":
+        backlog_key = extract_backlog_key(issue_body, project_key)
+        if not backlog_key:
+            print(f"Issue #{issue_number} にBacklog課題キーがありません。スキップします")
+            return
+
+        # 現在のBacklog課題説明を取得
+        current = bl_request(base, api_key, "GET", f"/issues/{backlog_key}", fatal=False)
+        current_desc = current.get("description", "") if current else ""
+        current_summary = current.get("summary", "") if current else ""
+
+        github_issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+        new_sync_content = issue_body or ""
+        new_desc = update_sync_section(current_desc, new_sync_content)
+
+        update_data = {}
+        if current_summary != clean_title:
+            update_data["summary"] = clean_title
+        if current_desc != new_desc:
+            update_data["description"] = new_desc
+
+        if update_data:
+            bl_request(base, api_key, "PATCH", f"/issues/{backlog_key}", update_data)
+            print(f"Backlog課題を更新しました: {backlog_key} ← GitHub Issue #{issue_number}")
+
+            # 更新通知コメントをBacklogへ追加
+            comment_body = (
+                f"GitHub Issue #{issue_number} が更新されました。\n\n"
+                f"- 更新者: @{issue_user}\n"
+                f"- タイトル: {clean_title}\n"
+                f"- GitHub Issue: {github_issue_url}"
+            )
+            bl_request(base, api_key, "POST", f"/issues/{backlog_key}/comments",
+                       {"content": comment_body}, fatal=False)
+        else:
+            print(f"差分なし。更新をスキップしました: {backlog_key}")
+
+    elif event_action in ("closed", "reopened"):
+        backlog_key = extract_backlog_key(issue_body, project_key)
+        if not backlog_key:
+            print(f"Issue #{issue_number} にBacklog課題キーがありません。スキップします")
+            return
+
+        status_name = "完了" if event_action == "closed" else "未対応"
+        status_id   = get_status_id(base, api_key, project_key, status_name)
+        bl_request(base, api_key, "PATCH", f"/issues/{backlog_key}", {"statusId": status_id})
+        print(f"Backlog課題のステータスを更新しました: {backlog_key} → {status_name}")
+
+    else:
+        print(f"未対応のアクション: {event_action}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sync_utils.py
+++ b/.github/scripts/sync_utils.py
@@ -1,0 +1,75 @@
+"""GitHub API共通ユーティリティ"""
+import os
+import sys
+import json
+import re
+import urllib.request
+import urllib.error
+
+
+GH_API_BASE = "https://api.github.com"
+
+
+def get_gh_token() -> str:
+    token = os.environ.get("GH_TOKEN", "")
+    if not token:
+        print("[ERROR] GH_TOKENが設定されていません")
+        sys.exit(1)
+    return token
+
+
+def get_gh_repo() -> str:
+    repo = os.environ.get("GH_REPO", "")
+    if not repo:
+        print("[ERROR] GH_REPOが設定されていません")
+        sys.exit(1)
+    return repo
+
+
+def gh_request(token: str, method: str, path: str, data: dict | None = None):
+    """GitHub APIへリクエストする。"""
+    url = f"{GH_API_BASE}{path}"
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if body:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body_txt = e.read().decode("utf-8", errors="replace")
+        print(f"[ERROR] GitHub API {method} {path} → HTTP {e.code}: {body_txt[:300]}")
+        return None
+
+
+def extract_backlog_key(text: str, project_key: str) -> str | None:
+    """Issue本文やタイトルからBacklog課題キーを抽出する。"""
+    pattern = rf"<!--\s*backlog-key:({re.escape(project_key)}-\d+)\s*-->"
+    m = re.search(pattern, text or "")
+    if m:
+        return m.group(1)
+    # タイトルの [SHOKUSU-123] 形式もフォールバックで検索
+    pattern2 = rf"\[({re.escape(project_key)}-\d+)\]"
+    m2 = re.search(pattern2, text or "")
+    return m2.group(1) if m2 else None
+
+
+def is_backlog_synced(body: str) -> bool:
+    """Backlog起源のIssueかどうかを判定する。"""
+    return "<!-- backlog-synced -->" in (body or "")
+
+
+def update_sync_section(description: str, new_content: str) -> str:
+    """Backlog課題説明の同期範囲のみを置換する。"""
+    start = "<!-- github-sync:start -->"
+    end = "<!-- github-sync:end -->"
+    new_section = f"{start}\n\n{new_content}\n\n{end}"
+    if start in description and end in description:
+        before = description[:description.index(start)]
+        after  = description[description.index(end) + len(end):]
+        return before + new_section + after
+    # 同期セクションがない場合は末尾に追加
+    return description.rstrip() + f"\n\n{new_section}"

--- a/.github/workflows/backlog-to-github-issue.yml
+++ b/.github/workflows/backlog-to-github-issue.yml
@@ -1,0 +1,40 @@
+name: Backlog課題 → GitHub Issue
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      minutes_back:
+        description: '何分前からの更新を確認するか'
+        required: false
+        default: '20'
+
+concurrency:
+  group: backlog-to-github-issue
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Backlog → GitHub Issue 同期
+        run: python .github/scripts/backlog_to_github.py
+        env:
+          MINUTES_BACK: ${{ github.event.inputs.minutes_back || '20' }}

--- a/.github/workflows/github-issue-comment-to-backlog.yml
+++ b/.github/workflows/github-issue-comment-to-backlog.yml
@@ -1,0 +1,42 @@
+name: GitHub Issueコメント → Backlogコメント
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+concurrency:
+  group: github-comment-to-backlog-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+  GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+  GH_ISSUE_BODY: ${{ github.event.issue.body }}
+  GH_COMMENT_ID: ${{ github.event.comment.id }}
+  GH_COMMENT_BODY: ${{ github.event.comment.body }}
+  GH_COMMENT_USER: ${{ github.event.comment.user.login }}
+  GH_COMMENT_URL: ${{ github.event.comment.html_url }}
+  GH_EVENT_ACTION: ${{ github.event.action }}
+
+jobs:
+  sync:
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: GitHub コメント → Backlog コメント同期
+        run: python .github/scripts/github_comment_to_backlog.py

--- a/.github/workflows/github-issue-to-backlog.yml
+++ b/.github/workflows/github-issue-to-backlog.yml
@@ -1,0 +1,42 @@
+name: GitHub Issue → Backlog課題
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+
+concurrency:
+  group: github-issue-to-backlog-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+  GH_EVENT_ACTION: ${{ github.event.action }}
+  GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+  GH_ISSUE_TITLE: ${{ github.event.issue.title }}
+  GH_ISSUE_BODY: ${{ github.event.issue.body }}
+  GH_ISSUE_URL: ${{ github.event.issue.html_url }}
+  GH_ISSUE_USER: ${{ github.event.issue.user.login }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: GitHub Issue → Backlog課題 同期
+        run: python .github/scripts/github_to_backlog.py

--- a/README.md
+++ b/README.md
@@ -63,3 +63,26 @@
    ```
 2. SQLを記述（`ALTER TABLE ...` など）
 3. `develop` へマージしてステージングデプロイを実行
+
+---
+
+## 🔄 Backlog ↔ GitHub Issue 双方向連携
+
+BacklogとGitHub Issueを自動同期する仕組みを導入しています。
+
+| 方向 | トリガー | 内容 |
+|------|----------|------|
+| Backlog → GitHub | 15分ごとのスケジュール | Backlog課題の作成・更新・完了をGitHub Issueに反映 |
+| GitHub → Backlog | Issue イベント | GitHub Issueの作成・編集・クローズ・再オープンをBacklog課題に反映 |
+| GitHub → Backlog | Issue Comment イベント | GitHub IssueへのコメントをBacklogコメントへ反映 |
+
+### 初期設定（初回のみ必要）
+
+以下の GitHub Secret を登録してください。
+
+```bash
+# BACKLOG_API_KEY のみ手動登録が必要（BacklogのAPIキーを取得して設定）
+gh secret set BACKLOG_API_KEY --body "YOUR_BACKLOG_API_KEY" --repo kamaho-source/shokusuu1
+```
+
+詳細は [docs/backlog-github-sync.md](docs/backlog-github-sync.md) を参照してください。

--- a/docs/backlog-github-sync.md
+++ b/docs/backlog-github-sync.md
@@ -1,0 +1,127 @@
+# Backlog ↔ GitHub Issue 双方向連携
+
+## 概要
+
+BacklogとGitHub Issueを双方向に自動同期する仕組みです。
+
+| 方向 | トリガー | 内容 |
+|------|----------|------|
+| Backlog → GitHub | 15分ごとのスケジュール | Backlog課題の作成・更新・完了をGitHub Issueへ反映 |
+| GitHub → Backlog | Issue イベント | GitHub Issueの作成・編集・クローズ・再オープンをBacklog課題へ反映 |
+| GitHub → Backlog | Issue Comment イベント | GitHub IssueへのコメントをBacklogコメントへ反映 |
+
+---
+
+## ファイル構成
+
+```
+.github/
+├── scripts/
+│   ├── backlog_client.py              # Backlog API共通クライアント
+│   ├── sync_utils.py                  # GitHub API共通ユーティリティ
+│   ├── backlog_to_github.py           # Backlog → GitHub 同期スクリプト
+│   ├── github_to_backlog.py           # GitHub → Backlog 同期スクリプト
+│   └── github_comment_to_backlog.py   # GitHub コメント → Backlog 同期スクリプト
+└── workflows/
+    ├── backlog-to-github-issue.yml         # Backlog → GitHub ワークフロー
+    ├── github-issue-to-backlog.yml         # GitHub → Backlog ワークフロー
+    └── github-issue-comment-to-backlog.yml # コメント同期ワークフロー
+```
+
+---
+
+## 必要な GitHub Secrets
+
+| Secret名 | 値 | 登録方法 |
+|----------|----|----------|
+| `BACKLOG_API_KEY` | BacklogのAPIキー | **手動登録が必要** |
+| `BACKLOG_SPACE_ID` | `kamaho` | 自動登録済み |
+| `BACKLOG_PROJECT_KEY` | `SHOKUSU` | 自動登録済み |
+| `BACKLOG_DOMAIN` | `backlog.com` | 自動登録済み |
+
+### BACKLOG_API_KEY の登録方法
+
+1. Backlogにログインし、[個人設定] → [API] からAPIキーを発行
+2. 以下のコマンドで登録:
+
+```bash
+gh secret set BACKLOG_API_KEY --body "取得したAPIキー" --repo kamaho-source/shokusuu1
+```
+
+または GitHub リポジトリの Settings → Secrets and variables → Actions から手動登録。
+
+---
+
+## 動作仕様
+
+### Backlog → GitHub Issue 同期 (`backlog-to-github-issue.yml`)
+
+- 15分ごとに実行（手動実行も可能）
+- 指定分数前（デフォルト: 20分）から更新されたBacklog課題を取得
+- **重複防止**: タイトルの `[SHOKUSU-XXX]` プレフィックスとbody内のHTMLコメントマーカーで既存Issueを検索
+- **無限ループ防止**: `GitHub Issue: https://github.com/` が説明に含まれる課題はGitHub起源と判断し、新規作成をスキップ（ステータス変更のみ反映）
+- Backlogの「完了」ステータス → GitHub Issueのcloseに反映
+
+### GitHub Issue → Backlog課題 同期 (`github-issue-to-backlog.yml`)
+
+- `opened`: 新規Backlog課題を作成。GitHub IssueのタイトルとbodyをBacklog課題に反映。GitHub Issue側にBacklog課題キーを追記
+- `edited`: Backlog課題のタイトル・説明を更新。差分がある場合のみBacklogにコメントを追加
+- `closed`: Backlog課題のステータスを「完了」に変更
+- `reopened`: Backlog課題のステータスを「未対応」に変更
+- **無限ループ防止**: `<!-- backlog-synced -->` マーカーが含まれるIssueはBacklog起源として新規作成をスキップ
+
+### GitHub コメント → Backlogコメント同期 (`github-issue-comment-to-backlog.yml`)
+
+- Issue Commentの`created`・`edited`イベントで発火
+- PRのコメントは除外（`if: ${{ !github.event.issue.pull_request }}`）
+- **重複防止**: `<!-- github-comment-id:XXX -->` マーカーで既存コメントを確認
+
+---
+
+## マーカー仕様
+
+| マーカー | 場所 | 用途 |
+|----------|------|------|
+| `<!-- backlog-synced -->` | GitHub Issue body | Backlog起源のIssueであることを示す |
+| `<!-- backlog-key:SHOKUSU-XXX -->` | GitHub Issue body | 対応するBacklog課題キーを保持 |
+| `<!-- github-sync:start -->` / `<!-- github-sync:end -->` | Backlog課題説明 | GitHub同期範囲を区切る |
+| `<!-- github-comment-id:XXX -->` | Backlogコメント | 同期済みGitHubコメントIDを保持（重複防止） |
+
+---
+
+## 手動実行
+
+`backlog-to-github-issue` ワークフローは手動実行が可能です。
+
+```bash
+gh workflow run backlog-to-github-issue.yml \
+  --repo kamaho-source/shokusuu1 \
+  -f minutes_back=60
+```
+
+`minutes_back` に大きな値を指定することで、過去の課題も一括同期できます。
+
+---
+
+## トラブルシューティング
+
+### 認証エラー（HTTP 401）
+
+```
+[ERROR] Backlog APIの認証に失敗しました。
+```
+
+確認項目:
+- `BACKLOG_API_KEY` Secret が正しく登録されているか
+- Secretの値に前後の空白や改行が含まれていないか
+- `BACKLOG_SPACE_ID` が `kamaho` になっているか
+- `BACKLOG_DOMAIN` が `backlog.com` になっているか
+
+### 同期が止まっている場合
+
+GitHub Actions のログを確認:
+
+```bash
+gh run list --workflow=backlog-to-github-issue.yml --repo kamaho-source/shokusuu1
+gh run view <RUN_ID> --log --repo kamaho-source/shokusuu1
+```


### PR DESCRIPTION
## Summary

- Backlog課題とGitHub Issueを自動的に双方向同期する仕組みを実装
- Backlog → GitHub: 15分ごとのスケジュール実行で更新課題をGitHub Issueに反映（重複防止・無限ループ防止付き）
- GitHub → Backlog: Issue events（opened/edited/closed/reopened）でBacklog課題をリアルタイム同期
- GitHub → Backlog: Issue Commentイベントでコメントを同期（重複防止付き）

## 追加ファイル

| ファイル | 役割 |
|----------|------|
| `.github/scripts/backlog_client.py` | Backlog API共通クライアント（再試行・認証エラー処理付き） |
| `.github/scripts/sync_utils.py` | GitHub API共通ユーティリティ |
| `.github/scripts/backlog_to_github.py` | Backlog → GitHub 同期スクリプト |
| `.github/scripts/github_to_backlog.py` | GitHub → Backlog 同期スクリプト |
| `.github/scripts/github_comment_to_backlog.py` | GitHub コメント → Backlog コメント同期スクリプト |
| `.github/workflows/backlog-to-github-issue.yml` | 15分ごとのスケジュールワークフロー |
| `.github/workflows/github-issue-to-backlog.yml` | Issue イベント連携ワークフロー |
| `.github/workflows/github-issue-comment-to-backlog.yml` | コメント連携ワークフロー |
| `docs/backlog-github-sync.md` | 設定・運用ドキュメント |

## 必要な手動設定（ユーザーが行う）

以下のSecret登録が必要です（他3つは自動登録済み）:

```bash
gh secret set BACKLOG_API_KEY --body "YOUR_BACKLOG_API_KEY" --repo kamaho-source/shokusuu1
```

BacklogのAPIキーは [個人設定] → [API] から取得してください。

## Test plan

- [ ] `BACKLOG_API_KEY` Secret を登録する
- [ ] `backlog-to-github-issue` ワークフローを手動実行し、Backlog課題がGitHub Issueに作成されることを確認
- [ ] GitHub Issueを新規作成し、Backlogに課題が自動作成されることを確認
- [ ] GitHub Issueをクローズし、Backlog課題のステータスが「完了」になることを確認
- [ ] GitHub Issueにコメントを追加し、Backlogコメントへ反映されることを確認