### PR TITLE
fix: マイグレーションロールバック安全化と監査ログ復元ワークフローを追加

### DIFF
--- a/.github/workflows/audit-log-restore.yml
+++ b/.github/workflows/audit-log-restore.yml
@@ -1,0 +1,196 @@
+name: 監査ログ復元（バックアップから）
+
+# バックアップダンプファイルに含まれる t_audit_log データを
+# 現在の t_audit_log テーブルへ INSERT IGNORE でインポートします。
+# 既存データ（i_id_audit が重複する行）は上書きされません。
+
+on:
+  workflow_dispatch:
+    inputs:
+      backup_filename:
+        description: |
+          復元元のバックアップファイル名（BACKUP_DIR 配下のファイル名）
+          例: dump_260719.sql  または  pre_rollback_20260719_231100.sql
+        required: true
+        default: 'dump_260719.sql'
+      dry_run:
+        description: |
+          dry_run=true にすると INSERT を実行せず対象行数だけ確認します
+          本番実行前に必ず true で確認してください
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      environment:
+        description: '復元対象環境'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+
+jobs:
+  # ── 本番環境 ──────────────────────────────────────────────────────────────
+  restore-production:
+    name: Restore Audit Log (Production)
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.environment == 'production' }}
+    steps:
+      - name: Restore t_audit_log via SSH
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          password: ${{ secrets.PROD_SSH_PASSWORD }}
+          port: 22
+          timeout: 60s
+          command_timeout: 15m
+          script: |
+            set -euo pipefail
+            BACKUP_DIR="${{ secrets.BACKUP_DIR || '/home/ubuntu/backups/shokusu' }}"
+            DB_CONTAINER="kamakura-shokusu_web_db"
+            DB_USER="${{ secrets.DB_USER }}"
+            DB_PASS="${{ secrets.DB_PASS }}"
+            DB_NAME="shokusu"
+            BACKUP_FILE="${BACKUP_DIR}/${{ github.event.inputs.backup_filename }}"
+            DRY_RUN="${{ github.event.inputs.dry_run }}"
+
+            # ── バックアップファイルの存在確認 ────────────────────────────
+            echo "── Checking backup file ─────────────────────────────────────────"
+            if [ ! -f "$BACKUP_FILE" ]; then
+              echo "::error::バックアップファイルが見つかりません: $BACKUP_FILE"
+              echo "利用可能なバックアップ:"
+              ls -lh "$BACKUP_DIR"/*.sql 2>/dev/null || echo "(なし)"
+              exit 1
+            fi
+            echo "Found: $BACKUP_FILE ($(du -sh "$BACKUP_FILE" | cut -f1))"
+
+            # ── バックアップから t_audit_log の INSERT 文を抽出 ───────────
+            echo "── Extracting t_audit_log INSERT statements ─────────────────────"
+            EXTRACT_FILE="/tmp/t_audit_log_extract_$(date +%Y%m%d_%H%M%S).sql"
+
+            # mysqldump の INSERT INTO `t_audit_log` VALUES (...) を抽出し
+            # INSERT IGNORE INTO に変換（PRIMARY KEY 重複行をスキップ）
+            grep "^INSERT INTO \`t_audit_log\`" "$BACKUP_FILE" \
+              | sed 's/^INSERT INTO `/INSERT IGNORE INTO `/g' \
+              > "$EXTRACT_FILE" || true
+
+            ROW_COUNT=$(wc -l < "$EXTRACT_FILE")
+            echo "抽出された INSERT 文: ${ROW_COUNT} 行"
+
+            if [ "$ROW_COUNT" -eq 0 ]; then
+              echo "::warning::バックアップファイルに t_audit_log のデータが見つかりませんでした。"
+              echo "バックアップ取得時点でテーブルが存在しなかった可能性があります。"
+              exit 0
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "── DRY RUN モード（実際には INSERT しません） ───────────────────"
+              echo "インポート予定の INSERT 文数: ${ROW_COUNT}"
+              echo "本番実行するには dry_run=false で再実行してください。"
+              exit 0
+            fi
+
+            # ── 復元前の現在の件数を確認 ──────────────────────────────────
+            echo "── Current t_audit_log row count (before restore) ───────────────"
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SELECT COUNT(*) AS current_count FROM t_audit_log;"
+
+            # ── バックアップファイルをコンテナへコピーしてインポート ────────
+            echo "── Importing t_audit_log data ───────────────────────────────────"
+            docker cp "$EXTRACT_FILE" "$DB_CONTAINER":/tmp/t_audit_log_restore.sql
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SOURCE /tmp/t_audit_log_restore.sql;"
+
+            # ── 復元後の件数を確認 ────────────────────────────────────────
+            echo "── Current t_audit_log row count (after restore) ────────────────"
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SELECT COUNT(*) AS restored_count FROM t_audit_log;"
+
+            # ── 一時ファイルを削除 ────────────────────────────────────────
+            rm -f "$EXTRACT_FILE"
+            docker exec "$DB_CONTAINER" rm -f /tmp/t_audit_log_restore.sql
+
+            echo "── 監査ログの復元が完了しました ─────────────────────────────────"
+
+  # ── ステージング環境 ──────────────────────────────────────────────────────
+  restore-staging:
+    name: Restore Audit Log (Staging)
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.environment == 'staging' }}
+    steps:
+      - name: Restore t_audit_log via SSH
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.STG_HOST }}
+          username: ${{ secrets.STG_USER }}
+          key: ${{ secrets.STG_SSH_PRIVATE_KEY }}
+          port: 22
+          timeout: 60s
+          command_timeout: 15m
+          script: |
+            set -euo pipefail
+            BACKUP_DIR="/home/ubuntu/backups/shokusu"
+            DB_CONTAINER="stg_db"
+            DB_USER="${{ secrets.STG_DB_USER }}"
+            DB_PASS="${{ secrets.STG_DB_PASS }}"
+            DB_NAME="shokusu"
+            BACKUP_FILE="${BACKUP_DIR}/${{ github.event.inputs.backup_filename }}"
+            DRY_RUN="${{ github.event.inputs.dry_run }}"
+
+            echo "── Checking backup file ─────────────────────────────────────────"
+            if [ ! -f "$BACKUP_FILE" ]; then
+              echo "::error::バックアップファイルが見つかりません: $BACKUP_FILE"
+              echo "利用可能なバックアップ:"
+              ls -lh "$BACKUP_DIR"/*.sql 2>/dev/null || echo "(なし)"
+              exit 1
+            fi
+            echo "Found: $BACKUP_FILE ($(du -sh "$BACKUP_FILE" | cut -f1))"
+
+            echo "── Extracting t_audit_log INSERT statements ─────────────────────"
+            EXTRACT_FILE="/tmp/t_audit_log_extract_$(date +%Y%m%d_%H%M%S).sql"
+            grep "^INSERT INTO \`t_audit_log\`" "$BACKUP_FILE" \
+              | sed 's/^INSERT INTO `/INSERT IGNORE INTO `/g' \
+              > "$EXTRACT_FILE" || true
+
+            ROW_COUNT=$(wc -l < "$EXTRACT_FILE")
+            echo "抽出された INSERT 文: ${ROW_COUNT} 行"
+
+            if [ "$ROW_COUNT" -eq 0 ]; then
+              echo "::warning::バックアップファイルに t_audit_log のデータが見つかりませんでした。"
+              exit 0
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "── DRY RUN モード（実際には INSERT しません） ───────────────────"
+              echo "インポート予定の INSERT 文数: ${ROW_COUNT}"
+              echo "本番実行するには dry_run=false で再実行してください。"
+              exit 0
+            fi
+
+            echo "── Current t_audit_log row count (before restore) ───────────────"
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SELECT COUNT(*) AS current_count FROM t_audit_log;"
+
+            echo "── Importing t_audit_log data ───────────────────────────────────"
+            docker cp "$EXTRACT_FILE" "$DB_CONTAINER":/tmp/t_audit_log_restore.sql
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SOURCE /tmp/t_audit_log_restore.sql;"
+
+            echo "── Current t_audit_log row count (after restore) ────────────────"
+            docker exec "$DB_CONTAINER" \
+              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+              -e "SELECT COUNT(*) AS restored_count FROM t_audit_log;"
+
+            rm -f "$EXTRACT_FILE"
+            docker exec "$DB_CONTAINER" rm -f /tmp/t_audit_log_restore.sql
+
+            echo "── 監査ログの復元が完了しました ─────────────────────────────────"

--- a/.github/workflows/migration-migrate.yml
+++ b/.github/workflows/migration-migrate.yml
@@ -6,11 +6,11 @@ on:
       environment:
         description: '対象環境'
         required: true
-        default: 'production'
+        default: 'staging'
         type: choice
         options:
-          - production
           - staging
+          - production
 
 jobs:
   migrate-production:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.environment == 'production' }}
     steps:
-      - name: Migration Migrate via SSH
+      - name: Pre-migrate backup & Migration Migrate via SSH
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.VPS_HOST }}
@@ -26,10 +26,23 @@ jobs:
           password: ${{ secrets.PROD_SSH_PASSWORD }}
           port: 22
           timeout: 60s
-          command_timeout: 10m
+          command_timeout: 15m
           script: |
             set -euo pipefail
             DEPLOY_PATH="/home/ubuntu/shokusuu1"
+            BACKUP_DIR="${{ secrets.BACKUP_DIR || '/home/ubuntu/backups/shokusu' }}"
+            DB_CONTAINER="kamakura-shokusu_web_db"
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+            # ── ① マイグレーション実行前にフルバックアップを取得 ──────────
+            echo "── Pre-migrate backup ────────────────────────────────────────────"
+            mkdir -p "$BACKUP_DIR"
+            docker exec "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.DB_USER }}" -p"${{ secrets.DB_PASS }}" shokusu \
+              --result-file=/tmp/pre_migrate_${TIMESTAMP}.sql
+            docker cp "$DB_CONTAINER":/tmp/pre_migrate_${TIMESTAMP}.sql \
+              "${BACKUP_DIR}/pre_migrate_${TIMESTAMP}.sql"
+            echo "Backup saved: ${BACKUP_DIR}/pre_migrate_${TIMESTAMP}.sql"
 
             echo "── Migration status before migrate ──────────────────────────────"
             docker compose -f "$DEPLOY_PATH/docker/docker-compose.yml" exec -T kamakura-shokusu_web \
@@ -53,10 +66,10 @@ jobs:
         with:
           host: ${{ secrets.STG_HOST }}
           username: ${{ secrets.STG_USER }}
-          key: ${{ secrets.STG_SSH_KEY }}
+          key: ${{ secrets.STG_SSH_PRIVATE_KEY }}
           port: 22
           timeout: 60s
-          command_timeout: 10m
+          command_timeout: 15m
           script: |
             set -euo pipefail
 

--- a/.github/workflows/migration-rollback.yml
+++ b/.github/workflows/migration-rollback.yml
@@ -4,29 +4,58 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'ロールバック先のマイグレーションバージョン（指定しない場合は1つ戻す）'
+        description: |
+          ★推奨★ ロールバック先のマイグレーションバージョン番号
+          例: 20260601000001
+          （指定した場合は steps は無視されます）
         required: false
         default: ''
       steps:
-        description: 'ロールバックするステップ数（targetが空の場合に使用、デフォルト1）'
+        description: |
+          ロールバックするステップ数（target が空の場合のみ使用）
+          ⚠️ 3 を超える場合は confirm_large_steps に "yes" を入力してください
         required: false
         default: '1'
+      confirm_large_steps:
+        description: 'steps が 3 を超える場合の確認（"yes" と入力してください）'
+        required: false
+        default: ''
       environment:
         description: 'ロールバック対象環境'
         required: true
-        default: 'production'
+        default: 'staging'
         type: choice
         options:
-          - production
           - staging
+          - production
 
 jobs:
+  # ── ガード: steps > 3 かつ confirm なしは即座に失敗 ──────────────────────
+  guard:
+    name: Safety Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate large steps
+        run: |
+          STEPS="${{ github.event.inputs.steps }}"
+          TARGET="${{ github.event.inputs.target }}"
+          CONFIRM="${{ github.event.inputs.confirm_large_steps }}"
+
+          if [ -z "$TARGET" ] && [ "$STEPS" -gt 3 ] && [ "$CONFIRM" != "yes" ]; then
+            echo "::error::steps=$STEPS は 3 を超えています。"
+            echo "::error::confirm_large_steps に \"yes\" を入力して再実行してください。"
+            exit 1
+          fi
+          echo "Safety check passed. target='$TARGET' steps=$STEPS"
+
+  # ── 本番環境 ──────────────────────────────────────────────────────────────
   rollback-production:
     name: Rollback Production DB
     runs-on: ubuntu-latest
+    needs: guard
     if: ${{ github.event.inputs.environment == 'production' }}
     steps:
-      - name: Migration Rollback via SSH
+      - name: Pre-rollback backup & Migration Rollback via SSH
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.VPS_HOST }}
@@ -34,11 +63,25 @@ jobs:
           password: ${{ secrets.PROD_SSH_PASSWORD }}
           port: 22
           timeout: 60s
-          command_timeout: 10m
+          command_timeout: 15m
           script: |
             set -euo pipefail
             DEPLOY_PATH="/home/ubuntu/shokusuu1"
+            BACKUP_DIR="${{ secrets.BACKUP_DIR || '/home/ubuntu/backups/shokusu' }}"
+            DB_CONTAINER="kamakura-shokusu_web_db"
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
+            # ── ① ロールバック前にフルバックアップを取得 ──────────────────
+            echo "── Pre-rollback backup ───────────────────────────────────────────"
+            mkdir -p "$BACKUP_DIR"
+            docker exec "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.DB_USER }}" -p"${{ secrets.DB_PASS }}" shokusu \
+              --result-file=/tmp/pre_rollback_${TIMESTAMP}.sql
+            docker cp "$DB_CONTAINER":/tmp/pre_rollback_${TIMESTAMP}.sql \
+              "${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
+            echo "Backup saved: ${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
+
+            # ── ② ロールバック前のマイグレーション状況を記録 ───────────────
             echo "── Migration status before rollback ─────────────────────────────"
             docker compose -f "$DEPLOY_PATH/docker/docker-compose.yml" exec -T kamakura-shokusu_web \
               php /var/www/html/kamaho-shokusu/bin/cake migrations status
@@ -59,27 +102,44 @@ jobs:
               done
             fi
 
+            # ── ③ ロールバック後の状況確認 ──────────────────────────────────
             echo "── Migration status after rollback ──────────────────────────────"
             docker compose -f "$DEPLOY_PATH/docker/docker-compose.yml" exec -T kamakura-shokusu_web \
               php /var/www/html/kamaho-shokusu/bin/cake migrations status
 
+  # ── ステージング環境 ──────────────────────────────────────────────────────
   rollback-staging:
     name: Rollback Staging DB
     runs-on: ubuntu-latest
+    needs: guard
     if: ${{ github.event.inputs.environment == 'staging' }}
     steps:
-      - name: Migration Rollback via SSH
+      - name: Pre-rollback backup & Migration Rollback via SSH
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.STG_HOST }}
           username: ${{ secrets.STG_USER }}
-          key: ${{ secrets.STG_SSH_KEY }}
+          key: ${{ secrets.STG_SSH_PRIVATE_KEY }}
           port: 22
           timeout: 60s
-          command_timeout: 10m
+          command_timeout: 15m
           script: |
             set -euo pipefail
+            BACKUP_DIR="/home/ubuntu/backups/shokusu"
+            DB_CONTAINER="stg_db"
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
+            # ── ① ロールバック前にフルバックアップを取得 ──────────────────
+            echo "── Pre-rollback backup ───────────────────────────────────────────"
+            mkdir -p "$BACKUP_DIR"
+            docker exec "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.STG_DB_USER }}" -p"${{ secrets.STG_DB_PASS }}" shokusu \
+              --result-file=/tmp/pre_rollback_${TIMESTAMP}.sql
+            docker cp "$DB_CONTAINER":/tmp/pre_rollback_${TIMESTAMP}.sql \
+              "${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
+            echo "Backup saved: ${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
+
+            # ── ② ロールバック前のマイグレーション状況 ──────────────────────
             echo "── Migration status before rollback ─────────────────────────────"
             docker exec stg_web php /var/www/html/kamaho-shokusu/bin/cake migrations status
 


### PR DESCRIPTION
## 概要

監査ログデータ消失（2026-07-19）の再発防止と過去データ復元のためのワークフロー改修です。
テナント関連の変更は含まれていません。

## 変更ファイル

- `.github/workflows/migration-rollback.yml` — 安全ガード追加・事前バックアップ追加
- `.github/workflows/migration-migrate.yml` — 事前バックアップ追加
- `.github/workflows/audit-log-restore.yml` — 新規（バックアップから監査ログを復元）

## 変更詳細

- ロールバック/マイグレーション実行前に自動フルバックアップを取得
- `STEPS > 3` の場合は `confirm_large_steps=yes` が必須（今回の STEPS=12 誤操作を防止）
- デフォルト環境を `production` → `staging` に変更
- `audit-log-restore.yml` でバックアップから `t_audit_log` データのみを `INSERT IGNORE` でインポートできるようにした（`dry_run` モード付き）
- `STG_SSH_KEY` → `STG_SSH_PRIVATE_KEY` に修正

## 関連

- 調査: 2026-07-19 に `STEPS=12` でロールバックを実行した結果、`t_audit_log` が `DROP TABLE` されデータ消失
- PR #581 はテナント関連が混入しているためクローズ予定