### PR TITLE
test: ポリシーダブル抽出とテストスイート修復 (#591)

### DIFF
--- a/src_web/kamaho-shokusu/tests/TestCase/Controller/TReservationInfoControllerTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Controller/TReservationInfoControllerTest.php
@@ -122,7 +122,7 @@ class TReservationInfoControllerTest extends TestCase
     public function testEvents()
     {
         $this->setAuthenticatedSession();
-        $this->get('/TReservationInfo/events');
+        $this->get('/TReservationInfo/events?start=2026-01-01&end=2026-01-31');
         $this->assertResponseOk();
         $this->assertHeader('Content-Type', 'application/json');
 
@@ -556,9 +556,9 @@ class TReservationInfoControllerTest extends TestCase
     {
         return [
             'index staff allowed' => ['/TReservationInfo/index', false, 0, 200],
-            'events staff allowed' => ['/TReservationInfo/events', false, 0, 200],
+            'events staff allowed' => ['/TReservationInfo/events?start=2026-01-01&end=2026-01-31', false, 0, 200],
             'copy endpoint denied by method as get' => ['/TReservationInfo/copy', true, 0, 405],
-            'events non staff denied' => ['/TReservationInfo/events', false, 1, 403],
+            'events non staff denied' => ['/TReservationInfo/events?start=2026-01-01&end=2026-01-31', false, 1, 403],
             'calendar events non staff denied' => ['/TReservationInfo/calendarEvents?start=2025-01-01&end=2025-01-31', false, 1, 403],
             'all rooms non admin denied' => ['/TReservationInfo/getAllRoomsMealCounts', false, 0, 403],
             'room users other room denied' => ['/TReservationInfo/getUsersByRoom/2', false, 0, 403],

--- a/src_web/kamaho-shokusu/tests/TestCase/Policy/TReservationInfoPolicyTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Policy/TReservationInfoPolicyTest.php
@@ -5,9 +5,6 @@ namespace App\Test\TestCase\Policy;
 
 use App\Model\Entity\TReservationInfo;
 use App\Policy\TReservationInfoPolicy;
-use App\Service\RoomAccessService;
-use Authorization\IdentityInterface;
-use Authorization\Policy\ResultInterface;
 use Cake\TestSuite\TestCase;
 
 class TReservationInfoPolicyTest extends TestCase
@@ -115,82 +112,5 @@ class TReservationInfoPolicyTest extends TestCase
         $resource = new TReservationInfo();
         $this->assertTrue($policy->canCopy($admin, $resource));
         $this->assertFalse($policy->canCopy($nonAdmin, $resource));
-    }
-}
-
-class TestRoomAccessService extends RoomAccessService
-{
-    /**
-     * @param array<int, array<int>> $map
-     * @param array<int, bool> $officeUsers
-     */
-    public function __construct(private array $map, private array $officeUsers = [])
-    {
-    }
-
-    public function getUserRoomIds(int $userId): array
-    {
-        return $this->map[$userId] ?? [];
-    }
-
-    public function isOfficeUser(int $userId): bool
-    {
-        return $this->officeUsers[$userId] ?? false;
-    }
-
-    public function userCanAccessRoom(int $userId, int $roomId): bool
-    {
-
-        return in_array($roomId, $this->getUserRoomIds($userId), true);
-    }
-}
-
-class TestIdentity implements IdentityInterface
-{
-    /**
-     * @param array<string, mixed> $data
-     */
-    public function __construct(private array $data)
-    {
-    }
-
-    public function can(string $action, mixed $resource): bool
-    {
-        return false;
-    }
-
-    public function canResult(string $action, mixed $resource): ResultInterface
-    {
-        throw new \BadMethodCallException('Not used in policy tests.');
-    }
-
-    public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed
-    {
-        return $resource;
-    }
-
-    public function getOriginalData(): \ArrayAccess|array
-    {
-        return $this->data;
-    }
-
-    public function offsetExists(mixed $offset): bool
-    {
-        return isset($this->data[$offset]);
-    }
-
-    public function offsetGet(mixed $offset): mixed
-    {
-        return $this->data[$offset] ?? null;
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): void
-    {
-        $this->data[$offset] = $value;
-    }
-
-    public function offsetUnset(mixed $offset): void
-    {
-        unset($this->data[$offset]);
     }
 }

--- a/src_web/kamaho-shokusu/tests/TestCase/Policy/TestIdentity.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Policy/TestIdentity.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Policy;
+
+use Authorization\IdentityInterface;
+use Authorization\Policy\ResultInterface;
+
+/**
+ * ポリシーテスト用 Identity ダブル。
+ */
+class TestIdentity implements IdentityInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(private array $data)
+    {
+    }
+
+    public function can(string $action, mixed $resource): bool
+    {
+        return false;
+    }
+
+    public function canResult(string $action, mixed $resource): ResultInterface
+    {
+        throw new \BadMethodCallException('Not used in policy tests.');
+    }
+
+    public function applyScope(string $action, mixed $resource, mixed ...$optionalArgs): mixed
+    {
+        return $resource;
+    }
+
+    public function getOriginalData(): \ArrayAccess|array
+    {
+        return $this->data;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->data[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->data[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->data[$offset]);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Policy/TestRoomAccessService.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Policy/TestRoomAccessService.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Policy;
+
+use App\Service\RoomAccessService;
+
+/**
+ * ポリシーテスト用 RoomAccessService ダブル。
+ */
+class TestRoomAccessService extends RoomAccessService
+{
+    /**
+     * @param array<int, array<int>> $map
+     * @param array<int, bool> $officeUsers
+     */
+    public function __construct(private array $map, private array $officeUsers = [])
+    {
+    }
+
+    public function getUserRoomIds(int $userId): array
+    {
+        return $this->map[$userId] ?? [];
+    }
+
+    public function isOfficeUser(int $userId): bool
+    {
+        return $this->officeUsers[$userId] ?? false;
+    }
+
+    public function userCanAccessRoom(int $userId, int $roomId): bool
+    {
+        return in_array($roomId, $this->getUserRoomIds($userId), true);
+    }
+}

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/AuditLogServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/AuditLogServiceTest.php
@@ -29,7 +29,7 @@ class AuditLogServiceTest extends TestCase
 
     private function lastLog(): ?\Cake\Datasource\EntityInterface
     {
-        return $this->table()->find()->order(['i_id_audit' => 'DESC'])->first();
+        return $this->table()->find()->orderBy(['i_id_audit' => 'DESC'])->first();
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `TestRoomAccessService` / `TestIdentity` を PSR-4 準拠の独立ファイルに抽出
- `TReservationInfoVulnerabilityTest` の Class not found を解消
- `events` API テストに必須の `start`/`end` クエリを追加
- `AuditLogServiceTest` の `orderBy()` へ移行

## Test plan
- [x] 全テスト 552件: Errors 67→0、Failures 76→2
- [x] Policy テスト 126件 PASS

残り2件は `AuditLogControllerTest` の actor フィルタ（別途調査）

Closes #591

Made with [Cursor](https://cursor.com)