### PR TITLE
fix: ブロック長の canToggle を Service 層と整合 (#586)

### DIFF
--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -76,6 +76,11 @@ class TReservationInfoPolicy
             return true;
         }
 
+        // ブロック長は同部屋の他ユーザー操作を試みられる（canAccessRoom + サービス層で所属を検証）
+        if ($this->isBlockLeader($user)) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src_web/kamaho-shokusu/tests/TestCase/Policy/TReservationInfoPolicyTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Policy/TReservationInfoPolicyTest.php
@@ -116,6 +116,38 @@ class TReservationInfoPolicyTest extends TestCase
         $this->assertTrue($policy->canCopy($admin, $resource));
         $this->assertFalse($policy->canCopy($nonAdmin, $resource));
     }
+
+    public function testCanToggleBlockLeaderAllowsOtherUserInSameRoom(): void
+    {
+        $policy = new TReservationInfoPolicy(new TestRoomAccessService([10 => [1]]));
+        $identity = new TestIdentity([
+            'i_id_user' => 10,
+            'i_admin' => 2,
+            'i_user_level' => 1,
+        ]);
+
+        $resource = new TReservationInfo();
+        $resource->set('i_id_user', 20, ['guard' => false]);
+        $resource->set('i_id_room', 1, ['guard' => false]);
+
+        $this->assertTrue($policy->canToggle($identity, $resource));
+    }
+
+    public function testCanToggleBlockLeaderDeniedForOtherRoom(): void
+    {
+        $policy = new TReservationInfoPolicy(new TestRoomAccessService([10 => [1]]));
+        $identity = new TestIdentity([
+            'i_id_user' => 10,
+            'i_admin' => 2,
+            'i_user_level' => 1,
+        ]);
+
+        $resource = new TReservationInfo();
+        $resource->set('i_id_user', 20, ['guard' => false]);
+        $resource->set('i_id_room', 3, ['guard' => false]);
+
+        $this->assertFalse($policy->canToggle($identity, $resource));
+    }
 }
 
 class TestRoomAccessService extends RoomAccessService


### PR DESCRIPTION
## Summary
- `canToggle` にブロック長判定を追加（`canAccessRoom` 通過後）

## Test plan
- [x] `TReservationInfoPolicyTest` PASS

Closes #586

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * ブロック長が、同じルーム内の他ユーザーの予約情報を切り替えられるようになりました。
  * 異なるルームの予約情報は、引き続き切り替えできません。

* **テスト**
  * 同一ルーム・別ルームでの権限判定を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->