### PR TITLE
feat: main 到達時に GitHub Issue を close

### DIFF
--- a/.github/scripts/backlog_branch_status.py
+++ b/.github/scripts/backlog_branch_status.py
@@ -2,9 +2,9 @@
 """
 ブランチ到達に応じて Backlog 課題ステータスを更新する。
 
-- develop 到達 → ステージング反映済み
-- release 到達 → リリース待ち
-- main 到達    → 完了
+- develop 到達 → ステージング反映済み（GitHub Issue は open のまま）
+- release 到達 → リリース待ち（GitHub Issue は open のまま）
+- main 到達    → 完了 + 紐づく GitHub Issue を close
 
 トリガー想定:
   - develop / release / main 向け PR の merge
@@ -24,7 +24,14 @@ from backlog_client import (  # noqa: E402
     load_backlog_env,
     resolve_bl_base,
 )
-from sync_utils import extract_backlog_key, get_gh_repo, get_gh_token, gh_request  # noqa: E402
+from sync_utils import (  # noqa: E402
+    close_github_issue,
+    extract_backlog_key,
+    find_github_issue_by_backlog_key,
+    get_gh_repo,
+    get_gh_token,
+    gh_request,
+)
 
 CLOSING_PATTERN = re.compile(
     r"(?:closes?|fixes?|resolves?)\s+#(\d+)",
@@ -111,33 +118,41 @@ def collect_keys_from_pr(
     pr_number: int,
     pr_title: str,
     pr_body: str,
-) -> set[str]:
+) -> tuple[set[str], set[int]]:
     keys = set(find_backlog_keys_in_text(project_key, pr_title, pr_body))
+    issue_numbers = set(find_issue_numbers(pr_title, pr_body))
 
-    for iss_num in find_issue_numbers(pr_title, pr_body):
+    for iss_num in list(issue_numbers):
         key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
         if key:
             keys.add(key)
             print(f"  PR #{pr_number} Issue #{iss_num} → {key}")
         else:
-            print(f"  PR #{pr_number} Issue #{iss_num} に Backlog キーなし")
+            print(f"  PR #{pr_number} Issue #{iss_num} に Backlog キーなし（Issue番号は保持）")
 
     commits = gh_request(token, "GET", f"/repos/{repo}/pulls/{pr_number}/commits?per_page=100") or []
     for commit in commits:
         message = (commit.get("commit") or {}).get("message", "") or ""
         keys.update(find_backlog_keys_in_text(project_key, message))
         for iss_num in find_issue_numbers(message):
+            issue_numbers.add(iss_num)
             key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
             if key:
                 keys.add(key)
 
-    return keys
+    return keys, issue_numbers
 
 
-def collect_keys_from_push(token: str, repo: str, project_key: str, commits_json: str) -> set[str]:
+def collect_keys_from_push(
+    token: str,
+    repo: str,
+    project_key: str,
+    commits_json: str,
+) -> tuple[set[str], set[int]]:
     import json
 
     keys: set[str] = set()
+    issue_numbers: set[int] = set()
     try:
         commits = json.loads(commits_json or "[]")
     except json.JSONDecodeError:
@@ -148,11 +163,12 @@ def collect_keys_from_push(token: str, repo: str, project_key: str, commits_json
         message = commit.get("message", "") or ""
         keys.update(find_backlog_keys_in_text(project_key, message))
         for iss_num in find_issue_numbers(message):
+            issue_numbers.add(iss_num)
             key = get_backlog_key_from_issue(token, repo, iss_num, project_key)
             if key:
                 keys.add(key)
                 print(f"  commit Issue #{iss_num} → {key}")
-    return keys
+    return keys, issue_numbers
 
 
 def current_status_name(base: str, api_key: str, backlog_key: str) -> str | None:
@@ -224,6 +240,36 @@ def update_status(
     return True
 
 
+def close_linked_github_issues(
+    token: str,
+    repo: str,
+    backlog_keys: set[str],
+    issue_numbers: set[int],
+    source: str,
+) -> int:
+    """main 到達時に紐づく GitHub Issue を close する。"""
+    to_close: set[int] = set(issue_numbers)
+    for key in sorted(backlog_keys):
+        gh_issue = find_github_issue_by_backlog_key(token, repo, key)
+        if gh_issue and gh_issue.get("number"):
+            to_close.add(int(gh_issue["number"]))
+
+    if not to_close:
+        print("close 対象の GitHub Issue はありません")
+        return 0
+
+    comment = (
+        f"<!-- github-branch-status:main-close -->\n\n"
+        f"`main` に到達したため、この Issue を close しました。\n"
+        f"- トリガー: {source}"
+    )
+    closed = 0
+    for num in sorted(to_close):
+        if close_github_issue(token, repo, num, comment=comment):
+            closed += 1
+    return closed
+
+
 def main() -> None:
     api_key, space_id, project_key, domain = load_backlog_env()
     base = resolve_bl_base(space_id, domain)
@@ -250,6 +296,7 @@ def main() -> None:
     print(f"イベント={event_name} branch={branch} → status={target_status}")
 
     keys: set[str] = set()
+    issue_numbers: set[int] = set()
     source = event_name
 
     if event_name == "pull_request":
@@ -260,29 +307,42 @@ def main() -> None:
             print("[ERROR] PR番号が取得できません")
             sys.exit(1)
         source = f"PR #{pr_number} merge → {branch}"
-        keys = collect_keys_from_pr(token, repo, project_key, pr_number, pr_title, pr_body)
+        keys, issue_numbers = collect_keys_from_pr(
+            token, repo, project_key, pr_number, pr_title, pr_body
+        )
     elif event_name == "push":
         source = f"push → {branch}"
-        keys = collect_keys_from_push(token, repo, project_key, push_commits)
+        keys, issue_numbers = collect_keys_from_push(token, repo, project_key, push_commits)
     else:
         # workflow_dispatch 等: PR番号があれば PR 基準、なければ push commits
         if pr_number > 0:
             source = f"manual PR #{pr_number} → {branch}"
-            keys = collect_keys_from_pr(token, repo, project_key, pr_number, pr_title, pr_body)
+            keys, issue_numbers = collect_keys_from_pr(
+                token, repo, project_key, pr_number, pr_title, pr_body
+            )
         else:
             source = f"manual → {branch}"
-            keys = collect_keys_from_push(token, repo, project_key, push_commits)
+            keys, issue_numbers = collect_keys_from_push(token, repo, project_key, push_commits)
 
-    if not keys:
-        print("紐づく Backlog 課題が見つかりませんでした。スキップします")
+    if not keys and not issue_numbers:
+        print("紐づく Backlog 課題 / GitHub Issue が見つかりませんでした。スキップします")
         return
 
-    print(f"更新対象: {', '.join(sorted(keys))}")
-    updated = 0
-    for key in sorted(keys):
-        if update_status(base, api_key, project_key, key, target_status, branch, source):
-            updated += 1
-    print(f"完了: updated={updated}/{len(keys)}")
+    if keys:
+        print(f"Backlog 更新対象: {', '.join(sorted(keys))}")
+        updated = 0
+        for key in sorted(keys):
+            if update_status(base, api_key, project_key, key, target_status, branch, source):
+                updated += 1
+        print(f"Backlog 完了: updated={updated}/{len(keys)}")
+    else:
+        print("Backlog 課題キーなし（GitHub Issue のみ処理）")
+
+    if branch == "main":
+        closed = close_linked_github_issues(token, repo, keys, issue_numbers, source)
+        print(f"GitHub Issue close: {closed} 件")
+    else:
+        print(f"{branch} 到達のため GitHub Issue は open のままにします")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/backlog_to_github.py
+++ b/.github/scripts/backlog_to_github.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone, timedelta
 
 sys.path.insert(0, os.path.dirname(__file__))
 from backlog_client import load_backlog_env, resolve_bl_base, bl_request
-from sync_utils import get_gh_token, get_gh_repo, gh_request, update_sync_section
+from sync_utils import get_gh_token, get_gh_repo, gh_request, update_sync_section, find_github_issue_by_backlog_key
 
 GITHUB_ISSUE_URL_PATTERN = r"GitHub Issue: https://github\.com/"
 
@@ -67,15 +67,7 @@ def get_updated_issues(base: str, api_key: str, project_id: int, updated_since: 
 
 def find_github_issue(token: str, repo: str, backlog_key: str) -> dict | None:
     """Backlog課題キーに対応するGitHub Issueを検索する (open+closed)。"""
-    query = f"[{backlog_key}] repo:{repo} in:title is:issue"
-    result = gh_request(token, "GET", f"/search/issues?q={query.replace(' ', '+')}&per_page=5")
-    if result and result.get("items"):
-        for item in result["items"]:
-            title = item.get("title", "")
-            body  = item.get("body", "") or ""
-            if title.startswith(f"[{backlog_key}]") or f"<!-- backlog-key:{backlog_key} -->" in body:
-                return item
-    return None
+    return find_github_issue_by_backlog_key(token, repo, backlog_key)
 
 
 def is_github_origin(description: str) -> bool:
@@ -86,14 +78,12 @@ def is_github_origin(description: str) -> bool:
 def backlog_status_to_gh_state(status_name: str) -> str:
     """Backlogステータス名 → GitHub Issue状態。
 
-    コード反映後のステータス（ステージング反映済み / リリース待ち / 完了）は
-    GitHub Issue を閉じたままにする（再オープン防止）。
+    GitHub Issue の close は main 到達（Backlog「完了」）を正とする。
+    ステージング反映済み / リリース待ちでは open を維持する。
     """
-    open_names = {"未対応", "処理中", "処理済み", "open", "in progress", "todo", "doing"}
-    name = (status_name or "").strip()
-    if name.lower() in {s.lower() for s in open_names}:
-        return "open"
-    return "closed"
+    closed_names = {"完了", "resolved", "closed", "done", "完了済み"}
+    name = (status_name or "").strip().lower()
+    return "closed" if name in {s.lower() for s in closed_names} else "open"
 
 
 def create_github_issue(token: str, repo: str, backlog_key: str, title: str, description: str, space_id: str, domain: str) -> dict | None:

--- a/.github/scripts/sync_utils.py
+++ b/.github/scripts/sync_utils.py
@@ -106,6 +106,59 @@ def extract_backlog_key(text: str, project_key: str) -> str | None:
     return m2.group(1) if m2 else None
 
 
+def find_github_issue_by_backlog_key(token: str, repo: str, backlog_key: str) -> dict | None:
+    """Backlog課題キーに対応するGitHub Issueを検索する (open+closed)。"""
+    query = f"[{backlog_key}] repo:{repo} in:title is:issue"
+    result = gh_request(token, "GET", f"/search/issues?q={query.replace(' ', '+')}&per_page=5")
+    if result and result.get("items"):
+        for item in result["items"]:
+            title = item.get("title", "")
+            body = item.get("body", "") or ""
+            if title.startswith(f"[{backlog_key}]") or f"<!-- backlog-key:{backlog_key} -->" in body:
+                return item
+    return None
+
+
+def close_github_issue(
+    token: str,
+    repo: str,
+    issue_number: int,
+    *,
+    comment: str | None = None,
+) -> bool:
+    """GitHub Issue を close する。既に closed なら False。"""
+    issue = gh_request(token, "GET", f"/repos/{repo}/issues/{issue_number}")
+    if not issue:
+        print(f"  GitHub Issue #{issue_number} を取得できませんでした")
+        return False
+    if issue.get("pull_request"):
+        print(f"  #{issue_number} は PR のためスキップします")
+        return False
+    if issue.get("state") == "closed":
+        print(f"  GitHub Issue #{issue_number} は既に closed")
+        return False
+
+    if comment:
+        gh_request(
+            token,
+            "POST",
+            f"/repos/{repo}/issues/{issue_number}/comments",
+            {"body": comment},
+        )
+
+    result = gh_request(
+        token,
+        "PATCH",
+        f"/repos/{repo}/issues/{issue_number}",
+        {"state": "closed", "state_reason": "completed"},
+    )
+    if result and result.get("state") == "closed":
+        print(f"  GitHub Issue #{issue_number} を closed にしました")
+        return True
+    print(f"  GitHub Issue #{issue_number} の close に失敗しました")
+    return False
+
+
 def is_backlog_synced(body: str) -> bool:
     """Backlog起源のIssueかどうかを判定する。"""
     return "<!-- backlog-synced -->" in (body or "")

--- a/.github/workflows/backlog-branch-status.yml
+++ b/.github/workflows/backlog-branch-status.yml
@@ -28,7 +28,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
-  issues: read
+  issues: write
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}

--- a/docs/backlog-github-sync.md
+++ b/docs/backlog-github-sync.md
@@ -75,7 +75,8 @@ Backlog 側のステータス名が異なる場合に設定します（未設定
 - 指定分数前（デフォルト: 20分）から更新されたBacklog課題を取得
 - **重複防止**: タイトルの `[SHOKUSU-XXX]` プレフィックスとbody内のHTMLコメントマーカーで既存Issueを検索
 - **無限ループ防止**: `GitHub Issue: https://github.com/` が説明に含まれる課題はGitHub起源と判断し、新規作成をスキップ（ステータス変更のみ反映）
-- Backlogの「完了」およびコード反映後ステータス → GitHub Issueのcloseに反映（再オープン防止）
+- Backlogの「完了」ステータス → GitHub Issueのcloseに反映
+- ステージング反映済み / リリース待ちでは GitHub Issue は open を維持（main 到達で close）
 
 ### GitHub Issue → Backlog課題 同期 (`github-issue-to-backlog.yml`)
 
@@ -87,14 +88,15 @@ Backlog 側のステータス名が異なる場合に設定します（未設定
 
 ### ブランチ到達 → Backlogステータス更新 (`backlog-branch-status.yml`)
 
-| 到達ブランチ | Backlogステータス |
-|--------------|-------------------|
-| `develop` | ステージング反映済み |
-| `release` | リリース待ち |
-| `main` | 完了 |
+| 到達ブランチ | Backlogステータス | GitHub Issue |
+|--------------|-------------------|--------------|
+| `develop` | ステージング反映済み | open のまま |
+| `release` | リリース待ち | open のまま |
+| `main` | 完了 | **close** |
 
 - develop / release / main 向け PR の **merge**、または同ブランチへの **push** で発火
-- PRタイトル・本文・コミットメッセージから `SHOKUSU-N` / `Closes #N` を抽出し、紐づく課題を更新
+- PRタイトル・本文・コミットメッセージから `SHOKUSU-N` / `Closes #N` / `#N` を抽出し、紐づく課題を更新
+- **main 到達時**は紐づく GitHub Issue を `completed` で close する（Backlog キー経由の Issue も含む）
 - 進行方向のみ更新（例: 完了 → ステージング反映済み への降格はしない）
 - 手動実行（`workflow_dispatch`）も可能
 


### PR DESCRIPTION
## Summary
- `main` 到達時に紐づく GitHub Issue を close
- develop / release では Issue は open のまま
- Backlog「完了」以外では GH Issue を閉じないよう同期を調整

main には先行反映済み。

Made with [Cursor](https://cursor.com)