### PR TITLE
fix: processToggle に過去日バリデーションを追加 (#585)

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationWriteService.php
@@ -314,6 +314,12 @@ class ReservationWriteService
         } catch (\Throwable $e) {
             throw new InvalidInputException('Invalid date value.');
         }
+
+        $datePolicy = new ReservationDatePolicy();
+        if ($datePolicy->isPastDate($dateStr)) {
+            throw new InvalidInputException('過去日の予約は変更できません。');
+        }
+
         if (!in_array($meal, [1, 2, 3, 4], true)) {
             throw new InvalidInputException('Invalid meal type (1..4).');
         }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationWriteServiceProcessToggleTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationWriteServiceProcessToggleTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Service;
+
+use App\Domain\Exception\InvalidInputException;
+use App\Service\ReservationWriteService;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ReservationWriteService::processToggle のテスト。
+ */
+class ReservationWriteServiceProcessToggleTest extends TestCase
+{
+    protected array $fixtures = [
+        'app.TIndividualReservationInfo',
+        'app.MRoomInfo',
+        'app.MUserInfo',
+        'app.MUserGroup',
+    ];
+
+    private ReservationWriteService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $reservationTable = TableRegistry::getTableLocator()->get('TIndividualReservationInfo');
+        $userTable        = TableRegistry::getTableLocator()->get('MUserInfo');
+        $roomTable        = TableRegistry::getTableLocator()->get('MRoomInfo');
+
+        $this->service = new ReservationWriteService(
+            $reservationTable,
+            $userTable,
+            $roomTable,
+            '/webroot/'
+        );
+    }
+
+    public function testProcessToggle_rejectsPastDate(): void
+    {
+        $this->expectException(InvalidInputException::class);
+        $this->expectExceptionMessage('過去日の予約は変更できません。');
+
+        $this->service->processToggle(
+            roomId: 1,
+            payload: [
+                'date' => '2020-01-01',
+                'meal' => 1,
+                'value' => 1,
+                'userId' => 1,
+            ],
+            loginUserId: 1,
+            loginUserName: '管理者ユーザー',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `processToggle` で過去日を `InvalidInputException` として拒否

## Test plan
- [x] `ReservationWriteServiceProcessToggleTest` PASS

Closes #585

Made with [Cursor](https://cursor.com)