### PR TITLE
fix: DirectRegisterMealsUseCase の例外握りつぶしを限定する (#583)

### DIFF
--- a/src_web/kamaho-shokusu/src/Application/UseCase/DirectRegisterMeals/DirectRegisterMealsUseCase.php
+++ b/src_web/kamaho-shokusu/src/Application/UseCase/DirectRegisterMeals/DirectRegisterMealsUseCase.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Application\UseCase\DirectRegisterMeals;
 
+use App\Domain\Exception\ConflictException;
 use App\Domain\Exception\DomainException;
 use App\Service\ReservationWriteService;
 
@@ -20,7 +21,7 @@ final class DirectRegisterMealsUseCase
     ) {}
 
     /**
-     * @throws DomainException 全件失敗など致命的なエラー時
+     * @throws DomainException 権限不足・DB障害など致命的なエラー時
      */
     public function execute(DirectRegisterMealsInput $input): DirectRegisterMealsOutput
     {
@@ -44,7 +45,9 @@ final class DirectRegisterMealsUseCase
                 );
                 $registered[] = $meal;
             } catch (DomainException $e) {
-                // すでに登録済み / バリデーション違反はスキップ扱い
+                if (!$this->isSkippable($e)) {
+                    throw $e;
+                }
                 $skipped[] = $meal;
             }
         }
@@ -53,5 +56,22 @@ final class DirectRegisterMealsUseCase
             registered: $registered,
             skipped:    $skipped,
         );
+    }
+
+    /**
+     * 一括直接登録で個別食事をスキップしてよい例外か判定する。
+     *
+     * 重複登録・昼食/弁当競合のみスキップ対象。権限不足・DB障害・楽観ロック競合は再スロー。
+     */
+    private function isSkippable(DomainException $e): bool
+    {
+        if (!$e instanceof ConflictException) {
+            return false;
+        }
+
+        $message = $e->getMessage();
+
+        return str_contains($message, '昼食と弁当')
+            || str_contains($message, '既に登録');
     }
 }

--- a/src_web/kamaho-shokusu/src/Controller/ReservationDirectRegisterController.php
+++ b/src_web/kamaho-shokusu/src/Controller/ReservationDirectRegisterController.php
@@ -106,9 +106,13 @@ class ReservationDirectRegisterController extends ReservationBaseController
 
             $output = $this->useCase->execute($input);
 
+            $auditContext['registered'] = $output->registered;
+            $auditContext['skipped']    = $output->skipped;
+            $auditResult = empty($output->registered) && !empty($output->skipped) ? 0 : 1;
+
             AuditLogService::record(
                 'reservation', 'direct_register_meals', $loginUserName, $loginUserId,
-                't_reservation_info', "room:{$roomId}", $auditContext, $this->getClientIp(), 1, $loginAccount
+                't_reservation_info', "room:{$roomId}", $auditContext, $this->getClientIp(), $auditResult, $loginAccount
             );
 
             return $this->apiResponseService->success($this->response, [

--- a/src_web/kamaho-shokusu/tests/TestCase/Application/UseCase/DirectRegisterMeals/DirectRegisterMealsUseCaseTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Application/UseCase/DirectRegisterMeals/DirectRegisterMealsUseCaseTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Application\UseCase\DirectRegisterMeals;
+
+use App\Application\UseCase\DirectRegisterMeals\DirectRegisterMealsInput;
+use App\Application\UseCase\DirectRegisterMeals\DirectRegisterMealsUseCase;
+use App\Domain\Exception\ConflictException;
+use App\Domain\Exception\PersistenceException;
+use App\Domain\Exception\UnauthorizedException;
+use App\Service\ReservationWriteService;
+use Cake\TestSuite\TestCase;
+
+/**
+ * DirectRegisterMealsUseCase のテスト。
+ */
+class DirectRegisterMealsUseCaseTest extends TestCase
+{
+    private function createUseCase(ReservationWriteService $writeService): DirectRegisterMealsUseCase
+    {
+        return new DirectRegisterMealsUseCase($writeService);
+    }
+
+    private function createInput(array $meals = [1, 2]): DirectRegisterMealsInput
+    {
+        return new DirectRegisterMealsInput(
+            date:          '2099-06-01',
+            roomId:        1,
+            loginUserId:   10,
+            loginUserName: 'テストユーザー',
+            targetUserId:  10,
+            mealIndices:   $meals,
+        );
+    }
+
+    public function testExecute_registersAllMealsOnSuccess(): void
+    {
+        $writeService = $this->createMock(ReservationWriteService::class);
+        $writeService->expects($this->exactly(2))
+            ->method('processToggle')
+            ->willReturn(['value' => true, 'details' => []]);
+
+        $output = $this->createUseCase($writeService)->execute($this->createInput([1, 2]));
+
+        $this->assertSame([1, 2], $output->registered);
+        $this->assertSame([], $output->skipped);
+    }
+
+    public function testExecute_skipsMealConflictException(): void
+    {
+        $writeService = $this->createMock(ReservationWriteService::class);
+        $writeService->expects($this->exactly(2))
+            ->method('processToggle')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount = ($callCount ?? 0) + 1;
+                if ($callCount === 1) {
+                    return ['value' => true, 'details' => []];
+                }
+                throw new ConflictException('昼食と弁当は同時に予約できません。');
+            });
+
+        $output = $this->createUseCase($writeService)->execute($this->createInput([1, 2]));
+
+        $this->assertSame([1], $output->registered);
+        $this->assertSame([2], $output->skipped);
+    }
+
+    public function testExecute_rethrowsUnauthorizedException(): void
+    {
+        $writeService = $this->createMock(ReservationWriteService::class);
+        $writeService->expects($this->once())
+            ->method('processToggle')
+            ->willThrowException(new UnauthorizedException('他ユーザーの予約を更新する権限がありません。'));
+
+        $this->expectException(UnauthorizedException::class);
+        $this->createUseCase($writeService)->execute($this->createInput([1]));
+    }
+
+    public function testExecute_rethrowsPersistenceException(): void
+    {
+        $writeService = $this->createMock(ReservationWriteService::class);
+        $writeService->expects($this->once())
+            ->method('processToggle')
+            ->willThrowException(new PersistenceException('Internal Server Error'));
+
+        $this->expectException(PersistenceException::class);
+        $this->createUseCase($writeService)->execute($this->createInput([1]));
+    }
+
+    public function testExecute_rethrowsOptimisticLockConflict(): void
+    {
+        $writeService = $this->createMock(ReservationWriteService::class);
+        $writeService->expects($this->once())
+            ->method('processToggle')
+            ->willThrowException(new ConflictException('他の操作と競合しました。画面を再読み込みして再実行してください。'));
+
+        $this->expectException(ConflictException::class);
+        $this->createUseCase($writeService)->execute($this->createInput([1]));
+    }
+}


### PR DESCRIPTION
## Summary
- `DirectRegisterMealsUseCase` でスキップ対象を重複登録・昼食/弁当競合の `ConflictException` のみに限定
- 権限不足・DB障害・楽観ロック競合は再スロー
- 監査ログに `registered` / `skipped` を記録し、全件スキップ時は `result=0`

## Test plan
- [x] `DirectRegisterMealsUseCaseTest` 5件 PASS
- [ ] カレンダー直接登録で部分成功・全スキップ・権限エラーを手動確認

Closes #583

Made with [Cursor](https://cursor.com)