### PR TITLE
feat: GitHub PR→Backlogコメント自動同期を追加

### DIFF
--- a/.github/scripts/bulk_sync_github_to_backlog.py
+++ b/.github/scripts/bulk_sync_github_to_backlog.py
@@ -20,7 +20,7 @@ import urllib.parse
 
 sys.path.insert(0, os.path.dirname(__file__))
 from backlog_client import load_backlog_env, resolve_bl_base, bl_request
-from sync_utils import get_gh_token, get_gh_repo, gh_request, extract_backlog_key, is_backlog_synced
+from sync_utils import get_gh_token, get_gh_repo, gh_request, extract_backlog_key, is_backlog_synced, get_linked_prs, format_pr_section
 
 GH_API_BASE = "https://api.github.com"
 
@@ -146,11 +146,16 @@ def main():
         # タイトルの[KEY]プレフィックスを除去
         clean_title = re.sub(r"^\[[\w]+-\d+\]\s*", "", title)
 
+        # 紐づくPRを取得
+        linked_prs = get_linked_prs(token, repo, number) if not dry_run else []
+        pr_section = format_pr_section(linked_prs)
+
         start_marker = "<!-- github-sync:start -->"
         end_marker   = "<!-- github-sync:end -->"
         description = (
             f"GitHub Issue: {url}\n\n"
-            f"{start_marker}\n\n"
+            + (f"{pr_section}\n\n" if pr_section else "")
+            + f"{start_marker}\n\n"
             f"{body}\n\n"
             f"{end_marker}"
         )

--- a/.github/scripts/github_pr_to_backlog.py
+++ b/.github/scripts/github_pr_to_backlog.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+GitHub PR → Backlog課題 PR情報同期スクリプト
+
+- PR が opened / edited / closed / reopened / merged になったとき
+- PRの本文から紐づくIssueのBacklogキーを取得
+- BacklogにPR情報をコメントとして追加（重複防止付き）
+- BacklogのPRステータスセクションを更新
+"""
+
+import os
+import sys
+import re
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from sync_utils import extract_backlog_key
+
+CLOSING_PATTERN = re.compile(
+    r"(?:closes?|fixes?|resolves?)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def find_linked_issue_numbers(pr_body: str) -> list[int]:
+    """PR本文から "Closes/Fixes/Resolves #N" パターンのIssue番号を抽出する。"""
+    return [int(m.group(1)) for m in CLOSING_PATTERN.finditer(pr_body or "")]
+
+
+def get_backlog_key_from_issue(token: str, repo: str, issue_number: int, project_key: str) -> str | None:
+    """GitHub IssueのタイトルまたはボディからBacklogキーを取得する。"""
+    import urllib.request
+    import urllib.error
+    import json
+
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            issue = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+    title = issue.get("title", "")
+    body  = issue.get("body", "") or ""
+    return extract_backlog_key(title + "\n" + body, project_key)
+
+
+def pr_comment_already_exists(base: str, api_key: str, backlog_key: str, pr_number: int) -> bool:
+    """同じPR番号のコメントが既にBacklogにあるか確認する。"""
+    marker = f"<!-- github-pr-id:{pr_number} -->"
+    comments = bl_request(base, api_key, "GET", f"/issues/{backlog_key}/comments",
+                          {"count": 100, "order": "desc"}, fatal=False)
+    if not comments:
+        return False
+    for c in comments:
+        if marker in (c.get("content", "") or ""):
+            return True
+    return False
+
+
+def build_pr_comment(pr_number: int, pr_title: str, pr_url: str,
+                     pr_user: str, pr_action: str, repo: str,
+                     issue_number: int | None = None) -> str:
+    issue_url = f"https://github.com/{repo}/issues/{issue_number}" if issue_number else ""
+    action_labels = {
+        "opened":      "📋 PRが作成されました",
+        "edited":      "✏️ PRが更新されました",
+        "closed":      "❌ PRがクローズされました",
+        "reopened":    "🔄 PRが再オープンされました",
+        "merged":      "✅ PRがマージされました",
+        "synchronize": "🔄 PRが更新されました（コミット追加）",
+    }
+    action_text = action_labels.get(pr_action, f"PR が {pr_action} されました")
+
+    lines = [
+        f"<!-- github-pr-id:{pr_number} -->",
+        f"",
+        f"## {action_text}",
+        f"",
+        f"- **PRタイトル:** [{pr_title}]({pr_url}) (#{pr_number})",
+        f"- **操作者:** @{pr_user}",
+        f"- **PR URL:** {pr_url}",
+    ]
+    if issue_url:
+        lines.append(f"- **関連Issue:** {issue_url}")
+
+    return "\n".join(lines)
+
+
+def main():
+    api_key, space_id, project_key, domain = load_backlog_env()
+    base = resolve_bl_base(space_id, domain)
+
+    gh_token    = os.environ.get("GH_TOKEN", "")
+    repo        = os.environ.get("GH_REPO", "")
+    pr_number   = int(os.environ.get("GH_PR_NUMBER", "0"))
+    pr_title    = os.environ.get("GH_PR_TITLE", "")
+    pr_body     = os.environ.get("GH_PR_BODY", "")
+    pr_url      = os.environ.get("GH_PR_URL", "")
+    pr_user     = os.environ.get("GH_PR_USER", "")
+    pr_action   = os.environ.get("GH_PR_ACTION", "opened")
+    pr_merged   = os.environ.get("GH_PR_MERGED", "false").lower() == "true"
+
+    if pr_merged and pr_action == "closed":
+        pr_action = "merged"
+
+    if not pr_number:
+        print("[ERROR] PR番号が取得できません")
+        sys.exit(1)
+
+    print(f"GitHub PR #{pr_number} の処理: action={pr_action}")
+
+    # PR本文から紐づくIssue番号を取得
+    issue_numbers = find_linked_issue_numbers(pr_body)
+
+    # PRタイトルから [SHOKUSU-N] 形式も検索
+    key_from_title = extract_backlog_key(pr_title, project_key)
+    if key_from_title:
+        # タイトルに直接キーがある場合はそれを使う
+        backlog_keys = [key_from_title]
+        linked_issues = {key_from_title: None}
+    else:
+        # 紐づくIssueのBacklogキーを収集
+        backlog_keys = []
+        linked_issues = {}
+        for iss_num in issue_numbers:
+            key = get_backlog_key_from_issue(gh_token, repo, iss_num, project_key)
+            if key:
+                backlog_keys.append(key)
+                linked_issues[key] = iss_num
+                print(f"  Issue #{iss_num} → Backlog課題: {key}")
+            else:
+                print(f"  Issue #{iss_num} にはBacklogキーがありません。スキップします")
+
+    if not backlog_keys:
+        print("紐づくBacklog課題が見つかりませんでした。スキップします")
+        return
+
+    for backlog_key in backlog_keys:
+        issue_number = linked_issues.get(backlog_key)
+
+        # 重複チェック（openedのみ。edited/mergedは常にコメント追加）
+        if pr_action == "opened" and pr_comment_already_exists(base, api_key, backlog_key, pr_number):
+            print(f"  [{backlog_key}] PR #{pr_number} のコメントは既に存在します。スキップします")
+            continue
+
+        comment = build_pr_comment(pr_number, pr_title, pr_url, pr_user, pr_action, repo, issue_number)
+        result = bl_request(base, api_key, "POST", f"/issues/{backlog_key}/comments",
+                            {"content": comment}, fatal=False)
+        if result:
+            print(f"  [{backlog_key}] BacklogにPR情報を追加しました (action={pr_action})")
+        else:
+            print(f"  [{backlog_key}] Backlogへのコメント追加に失敗しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/patch_backlog_with_pr.py
+++ b/.github/scripts/patch_backlog_with_pr.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+既存BacklogイシューへPR情報を手動で追記する一時スクリプト。
+
+対象: PR #559 → SHOKUSU-10
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from sync_utils import extract_backlog_key, get_linked_prs, format_pr_section
+import urllib.request
+import json
+
+
+def gh_request(token: str, method: str, path: str):
+    url = f"https://api.github.com{path}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def main():
+    api_key, space_id, project_key, domain = load_backlog_env()
+    base  = resolve_bl_base(space_id, domain)
+    token = os.environ.get("GH_TOKEN", "")
+    repo  = os.environ.get("GH_REPO", "")
+
+    # PR番号と対象Backlogキーのマッピング（既存未反映分）
+    mappings = [
+        {"pr_number": 559, "backlog_key": f"{project_key}-10"},
+    ]
+
+    for m in mappings:
+        pr_num      = m["pr_number"]
+        backlog_key = m["backlog_key"]
+
+        # PR情報を取得
+        pr = gh_request(token, "GET", f"/repos/{repo}/pulls/{pr_num}")
+        pr_title  = pr.get("title", "")
+        pr_url    = pr.get("html_url", "")
+        pr_user   = pr.get("user", {}).get("login", "")
+        pr_merged = pr.get("merged_at") is not None
+        pr_state  = "merged" if pr_merged else pr.get("state", "open")
+
+        state_label = "✅ マージ済み" if pr_merged else ("🔄 オープン" if pr_state == "open" else "❌ クローズ")
+
+        comment = (
+            f"<!-- github-pr-id:{pr_num} -->\n\n"
+            f"## {state_label} PRが紐づいています\n\n"
+            f"- **PRタイトル:** [{pr_title}]({pr_url}) (#{pr_num})\n"
+            f"- **操作者:** @{pr_user}\n"
+            f"- **PR URL:** {pr_url}\n"
+        )
+
+        result = bl_request(base, api_key, "POST", f"/issues/{backlog_key}/comments",
+                            {"content": comment}, fatal=False)
+        if result:
+            print(f"[OK] {backlog_key} にPR #{pr_num} の情報を追加しました")
+        else:
+            print(f"[ERROR] {backlog_key} へのコメント追加に失敗しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sync_utils.py
+++ b/.github/scripts/sync_utils.py
@@ -45,6 +45,55 @@ def gh_request(token: str, method: str, path: str, data: dict | None = None):
         return None
 
 
+def get_linked_prs(token: str, repo: str, issue_number: int) -> list[dict]:
+    """Issueに紐づくPR一覧を返す（Closes/Fixes/Resolves #N パターンで検索）。"""
+    result = gh_request(
+        token, "GET",
+        f"/repos/{repo}/issues/{issue_number}/timeline?per_page=100"
+    )
+    if not result:
+        return []
+
+    pr_numbers = set()
+    for event in result:
+        if event.get("event") == "cross-referenced":
+            src = event.get("source", {})
+            if src.get("type") == "pullrequest":
+                issue_info = src.get("issue", {})
+                if issue_info.get("pull_request"):
+                    pr_numbers.add(issue_info["number"])
+
+    # PR本文で "Closes/Fixes/Resolves #N" を検索
+    search_result = gh_request(
+        token, "GET",
+        f"/search/issues?q=repo:{repo}+is:pr+{issue_number}+in:body&per_page=20"
+    )
+    if search_result:
+        for item in search_result.get("items", []):
+            body = item.get("body", "") or ""
+            if re.search(rf"(?:closes?|fixes?|resolves?)\s+#?{issue_number}\b", body, re.IGNORECASE):
+                pr_numbers.add(item["number"])
+
+    prs = []
+    for pr_num in sorted(pr_numbers):
+        pr = gh_request(token, "GET", f"/repos/{repo}/pulls/{pr_num}")
+        if pr:
+            prs.append(pr)
+    return prs
+
+
+def format_pr_section(prs: list[dict]) -> str:
+    """PR一覧をBacklog用テキストに変換する。"""
+    if not prs:
+        return ""
+    lines = ["**関連PR:**"]
+    for pr in prs:
+        state = pr.get("state", "open")
+        state_label = "✅ マージ済み" if pr.get("merged_at") else ("🔄 オープン" if state == "open" else "❌ クローズ")
+        lines.append(f"- [{state_label}] [{pr['title']}]({pr['html_url']}) (#{pr['number']})")
+    return "\n".join(lines)
+
+
 def extract_backlog_key(text: str, project_key: str) -> str | None:
     """Issue本文やタイトルからBacklog課題キーを抽出する。"""
     pattern = rf"<!--\s*backlog-key:({re.escape(project_key)}-\d+)\s*-->"

--- a/.github/workflows/github-pr-to-backlog.yml
+++ b/.github/workflows/github-pr-to-backlog.yml
@@ -1,0 +1,44 @@
+name: GitHub PR → Backlogコメント
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+
+concurrency:
+  group: github-pr-to-backlog-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+  GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+  GH_PR_TITLE: ${{ github.event.pull_request.title }}
+  GH_PR_BODY: ${{ github.event.pull_request.body }}
+  GH_PR_URL: ${{ github.event.pull_request.html_url }}
+  GH_PR_USER: ${{ github.event.pull_request.user.login }}
+  GH_PR_ACTION: ${{ github.event.action }}
+  GH_PR_MERGED: ${{ github.event.pull_request.merged }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: GitHub PR → Backlogコメント同期
+        run: python .github/scripts/github_pr_to_backlog.py

--- a/.github/workflows/patch-backlog-with-existing-prs.yml
+++ b/.github/workflows/patch-backlog-with-existing-prs.yml
@@ -1,0 +1,27 @@
+name: 既存PRをBacklog課題へ反映（一時）
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+
+jobs:
+  patch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: 既存PRをBacklog課題へ反映
+        run: python .github/scripts/patch_backlog_with_pr.py


### PR DESCRIPTION
## Summary

- GitHub PRが作成・更新・クローズ・マージされたときにBacklog課題へコメントで自動反映
- PRタイトルまたは本文の `Closes #N` / `Fixes #N` / `Resolves #N` からBacklog課題を特定
- 既存未反映PR（#559 → SHOKUSU-10）を手動反映するワークフローを追加
- 一括同期スクリプト（bulk_sync）もPR情報を含むよう改善

## 追加ファイル

| ファイル | 役割 |
|---|---|
| `.github/scripts/github_pr_to_backlog.py` | PR→Backlogコメント同期スクリプト |
| `.github/scripts/patch_backlog_with_pr.py` | 既存未反映PRを手動反映する一時スクリプト |
| `.github/workflows/github-pr-to-backlog.yml` | PR イベント連携ワークフロー |
| `.github/workflows/patch-backlog-with-existing-prs.yml` | 既存PR反映用ワークフロー（一時） |

## Test plan

- [ ] mainにマージ後 `patch-backlog-with-existing-prs` ワークフローを手動実行（SHOKUSU-10にPR #559が反映されることを確認）
- [ ] 新規PRを作成してBacklog課題にコメントが追加されることを確認