### PR TITLE
chore: Backlogブランチ到達ステータス同期を release に反映

### DIFF
--- a/.github/scripts/backlog_branch_status.py
+++ b/.github/scripts/backlog_branch_status.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+ブランチ到達に応じて Backlog 課題ステータスを更新する。
+
+- develop 到達 → ステージング反映済み
+- release 到達 → リリース待ち
+- main 到達    → 完了
+
+トリガー想定:
+  - develop / release / main 向け PR の merge
+  - 同ブランチへの push（コミットメッセージから課題キーを抽出）
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from backlog_client import (  # noqa: E402
+    bl_request,
+    get_status_id,
+    load_backlog_env,
+    resolve_bl_base,
+)
+from sync_utils import extract_backlog_key, get_gh_repo, get_gh_token, gh_request  # noqa: E402
+
+CLOSING_PATTERN = re.compile(
+    r"(?:closes?|fixes?|resolves?)\s+#(\d+)",
+    re.IGNORECASE,
+)
+ISSUE_REF_PATTERN = re.compile(r"(?<![A-Za-z0-9_-])#(\d+)\b")
+
+# 進行方向のみ進める（降格しない）
+STATUS_RANK = {
+    "ステージング反映済み": 1,
+    "リリース待ち": 2,
+    "完了": 3,
+}
+
+
+def branch_to_status_name(branch: str) -> str | None:
+    mapping = {
+        "develop": os.environ.get("BACKLOG_STATUS_ON_DEVELOP", "ステージング反映済み"),
+        "release": os.environ.get("BACKLOG_STATUS_ON_RELEASE", "リリース待ち"),
+        "main": os.environ.get("BACKLOG_STATUS_ON_MAIN", "完了"),
+    }
+    return mapping.get(branch)
+
+
+def find_issue_numbers(*texts: str) -> list[int]:
+    found: list[int] = []
+    for text in texts:
+        if not text:
+            continue
+        for m in CLOSING_PATTERN.finditer(text):
+            found.append(int(m.group(1)))
+        # Closes 以外の素の #N もコミットメッセージ向けに拾う（PR番号誤検知を減らすため closes 優先）
+        if not CLOSING_PATTERN.search(text):
+            for m in ISSUE_REF_PATTERN.finditer(text):
+                found.append(int(m.group(1)))
+    # 順序維持で重複除去
+    seen: set[int] = set()
+    out: list[int] = []
+    for n in found:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def find_backlog_keys_in_text(project_key: str, *texts: str) -> list[str]:
+    keys: list[str] = []
+    pattern = re.compile(rf"\b({re.escape(project_key)}-\d+)\b", re.IGNORECASE)
+    for text in texts:
+        if not text:
+            continue
+        marker_key = extract_backlog_key(text, project_key)
+        if marker_key:
+            keys.append(marker_key)
+        for m in pattern.finditer(text):
+            keys.append(m.group(1))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for key in keys:
+        m = re.match(rf"^({re.escape(project_key)})-(\d+)$", key, re.IGNORECASE)
+        if not m:
+            continue
+        nk = f"{project_key}-{m.group(2)}"
+        if nk not in seen:
+            seen.add(nk)
+            normalized.append(nk)
+    return normalized
+
+
+def get_backlog_key_from_issue(token: str, repo: str, issue_number: int, project_key: str) -> str | None:
+    issue = gh_request(token, "GET", f"/repos/{repo}/issues/{issue_number}")
+    if not issue:
+        return None
+    title = issue.get("title", "") or ""
+    body = issue.get("body", "") or ""
+    return extract_backlog_key(title + "\n" + body, project_key)
+
+
+def collect_keys_from_pr(
+    token: str,
+    repo: str,
+    project_key: str,
+    pr_number: int,
+    pr_title: str,
+    pr_body: str,
+) -> set[str]:
+    keys = set(find_backlog_keys_in_text(project_key, pr_title, pr_body))
+
+    for iss_num in find_issue_numbers(pr_title, pr_body):
+        key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
+        if key:
+            keys.add(key)
+            print(f"  PR #{pr_number} Issue #{iss_num} → {key}")
+        else:
+            print(f"  PR #{pr_number} Issue #{iss_num} に Backlog キーなし")
+
+    commits = gh_request(token, "GET", f"/repos/{repo}/pulls/{pr_number}/commits?per_page=100") or []
+    for commit in commits:
+        message = (commit.get("commit") or {}).get("message", "") or ""
+        keys.update(find_backlog_keys_in_text(project_key, message))
+        for iss_num in find_issue_numbers(message):
+            key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
+            if key:
+                keys.add(key)
+
+    return keys
+
+
+def collect_keys_from_push(token: str, repo: str, project_key: str, commits_json: str) -> set[str]:
+    import json
+
+    keys: set[str] = set()
+    try:
+        commits = json.loads(commits_json or "[]")
+    except json.JSONDecodeError:
+        print("[WARN] GH_PUSH_COMMITS の JSON 解析に失敗しました")
+        commits = []
+
+    for commit in commits:
+        message = commit.get("message", "") or ""
+        keys.update(find_backlog_keys_in_text(project_key, message))
+        for iss_num in find_issue_numbers(message):
+            key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
+            if key:
+                keys.add(key)
+                print(f"  commit Issue #{iss_num} → {key}")
+    return keys
+
+
+def current_status_name(base: str, api_key: str, backlog_key: str) -> str | None:
+    issue = bl_request(base, api_key, "GET", f"/issues/{backlog_key}", fatal=False)
+    if not issue:
+        return None
+    return (issue.get("status") or {}).get("name")
+
+
+def should_update(current: str | None, target: str) -> bool:
+    if current is None:
+        return True
+    if current == target:
+        return False
+    cur_rank = STATUS_RANK.get(current, 0)
+    tgt_rank = STATUS_RANK.get(target, 0)
+    # 既知の進行ステータス同士は降格しない。未知ステータスからは昇格可能。
+    if cur_rank and tgt_rank and tgt_rank < cur_rank:
+        print(f"  降格のためスキップ: {current} → {target}")
+        return False
+    return True
+
+
+def update_status(
+    base: str,
+    api_key: str,
+    project_key: str,
+    backlog_key: str,
+    target_status: str,
+    branch: str,
+    source: str,
+) -> bool:
+    status_id = get_status_id(base, api_key, project_key, target_status, fatal=False)
+    if status_id is None:
+        return False
+
+    current = current_status_name(base, api_key, backlog_key)
+    if not should_update(current, target_status):
+        print(f"  [{backlog_key}] 変更なし ({current})")
+        return False
+
+    result = bl_request(
+        base,
+        api_key,
+        "PATCH",
+        f"/issues/{backlog_key}",
+        {"statusId": status_id},
+        fatal=False,
+    )
+    if not result:
+        print(f"  [{backlog_key}] ステータス更新失敗")
+        return False
+
+    comment = (
+        f"<!-- github-branch-status:{branch} -->\n\n"
+        f"GitHub ブランチ `{branch}` に到達したため、ステータスを「{target_status}」に更新しました。\n"
+        f"- トリガー: {source}\n"
+        f"- 以前のステータス: {current or '(不明)'}"
+    )
+    bl_request(
+        base,
+        api_key,
+        "POST",
+        f"/issues/{backlog_key}/comments",
+        {"content": comment},
+        fatal=False,
+    )
+    print(f"  [{backlog_key}] {current} → {target_status}")
+    return True
+
+
+def main() -> None:
+    api_key, space_id, project_key, domain = load_backlog_env()
+    base = resolve_bl_base(space_id, domain)
+    token = get_gh_token()
+    repo = get_gh_repo()
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    branch = os.environ.get("GH_TARGET_BRANCH", "").strip()
+    pr_merged = os.environ.get("GH_PR_MERGED", "false").lower() == "true"
+    pr_number = int(os.environ.get("GH_PR_NUMBER", "0") or "0")
+    pr_title = os.environ.get("GH_PR_TITLE", "")
+    pr_body = os.environ.get("GH_PR_BODY", "")
+    push_commits = os.environ.get("GH_PUSH_COMMITS", "[]")
+
+    if not branch:
+        print("[ERROR] GH_TARGET_BRANCH が未設定です")
+        sys.exit(1)
+
+    target_status = branch_to_status_name(branch)
+    if not target_status:
+        print(f"対象外ブランチのためスキップ: {branch}")
+        return
+
+    print(f"イベント={event_name} branch={branch} → status={target_status}")
+
+    keys: set[str] = set()
+    source = event_name
+
+    if event_name == "pull_request":
+        if not pr_merged:
+            print("未マージの PR のためスキップします")
+            return
+        if pr_number <= 0:
+            print("[ERROR] PR番号が取得できません")
+            sys.exit(1)
+        source = f"PR #{pr_number} merge → {branch}"
+        keys = collect_keys_from_pr(token, repo, project_key, pr_number, pr_title, pr_body)
+    elif event_name == "push":
+        source = f"push → {branch}"
+        keys = collect_keys_from_push(token, repo, project_key, push_commits)
+    else:
+        # workflow_dispatch 等: PR番号があれば PR 基準、なければ push commits
+        if pr_number > 0:
+            source = f"manual PR #{pr_number} → {branch}"
+            keys = collect_keys_from_pr(token, repo, project_key, pr_number, pr_title, pr_body)
+        else:
+            source = f"manual → {branch}"
+            keys = collect_keys_from_push(token, repo, project_key, push_commits)
+
+    if not keys:
+        print("紐づく Backlog 課題が見つかりませんでした。スキップします")
+        return
+
+    print(f"更新対象: {', '.join(sorted(keys))}")
+    updated = 0
+    for key in sorted(keys):
+        if update_status(base, api_key, project_key, key, target_status, branch, source):
+            updated += 1
+    print(f"完了: updated={updated}/{len(keys)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/backlog_client.py
+++ b/.github/scripts/backlog_client.py
@@ -112,3 +112,30 @@ def bl_request(
             return None
 
     return None
+
+
+def get_project_statuses(base: str, api_key: str, project_key: str) -> list[dict]:
+    """プロジェクトのステータス一覧を返す。"""
+    statuses = bl_request(base, api_key, "GET", f"/projects/{project_key}/statuses", fatal=False)
+    return statuses or []
+
+
+def get_status_id(
+    base: str,
+    api_key: str,
+    project_key: str,
+    status_name: str,
+    *,
+    fatal: bool = True,
+) -> int | None:
+    """ステータス名から ID を解決する。見つからない場合は None（fatal なら exit）。"""
+    statuses = get_project_statuses(base, api_key, project_key)
+    for s in statuses:
+        if s.get("name") == status_name:
+            return int(s["id"])
+
+    available = ", ".join(f"{s.get('name')}(id={s.get('id')})" for s in statuses) or "(取得失敗)"
+    print(f"[ERROR] ステータス「{status_name}」が見つかりません。利用可能: {available}")
+    if fatal:
+        sys.exit(1)
+    return None

--- a/.github/scripts/backlog_to_github.py
+++ b/.github/scripts/backlog_to_github.py
@@ -84,9 +84,16 @@ def is_github_origin(description: str) -> bool:
 
 
 def backlog_status_to_gh_state(status_name: str) -> str:
-    """Backlogステータス名 → GitHub Issue状態。"""
-    closed_names = {"完了", "resolved", "closed", "done", "完了済み"}
-    return "closed" if status_name.lower() in {s.lower() for s in closed_names} else "open"
+    """Backlogステータス名 → GitHub Issue状態。
+
+    コード反映後のステータス（ステージング反映済み / リリース待ち / 完了）は
+    GitHub Issue を閉じたままにする（再オープン防止）。
+    """
+    open_names = {"未対応", "処理中", "処理済み", "open", "in progress", "todo", "doing"}
+    name = (status_name or "").strip()
+    if name.lower() in {s.lower() for s in open_names}:
+        return "open"
+    return "closed"
 
 
 def create_github_issue(token: str, repo: str, backlog_key: str, title: str, description: str, space_id: str, domain: str) -> dict | None:

--- a/.github/scripts/github_to_backlog.py
+++ b/.github/scripts/github_to_backlog.py
@@ -4,7 +4,7 @@ GitHub Issue → Backlog課題 同期スクリプト
 
 - opened:   Backlog課題を新規作成（Backlog起源Issueはスキップ）
 - edited:   Backlog課題タイトル・説明を更新
-- closed:   Backlog課題を完了に
+- closed:   ステータスは変更しない（完了は main 到達時に更新）
 - reopened: Backlog課題を未対応に
 """
 
@@ -14,7 +14,7 @@ import re
 import json
 
 sys.path.insert(0, os.path.dirname(__file__))
-from backlog_client import load_backlog_env, resolve_bl_base, bl_request
+from backlog_client import load_backlog_env, resolve_bl_base, bl_request, get_status_id
 from sync_utils import get_gh_token, get_gh_repo, gh_request, extract_backlog_key, is_backlog_synced, update_sync_section
 
 
@@ -30,16 +30,6 @@ def get_issue_type_id(base: str, api_key: str, project_key: str) -> int:
             return t["id"]
     print(f"課題種別を使用: {types[0]['name']} (id={types[0]['id']})")
     return types[0]["id"]
-
-
-def get_status_id(base: str, api_key: str, project_key: str, status_name: str) -> int:
-    statuses = bl_request(base, api_key, "GET", f"/projects/{project_key}/statuses")
-    if statuses:
-        for s in statuses:
-            if s.get("name") == status_name:
-                return s["id"]
-    # フォールバック
-    return 1 if status_name == "未対応" else 4
 
 
 def create_backlog_issue(base: str, api_key: str, project_id: int, issue_type_id: int,
@@ -164,14 +154,39 @@ def main():
         else:
             print(f"差分なし。更新をスキップしました: {backlog_key}")
 
-    elif event_action in ("closed", "reopened"):
+    elif event_action == "closed":
         backlog_key = extract_backlog_key(issue_body, project_key)
         if not backlog_key:
             print(f"Issue #{issue_number} にBacklog課題キーがありません。スキップします")
             return
 
-        status_name = "完了" if event_action == "closed" else "未対応"
-        status_id   = get_status_id(base, api_key, project_key, status_name)
+        # 完了ステータスは main 到達時（backlog_branch_status）で更新する。
+        # ここで完了にすると develop マージ直後に「ステージング反映済み」と競合する。
+        github_issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+        comment_body = (
+            f"GitHub Issue #{issue_number} がクローズされました。\n\n"
+            f"- 更新者: @{issue_user}\n"
+            f"- GitHub Issue: {github_issue_url}\n"
+            f"- 備考: Backlogステータスはブランチ到達（develop/release/main）で自動更新します。"
+        )
+        bl_request(
+            base,
+            api_key,
+            "POST",
+            f"/issues/{backlog_key}/comments",
+            {"content": comment_body},
+            fatal=False,
+        )
+        print(f"Issueクローズをコメント通知しました（ステータス変更なし）: {backlog_key}")
+
+    elif event_action == "reopened":
+        backlog_key = extract_backlog_key(issue_body, project_key)
+        if not backlog_key:
+            print(f"Issue #{issue_number} にBacklog課題キーがありません。スキップします")
+            return
+
+        status_name = "未対応"
+        status_id = get_status_id(base, api_key, project_key, status_name)
         bl_request(base, api_key, "PATCH", f"/issues/{backlog_key}", {"statusId": status_id})
         print(f"Backlog課題のステータスを更新しました: {backlog_key} → {status_name}")
 

--- a/.github/workflows/backlog-branch-status.yml
+++ b/.github/workflows/backlog-branch-status.yml
@@ -1,0 +1,124 @@
+name: Backlog ブランチ到達ステータス更新
+
+# develop → ステージング反映済み
+# release → リリース待ち
+# main    → 完了
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop, release, main]
+  push:
+    branches: [develop, release, main]
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "対象ブランチ (develop / release / main)"
+        required: true
+        type: choice
+        options: [develop, release, main]
+      pr_number:
+        description: "任意: 対象PR番号（指定時はそのPRから課題を抽出）"
+        required: false
+        type: string
+
+concurrency:
+  group: backlog-branch-status-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+  GH_REPO: ${{ github.repository }}
+  BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+  BACKLOG_SPACE_ID: ${{ secrets.BACKLOG_SPACE_ID }}
+  BACKLOG_PROJECT_KEY: ${{ secrets.BACKLOG_PROJECT_KEY }}
+  BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }}
+  BACKLOG_STATUS_ON_DEVELOP: ${{ vars.BACKLOG_STATUS_ON_DEVELOP || 'ステージング反映済み' }}
+  BACKLOG_STATUS_ON_RELEASE: ${{ vars.BACKLOG_STATUS_ON_RELEASE || 'リリース待ち' }}
+  BACKLOG_STATUS_ON_MAIN: ${{ vars.BACKLOG_STATUS_ON_MAIN || '完了' }}
+
+jobs:
+  update-status:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 対象ブランチとPR情報を環境変数へ
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const eventName = context.eventName;
+            let branch = '';
+            let prNumber = '';
+            let prTitle = '';
+            let prBody = '';
+            let prMerged = 'false';
+            let pushCommits = '[]';
+
+            if (eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              branch = pr.base.ref;
+              prNumber = String(pr.number);
+              prTitle = pr.title || '';
+              prBody = pr.body || '';
+              prMerged = String(pr.merged === true);
+            } else if (eventName === 'push') {
+              branch = context.ref.replace(/^refs\/heads\//, '');
+              pushCommits = JSON.stringify(
+                (context.payload.commits || []).map((c) => ({
+                  id: c.id,
+                  message: c.message || '',
+                }))
+              );
+            } else if (eventName === 'workflow_dispatch') {
+              branch = context.payload.inputs.target_branch;
+              prNumber = context.payload.inputs.pr_number || '';
+            }
+
+            const out = process.env.GITHUB_ENV;
+            fs.appendFileSync(out, `GH_TARGET_BRANCH=${branch}\n`);
+            fs.appendFileSync(out, `GH_PR_NUMBER=${prNumber}\n`);
+            fs.appendFileSync(out, `GH_PR_MERGED=${prMerged}\n`);
+            // multiline env for title/body/commits
+            const writeMultiline = (key, value) => {
+              fs.appendFileSync(out, `${key}<<EOF\n${value}\nEOF\n`);
+            };
+            writeMultiline('GH_PR_TITLE', prTitle);
+            writeMultiline('GH_PR_BODY', prBody);
+            writeMultiline('GH_PUSH_COMMITS', pushCommits);
+            core.info(`branch=${branch} pr=${prNumber || '-'} merged=${prMerged}`);
+
+      - name: 手動実行時に PR 情報を取得
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
+        env:
+          GH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          pr="$(gh api "repos/${GH_REPO}/pulls/${GH_PR_NUMBER}")"
+          title="$(printf '%s' "$pr" | python -c 'import json,sys; print(json.load(sys.stdin).get("title") or "")')"
+          body="$(printf '%s' "$pr" | python -c 'import json,sys; print(json.load(sys.stdin).get("body") or "")')"
+          {
+            echo "GH_PR_NUMBER=${GH_PR_NUMBER}"
+            echo "GH_PR_MERGED=true"
+            echo "GH_PR_TITLE<<EOF"
+            echo "$title"
+            echo "EOF"
+            echo "GH_PR_BODY<<EOF"
+            echo "$body"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Backlog ステータス更新
+        run: python .github/scripts/backlog_branch_status.py

--- a/docs/backlog-github-sync.md
+++ b/docs/backlog-github-sync.md
@@ -9,6 +9,7 @@ BacklogとGitHub Issueを双方向に自動同期する仕組みです。
 | Backlog → GitHub | 15分ごとのスケジュール | Backlog課題の作成・更新・完了をGitHub Issueへ反映 |
 | GitHub → Backlog | Issue イベント | GitHub Issueの作成・編集・クローズ・再オープンをBacklog課題へ反映 |
 | GitHub → Backlog | Issue Comment イベント | GitHub IssueへのコメントをBacklogコメントへ反映 |
+| GitHub → Backlog | develop / release / main 到達 | ブランチ到達に応じて Backlog ステータスを更新 |
 
 ---
 
@@ -21,11 +22,13 @@ BacklogとGitHub Issueを双方向に自動同期する仕組みです。
 │   ├── sync_utils.py                  # GitHub API共通ユーティリティ
 │   ├── backlog_to_github.py           # Backlog → GitHub 同期スクリプト
 │   ├── github_to_backlog.py           # GitHub → Backlog 同期スクリプト
-│   └── github_comment_to_backlog.py   # GitHub コメント → Backlog 同期スクリプト
+│   ├── github_comment_to_backlog.py   # GitHub コメント → Backlog 同期スクリプト
+│   └── backlog_branch_status.py      # ブランチ到達 → Backlog ステータス更新
 └── workflows/
     ├── backlog-to-github-issue.yml         # Backlog → GitHub ワークフロー
     ├── github-issue-to-backlog.yml         # GitHub → Backlog ワークフロー
-    └── github-issue-comment-to-backlog.yml # コメント同期ワークフロー
+    ├── github-issue-comment-to-backlog.yml # コメント同期ワークフロー
+    └── backlog-branch-status.yml          # ブランチ到達ステータス更新
 ```
 
 ---
@@ -50,6 +53,18 @@ gh secret set BACKLOG_API_KEY --body "取得したAPIキー" --repo kamaho-sourc
 
 または GitHub リポジトリの Settings → Secrets and variables → Actions から手動登録。
 
+### 任意の Repository Variables（ステータス名上書き）
+
+Backlog 側のステータス名が異なる場合に設定します（未設定時は下記デフォルト）。
+
+| Variable | デフォルト |
+|----------|------------|
+| `BACKLOG_STATUS_ON_DEVELOP` | `ステージング反映済み` |
+| `BACKLOG_STATUS_ON_RELEASE` | `リリース待ち` |
+| `BACKLOG_STATUS_ON_MAIN` | `完了` |
+
+**前提:** Backlog プロジェクトに上記ステータスが存在すること。無い場合はプロジェクト設定で追加してください。
+
 ---
 
 ## 動作仕様
@@ -60,15 +75,35 @@ gh secret set BACKLOG_API_KEY --body "取得したAPIキー" --repo kamaho-sourc
 - 指定分数前（デフォルト: 20分）から更新されたBacklog課題を取得
 - **重複防止**: タイトルの `[SHOKUSU-XXX]` プレフィックスとbody内のHTMLコメントマーカーで既存Issueを検索
 - **無限ループ防止**: `GitHub Issue: https://github.com/` が説明に含まれる課題はGitHub起源と判断し、新規作成をスキップ（ステータス変更のみ反映）
-- Backlogの「完了」ステータス → GitHub Issueのcloseに反映
+- Backlogの「完了」およびコード反映後ステータス → GitHub Issueのcloseに反映（再オープン防止）
 
 ### GitHub Issue → Backlog課題 同期 (`github-issue-to-backlog.yml`)
 
 - `opened`: 新規Backlog課題を作成。GitHub IssueのタイトルとbodyをBacklog課題に反映。GitHub Issue側にBacklog課題キーを追記
 - `edited`: Backlog課題のタイトル・説明を更新。差分がある場合のみBacklogにコメントを追加
-- `closed`: Backlog課題のステータスを「完了」に変更
+- `closed`: Backlogへクローズ通知コメントのみ（**ステータスは変更しない**）
 - `reopened`: Backlog課題のステータスを「未対応」に変更
 - **無限ループ防止**: `<!-- backlog-synced -->` マーカーが含まれるIssueはBacklog起源として新規作成をスキップ
+
+### ブランチ到達 → Backlogステータス更新 (`backlog-branch-status.yml`)
+
+| 到達ブランチ | Backlogステータス |
+|--------------|-------------------|
+| `develop` | ステージング反映済み |
+| `release` | リリース待ち |
+| `main` | 完了 |
+
+- develop / release / main 向け PR の **merge**、または同ブランチへの **push** で発火
+- PRタイトル・本文・コミットメッセージから `SHOKUSU-N` / `Closes #N` を抽出し、紐づく課題を更新
+- 進行方向のみ更新（例: 完了 → ステージング反映済み への降格はしない）
+- 手動実行（`workflow_dispatch`）も可能
+
+```bash
+gh workflow run backlog-branch-status.yml \
+  --repo kamaho-source/shokusuu1 \
+  -f target_branch=develop \
+  -f pr_number=593
+```
 
 ### GitHub コメント → Backlogコメント同期 (`github-issue-comment-to-backlog.yml`)
 
@@ -86,6 +121,7 @@ gh secret set BACKLOG_API_KEY --body "取得したAPIキー" --repo kamaho-sourc
 | `<!-- backlog-key:SHOKUSU-XXX -->` | GitHub Issue body | 対応するBacklog課題キーを保持 |
 | `<!-- github-sync:start -->` / `<!-- github-sync:end -->` | Backlog課題説明 | GitHub同期範囲を区切る |
 | `<!-- github-comment-id:XXX -->` | Backlogコメント | 同期済みGitHubコメントIDを保持（重複防止） |
+| `<!-- github-branch-status:BRANCH -->` | Backlogコメント | ブランチ到達によるステータス更新の痕跡 |
 
 ---
 
@@ -116,6 +152,14 @@ gh workflow run backlog-to-github-issue.yml \
 - Secretの値に前後の空白や改行が含まれていないか
 - `BACKLOG_SPACE_ID` が `kamaho` になっているか
 - `BACKLOG_DOMAIN` が `backlog.com` になっているか
+
+### ステータス名が見つからない
+
+```
+[ERROR] ステータス「ステージング反映済み」が見つかりません
+```
+
+Backlog プロジェクト設定でステータスを追加するか、Repository Variables で実在する名前に合わせてください。
 
 ### 同期が止まっている場合
 


### PR DESCRIPTION
## Summary
- main に先行投入した Backlog ブランチ到達ステータス自動更新を release へ同期する
- develop→ステージング反映済み / release→リリース待ち / main→完了

## Note
main には既に反映済み。この PR は後から merge する想定の draft。

## Test plan
- [ ] Backlog に対象ステータスが存在することを確認
- [ ] release 向け PR merge でステータス更新ワークフローが動くこと

Made with [Cursor](https://cursor.com)