### PR TITLE
fix: フロントの日付生成をローカルタイムゾーンに統一 (#588)

### DIFF
--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_config.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_config.js
@@ -22,4 +22,18 @@
         roomIds:   cfg.roomIds   || [],
         roomCount: cfg.roomCount || 0
     };
+
+    /**
+     * Date をローカルタイムゾーンの YYYY-MM-DD 文字列に変換する。
+     * toISOString() は UTC のため JST 環境で日付がずれるのを防ぐ。
+     */
+    window.formatLocalYmd = function (d) {
+        if (!d || !(d instanceof Date) || isNaN(d.getTime())) {
+            return '';
+        }
+        var y = d.getFullYear();
+        var m = String(d.getMonth() + 1).padStart(2, '0');
+        var day = String(d.getDate()).padStart(2, '0');
+        return y + '-' + m + '-' + day;
+    };
 })();

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_export.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_export.js
@@ -73,7 +73,12 @@
             }
             default: return;
         }
-        var fmt = function (d) { return d.toISOString().slice(0, 10); };
+        var fmt = window.formatLocalYmd || function (d) {
+            var y = d.getFullYear();
+            var m = String(d.getMonth() + 1).padStart(2, '0');
+            var day = String(d.getDate()).padStart(2, '0');
+            return y + '-' + m + '-' + day;
+        };
         from.value = fmt(s);
         to.value   = fmt(e);
         if (chip) chip.textContent = from.value + ' 〜 ' + to.value;

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1024,7 +1024,7 @@ function openModalById(id){
                     // キーボードフォーカスでセルを選択できるようにする
                     var frame = info.el.querySelector('.fc-daygrid-day-frame') || info.el;
                     frame.setAttribute('tabindex', '0');
-                    var dateStr = info.date.toISOString().slice(0, 10);
+                    var dateStr = window.formatLocalYmd(info.date);
                     var wday = ['日','月','火','水','木','金','土'][info.date.getDay()];
                     var label = y + '年' + (m+1) + '月' + d + '日（' + wday + '）';
                     if (name) label += '（' + name + '）';
@@ -1085,7 +1085,7 @@ function openModalById(id){
                     var unreservedEvents=[];
                     var cur=new Date(fetchInfo.start);
                     while(cur < fetchInfo.end){
-                        var dateStr = cur.toISOString().slice(0,10);
+                        var dateStr = window.formatLocalYmd(cur);
                         if(reservedDates.indexOf(dateStr) === -1){
                             unreservedEvents.push({
                                 title:'未予約', start:dateStr, allDay:true,
@@ -2323,7 +2323,7 @@ document.addEventListener('shown.bs.modal', function(ev) {
 
         const isMonday = (d)=> d.getDay() === 1;
         const isFirst  = (d)=> d.getDate() === 1;
-        const ymd      = (d)=> d.toISOString().slice(0,10);
+        const ymd      = (d)=> window.formatLocalYmd(d);
 
         function parseDate(val){
             if(!val) return null;


### PR DESCRIPTION
## Summary
- `formatLocalYmd()` を `treservation_config.js` に追加
- `treservation_index.js` / `treservation_export.js` の `toISOString()` を置換

## Test plan
- [ ] カレンダー「未予約」表示が正しい日付になること
- [ ] エクスポート期間プリセットの日付がずれないこと

Closes #588

Made with [Cursor](https://cursor.com)