### PR TITLE
fix: CodeRabbit指摘事項の修正とbranch-check更新（PR #592 対応）

### DIFF
--- a/.github/workflows/audit-log-restore.yml
+++ b/.github/workflows/audit-log-restore.yml
@@ -1,5 +1,8 @@
 name: 監査ログ復元（バックアップから）
 
+permissions:
+  contents: read
+
 # バックアップダンプファイルに含まれる t_audit_log データを
 # 現在の t_audit_log テーブルへ INSERT IGNORE でインポートします。
 # 既存データ（i_id_audit が重複する行）は上書きされません。
@@ -41,6 +44,9 @@ jobs:
     steps:
       - name: Restore t_audit_log via SSH
         uses: appleboy/ssh-action@v1.2.2
+        env:
+          BACKUP_FILENAME: ${{ github.event.inputs.backup_filename }}
+          DRY_RUN_FLAG: ${{ github.event.inputs.dry_run }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.PROD_USER }}
@@ -48,6 +54,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 15m
+          envs: BACKUP_FILENAME,DRY_RUN_FLAG
           script: |
             set -euo pipefail
             BACKUP_DIR="${{ secrets.BACKUP_DIR || '/home/ubuntu/backups/shokusu' }}"
@@ -55,8 +62,8 @@ jobs:
             DB_USER="${{ secrets.DB_USER }}"
             DB_PASS="${{ secrets.DB_PASS }}"
             DB_NAME="shokusu"
-            BACKUP_FILE="${BACKUP_DIR}/${{ github.event.inputs.backup_filename }}"
-            DRY_RUN="${{ github.event.inputs.dry_run }}"
+            BACKUP_FILE="${BACKUP_DIR}/${BACKUP_FILENAME}"
+            DRY_RUN="${DRY_RUN_FLAG}"
 
             # ── バックアップファイルの存在確認 ────────────────────────────
             echo "── Checking backup file ─────────────────────────────────────────"
@@ -96,21 +103,21 @@ jobs:
 
             # ── 復元前の現在の件数を確認 ──────────────────────────────────
             echo "── Current t_audit_log row count (before restore) ───────────────"
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SELECT COUNT(*) AS current_count FROM t_audit_log;"
 
             # ── バックアップファイルをコンテナへコピーしてインポート ────────
             echo "── Importing t_audit_log data ───────────────────────────────────"
             docker cp "$EXTRACT_FILE" "$DB_CONTAINER":/tmp/t_audit_log_restore.sql
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SOURCE /tmp/t_audit_log_restore.sql;"
 
             # ── 復元後の件数を確認 ────────────────────────────────────────
             echo "── Current t_audit_log row count (after restore) ────────────────"
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SELECT COUNT(*) AS restored_count FROM t_audit_log;"
 
             # ── 一時ファイルを削除 ────────────────────────────────────────
@@ -127,6 +134,9 @@ jobs:
     steps:
       - name: Restore t_audit_log via SSH
         uses: appleboy/ssh-action@v1.2.2
+        env:
+          BACKUP_FILENAME: ${{ github.event.inputs.backup_filename }}
+          DRY_RUN_FLAG: ${{ github.event.inputs.dry_run }}
         with:
           host: ${{ secrets.STG_HOST }}
           username: ${{ secrets.STG_USER }}
@@ -134,6 +144,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 15m
+          envs: BACKUP_FILENAME,DRY_RUN_FLAG
           script: |
             set -euo pipefail
             BACKUP_DIR="/home/ubuntu/backups/shokusu"
@@ -141,8 +152,8 @@ jobs:
             DB_USER="${{ secrets.STG_DB_USER }}"
             DB_PASS="${{ secrets.STG_DB_PASS }}"
             DB_NAME="shokusu"
-            BACKUP_FILE="${BACKUP_DIR}/${{ github.event.inputs.backup_filename }}"
-            DRY_RUN="${{ github.event.inputs.dry_run }}"
+            BACKUP_FILE="${BACKUP_DIR}/${BACKUP_FILENAME}"
+            DRY_RUN="${DRY_RUN_FLAG}"
 
             echo "── Checking backup file ─────────────────────────────────────────"
             if [ ! -f "$BACKUP_FILE" ]; then
@@ -175,19 +186,19 @@ jobs:
             fi
 
             echo "── Current t_audit_log row count (before restore) ───────────────"
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SELECT COUNT(*) AS current_count FROM t_audit_log;"
 
             echo "── Importing t_audit_log data ───────────────────────────────────"
             docker cp "$EXTRACT_FILE" "$DB_CONTAINER":/tmp/t_audit_log_restore.sql
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SOURCE /tmp/t_audit_log_restore.sql;"
 
             echo "── Current t_audit_log row count (after restore) ────────────────"
-            docker exec "$DB_CONTAINER" \
-              mysql -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" \
+            docker exec -e MYSQL_PWD="$DB_PASS" "$DB_CONTAINER" \
+              mysql -u "$DB_USER" "$DB_NAME" \
               -e "SELECT COUNT(*) AS restored_count FROM t_audit_log;"
 
             rm -f "$EXTRACT_FILE"

--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -26,8 +26,9 @@ jobs:
         run: |
           if [[ "${{ github.head_ref }}" != feature/* ]] && \
              [[ "${{ github.head_ref }}" != fix/* ]] && \
-             [[ "${{ github.head_ref }}" != hotfix/* ]]; then
-            echo "ERROR: develop へのPRは feature/・fix/・hotfix/ ブランチからのみ許可されています。"
+             [[ "${{ github.head_ref }}" != hotfix/* ]] && \
+             [[ "${{ github.head_ref }}" != main ]]; then
+            echo "ERROR: develop へのPRは feature/・fix/・hotfix/・main ブランチからのみ許可されています。"
             echo "現在のブランチ: ${{ github.head_ref }}"
             exit 1
           fi

--- a/.github/workflows/migration-migrate.yml
+++ b/.github/workflows/migration-migrate.yml
@@ -1,5 +1,8 @@
 name: マイグレーション 適用（緊急用）
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -37,8 +40,8 @@ jobs:
             # ── ① マイグレーション実行前にフルバックアップを取得 ──────────
             echo "── Pre-migrate backup ────────────────────────────────────────────"
             mkdir -p "$BACKUP_DIR"
-            docker exec "$DB_CONTAINER" \
-              mysqldump -u "${{ secrets.DB_USER }}" -p"${{ secrets.DB_PASS }}" shokusu \
+            docker exec -e MYSQL_PWD="${{ secrets.DB_PASS }}" "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.DB_USER }}" shokusu \
               --result-file=/tmp/pre_migrate_${TIMESTAMP}.sql
             docker cp "$DB_CONTAINER":/tmp/pre_migrate_${TIMESTAMP}.sql \
               "${BACKUP_DIR}/pre_migrate_${TIMESTAMP}.sql"
@@ -61,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.environment == 'staging' }}
     steps:
-      - name: Migration Migrate via SSH
+      - name: Pre-migrate backup & Migration Migrate via SSH
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.STG_HOST }}
@@ -72,6 +75,18 @@ jobs:
           command_timeout: 15m
           script: |
             set -euo pipefail
+            BACKUP_DIR="/home/ubuntu/backups/shokusu"
+            DB_CONTAINER="stg_db"
+            TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+            echo "── Pre-migrate backup ────────────────────────────────────────────"
+            mkdir -p "$BACKUP_DIR"
+            docker exec -e MYSQL_PWD="${{ secrets.STG_DB_PASS }}" "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.STG_DB_USER }}" shokusu \
+              --result-file=/tmp/pre_migrate_${TIMESTAMP}.sql
+            docker cp "$DB_CONTAINER":/tmp/pre_migrate_${TIMESTAMP}.sql \
+              "${BACKUP_DIR}/pre_migrate_${TIMESTAMP}.sql"
+            echo "Backup saved: ${BACKUP_DIR}/pre_migrate_${TIMESTAMP}.sql"
 
             echo "── Migration status before migrate ──────────────────────────────"
             docker exec stg_web php /var/www/html/kamaho-shokusu/bin/cake migrations status

--- a/.github/workflows/migration-rollback.yml
+++ b/.github/workflows/migration-rollback.yml
@@ -1,5 +1,8 @@
 name: マイグレーション ロールバック（緊急用）
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -36,11 +39,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate large steps
+        env:
+          STEPS: ${{ github.event.inputs.steps }}
+          TARGET: ${{ github.event.inputs.target }}
+          CONFIRM: ${{ github.event.inputs.confirm_large_steps }}
         run: |
-          STEPS="${{ github.event.inputs.steps }}"
-          TARGET="${{ github.event.inputs.target }}"
-          CONFIRM="${{ github.event.inputs.confirm_large_steps }}"
-
+          set -euo pipefail
+          if ! [[ "$STEPS" =~ ^[0-9]+$ ]]; then
+            echo "::error::steps は数値で入力してください（入力値: $STEPS）"
+            exit 1
+          fi
           if [ -z "$TARGET" ] && [ "$STEPS" -gt 3 ] && [ "$CONFIRM" != "yes" ]; then
             echo "::error::steps=$STEPS は 3 を超えています。"
             echo "::error::confirm_large_steps に \"yes\" を入力して再実行してください。"
@@ -57,6 +65,9 @@ jobs:
     steps:
       - name: Pre-rollback backup & Migration Rollback via SSH
         uses: appleboy/ssh-action@v1.2.2
+        env:
+          TARGET: ${{ github.event.inputs.target }}
+          STEPS: ${{ github.event.inputs.steps }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.PROD_USER }}
@@ -64,6 +75,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 15m
+          envs: TARGET,STEPS
           script: |
             set -euo pipefail
             DEPLOY_PATH="/home/ubuntu/shokusuu1"
@@ -74,8 +86,8 @@ jobs:
             # ── ① ロールバック前にフルバックアップを取得 ──────────────────
             echo "── Pre-rollback backup ───────────────────────────────────────────"
             mkdir -p "$BACKUP_DIR"
-            docker exec "$DB_CONTAINER" \
-              mysqldump -u "${{ secrets.DB_USER }}" -p"${{ secrets.DB_PASS }}" shokusu \
+            docker exec -e MYSQL_PWD="${{ secrets.DB_PASS }}" "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.DB_USER }}" shokusu \
               --result-file=/tmp/pre_rollback_${TIMESTAMP}.sql
             docker cp "$DB_CONTAINER":/tmp/pre_rollback_${TIMESTAMP}.sql \
               "${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
@@ -85,9 +97,6 @@ jobs:
             echo "── Migration status before rollback ─────────────────────────────"
             docker compose -f "$DEPLOY_PATH/docker/docker-compose.yml" exec -T kamakura-shokusu_web \
               php /var/www/html/kamaho-shokusu/bin/cake migrations status
-
-            TARGET="${{ github.event.inputs.target }}"
-            STEPS="${{ github.event.inputs.steps }}"
 
             if [ -n "$TARGET" ]; then
               echo "── Rolling back to version: $TARGET ─────────────────────────────"
@@ -116,6 +125,9 @@ jobs:
     steps:
       - name: Pre-rollback backup & Migration Rollback via SSH
         uses: appleboy/ssh-action@v1.2.2
+        env:
+          TARGET: ${{ github.event.inputs.target }}
+          STEPS: ${{ github.event.inputs.steps }}
         with:
           host: ${{ secrets.STG_HOST }}
           username: ${{ secrets.STG_USER }}
@@ -123,6 +135,7 @@ jobs:
           port: 22
           timeout: 60s
           command_timeout: 15m
+          envs: TARGET,STEPS
           script: |
             set -euo pipefail
             BACKUP_DIR="/home/ubuntu/backups/shokusu"
@@ -132,8 +145,8 @@ jobs:
             # ── ① ロールバック前にフルバックアップを取得 ──────────────────
             echo "── Pre-rollback backup ───────────────────────────────────────────"
             mkdir -p "$BACKUP_DIR"
-            docker exec "$DB_CONTAINER" \
-              mysqldump -u "${{ secrets.STG_DB_USER }}" -p"${{ secrets.STG_DB_PASS }}" shokusu \
+            docker exec -e MYSQL_PWD="${{ secrets.STG_DB_PASS }}" "$DB_CONTAINER" \
+              mysqldump -u "${{ secrets.STG_DB_USER }}" shokusu \
               --result-file=/tmp/pre_rollback_${TIMESTAMP}.sql
             docker cp "$DB_CONTAINER":/tmp/pre_rollback_${TIMESTAMP}.sql \
               "${BACKUP_DIR}/pre_rollback_${TIMESTAMP}.sql"
@@ -142,9 +155,6 @@ jobs:
             # ── ② ロールバック前のマイグレーション状況 ──────────────────────
             echo "── Migration status before rollback ─────────────────────────────"
             docker exec stg_web php /var/www/html/kamaho-shokusu/bin/cake migrations status
-
-            TARGET="${{ github.event.inputs.target }}"
-            STEPS="${{ github.event.inputs.steps }}"
 
             if [ -n "$TARGET" ]; then
               echo "── Rolling back to version: $TARGET ─────────────────────────────"

--- a/src_web/kamaho-shokusu/src/Application.php
+++ b/src_web/kamaho-shokusu/src/Application.php
@@ -118,7 +118,6 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             'resolver' => [
                 'className' => 'Authentication.Orm',
                 'userModel' => 'MUserInfo',
-                'fields'    => ['i_id_user', 'c_login_account', 'c_user_name', 'i_admin', 'i_user_level'],
             ],
             'fields' => [
                 'username' => 'c_login_account',

--- a/src_web/kamaho-shokusu/src/Controller/MMealPriceInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MMealPriceInfoController.php
@@ -190,6 +190,20 @@ class MMealPriceInfoController extends AppController
 
         $monthlyData = $this->mealSummaryExportService->aggregate($year, $month);
 
+        $identity = $this->request->getAttribute('identity');
+        \App\Service\AuditLogService::record(
+            'master',
+            'meal_price_excel_export',
+            $identity?->get('c_user_name') ?? '不明',
+            $identity ? (int)$identity->get('i_id_user') : 0,
+            'm_meal_price_info',
+            null,
+            ['year' => $year, 'month' => $month],
+            $this->getClientIp(),
+            1,
+            (string)($identity?->get('c_login_account') ?? '')
+        );
+
         return $apiResponse->success($this->response, ['rows' => $monthlyData]);
     }
 

--- a/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MRoomTransferScheduleController.php
@@ -111,7 +111,7 @@ class MRoomTransferScheduleController extends AppController
         $rooms = $this->fetchTable('MRoomInfo')->find('list', [
             'keyField'   => 'i_id_room',
             'valueField' => 'c_room_name',
-        ])->toArray();
+        ])->where(['i_del_flg' => 0])->toArray();
 
         $userRoomRows = $this->fetchTable('MUserGroup')->find()
             ->select(['i_id_user', 'i_id_room'])

--- a/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
+++ b/src_web/kamaho-shokusu/src/Controller/MUserInfoController.php
@@ -244,7 +244,7 @@ class MUserInfoController extends AppController
         $rooms = $this->MRoomInfo->find('list', [
             'keyField'   => 'i_id_room',
             'valueField' => 'c_room_name',
-        ])->toArray();
+        ])->where(['i_del_flg' => 0])->toArray();
 
         $ages  = range(1, 80);
         $roles = [0 => '職員', 1 => '児童', 3 => 'その他'];
@@ -295,7 +295,7 @@ class MUserInfoController extends AppController
             }
         }
 
-        $rooms = $this->MRoomInfo->find('list', ['keyField' => 'i_id_room', 'valueField' => 'c_room_name'])->toArray();
+        $rooms = $this->MRoomInfo->find('list', ['keyField' => 'i_id_room', 'valueField' => 'c_room_name'])->where(['i_del_flg' => 0])->toArray();
 
         $selectedRooms = [];
         if (!empty($mUserInfo->m_user_group)) {

--- a/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/ApprovalPolicy.php
@@ -117,28 +117,6 @@ class ApprovalPolicy
         return $this->isAdmin($user) || $this->isBlockLeader($user);
     }
 
-    private function getUserId(?IdentityInterface $user): int
-    {
-        $identity = $this->getOriginalIdentity($user);
-        if ($identity === null) {
-            return 0;
-        }
-
-        if (is_object($identity) && method_exists($identity, 'get')) {
-            return (int)$identity->get('i_id_user');
-        }
-
-        if (is_array($identity)) {
-            return (int)($identity['i_id_user'] ?? 0);
-        }
-
-        if ($identity instanceof \ArrayAccess) {
-            return (int)($identity['i_id_user'] ?? 0);
-        }
-
-        return 0;
-    }
-
     private function getOriginalIdentity(?IdentityInterface $user): object|array|null
     {
         if ($user === null) {

--- a/src_web/kamaho-shokusu/src/Policy/AuditLogPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/AuditLogPolicy.php
@@ -14,11 +14,21 @@ use Authorization\IdentityInterface;
  */
 class AuditLogPolicy
 {
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Controller\AuditLogController $resource
+     * @return bool
+     */
     public function canIndex(?IdentityInterface $user, \App\Controller\AuditLogController $resource): bool
     {
         return $this->isSystemAdmin($user);
     }
 
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Controller\AuditLogController $resource
+     * @return bool
+     */
     public function canExport(?IdentityInterface $user, \App\Controller\AuditLogController $resource): bool
     {
         return $this->isSystemAdmin($user);

--- a/src_web/kamaho-shokusu/src/Policy/MNoticePolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/MNoticePolicy.php
@@ -7,21 +7,41 @@ use Authorization\IdentityInterface;
 
 class MNoticePolicy
 {
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Model\Entity\MNotice $resource
+     * @return bool
+     */
     public function canIndex(?IdentityInterface $user, \App\Model\Entity\MNotice $resource): bool
     {
         return $this->isAdmin($user);
     }
 
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Model\Entity\MNotice $resource
+     * @return bool
+     */
     public function canAdd(?IdentityInterface $user, \App\Model\Entity\MNotice $resource): bool
     {
         return $this->isAdmin($user);
     }
 
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Model\Entity\MNotice $resource
+     * @return bool
+     */
     public function canEdit(?IdentityInterface $user, \App\Model\Entity\MNotice $resource): bool
     {
         return $this->isAdmin($user);
     }
 
+    /**
+     * @param IdentityInterface|null $user
+     * @param \App\Model\Entity\MNotice $resource
+     * @return bool
+     */
     public function canDelete(?IdentityInterface $user, \App\Model\Entity\MNotice $resource): bool
     {
         return $this->isAdmin($user);
@@ -43,6 +63,10 @@ class MNoticePolicy
         }
 
         if (is_array($identity)) {
+            return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
+        }
+
+        if ($identity instanceof \ArrayAccess) {
             return in_array((int)($identity['i_admin'] ?? 0), [1, 3]);
         }
 

--- a/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
+++ b/src_web/kamaho-shokusu/src/Policy/TReservationInfoPolicy.php
@@ -40,7 +40,7 @@ class TReservationInfoPolicy
 
     public function canChangeEdit(?IdentityInterface $user, TReservationInfo $resource): bool
     {
-        return $this->isStaffOrAdmin($user) || $this->isRoomAffiliated($user);
+        return $this->isStaffOrAdmin($user);
     }
 
     public function canToggle(?IdentityInterface $user, TReservationInfo $resource): bool
@@ -319,24 +319,7 @@ class TReservationInfoPolicy
         return $this->isAdmin($user) || $this->isStaff($user);
     }
 
-    private function hasStaffId(?IdentityInterface $user): bool
-    {
-        $identity = $this->getOriginalIdentity($user);
-        if ($identity === null) {
-            return false;
-        }
-
-        $staffId = null;
-        if (is_object($identity) && method_exists($identity, 'get')) {
-            $staffId = $identity->get('i_id_staff');
-        } elseif (is_array($identity) || $identity instanceof \ArrayAccess) {
-            $staffId = $identity['i_id_staff'] ?? null;
-        }
-
-        return $staffId !== null && $staffId !== '' && $staffId !== 0;
-    }
-
-    public function isBlockLeaderOrAdmin(?IdentityInterface $user): bool
+public function isBlockLeaderOrAdmin(?IdentityInterface $user): bool
     {
         return $this->isAdmin($user) || $this->isBlockLeader($user);
     }

--- a/src_web/kamaho-shokusu/tests/TestCase/ApplicationTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/ApplicationTest.php
@@ -20,6 +20,7 @@ use App\Application;
 use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\Middleware\SecurityHeadersMiddleware;
 use Cake\Routing\Middleware\AssetMiddleware;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\TestSuite\IntegrationTestTrait;
@@ -97,10 +98,12 @@ class ApplicationTest extends TestCase
 
         $middleware = $app->middleware($middleware);
 
-        $this->assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->current());
+        $this->assertInstanceOf(SecurityHeadersMiddleware::class, $middleware->current());
         $middleware->seek(1);
-        $this->assertInstanceOf(AssetMiddleware::class, $middleware->current());
+        $this->assertInstanceOf(ErrorHandlerMiddleware::class, $middleware->current());
         $middleware->seek(2);
+        $this->assertInstanceOf(AssetMiddleware::class, $middleware->current());
+        $middleware->seek(3);
         $this->assertInstanceOf(RoutingMiddleware::class, $middleware->current());
     }
 }

--- a/src_web/kamaho-shokusu/tests/schema.php
+++ b/src_web/kamaho-shokusu/tests/schema.php
@@ -188,6 +188,7 @@ return [
             'c_target_table'    => ['type' => 'string', 'length' => 100, 'null' => true],
             'c_target_id'       => ['type' => 'string', 'length' => 255, 'null' => true],
             'i_actor_user_id'   => ['type' => 'integer', 'null' => true],
+            'c_actor_login_id'  => ['type' => 'string', 'length' => 100, 'null' => true],
             'c_actor_user_name' => ['type' => 'string', 'length' => 50,  'null' => false],
             'c_ip_address'      => ['type' => 'string', 'length' => 45,  'null' => true],
             'i_result'          => ['type' => 'boolean', 'null' => false, 'default' => true],


### PR DESCRIPTION
## 概要

PR #592 のブランチチェック失敗の修正と、CodeRabbit が指摘した全課題を対応します。

## branch-check 修正

`main → develop` の同期PRを許可するよう branch-check.yml を更新。

## Critical 修正

- `TReservationInfoPolicy::canChangeEdit()`: 未定義の `isRoomAffiliated()` 呼び出しを除去（実行時500エラーの原因）
- `TReservationInfoPolicy`: 未使用の `hasStaffId()` を削除

## Major 修正

- `tests/schema.php`: `t_audit_log` に `c_actor_login_id` カラムを追加（Migration 20260713000001 との整合性）
- `Application.php`: `resolver` 内の無効な `fields` キーを削除
- `MMealPriceInfoController::exportMealSummary()`: 監査ログ記録（`AuditLogService::record()`）を復元
- `migration-migrate.yml`: ステージング側にマイグレーション前の自動バックアップを追加（本番との非対称解消）

## セキュリティ修正

- 3ワークフローに `permissions: contents: read` を追加（最小権限）
- `mysqldump`/`mysql` の `-p` フラグを `MYSQL_PWD` 環境変数経由に変更（プロセスリスト漏洩防止）
- `audit-log-restore.yml` / `migration-rollback.yml`: `workflow_dispatch` 入力を `envs` 経由に変更（コマンドインジェクション対策）
- `migration-rollback.yml` guard ジョブ: `set -euo pipefail` と `steps` 数値バリデーションを追加

## データ品質修正

- `MRoomTransferScheduleController` / `MUserInfoController`: rooms クエリに `i_del_flg = 0` フィルター追加（削除済み部屋が選択肢に出る問題を修正）

## コード品質修正

- `MNoticePolicy::isAdmin()`: `ArrayAccess` ブランチを追加
- `ApplicationTest`: `SecurityHeadersMiddleware` 追加に合わせてミドルウェア順序のアサーションを修正
- `ApprovalPolicy`: 未使用の `getUserId()` を削除
- `AuditLogPolicy` / `MNoticePolicy`: 公開メソッドに PHPDoc を追加