### PR TITLE
chore: Python __pycache__ を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ terraform/staging/terraform.tfvars
 # 監査レポートの閲覧用コピー（正本は docs/audit-507*.html）
 /src_web/audit-507.html
 /src_web/audit-507-public.html
+
+# Python
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- ルート `.gitignore` に `__pycache__/` と `*.py[cod]` を追加

## Test plan
- [ ] `python .github/scripts/*.py` 実行後も `__pycache__` が untracked のまま／status に出ない


Made with [Cursor](https://cursor.com)