### PR TITLE
fix: Dependabot セキュリティアラート対応（composer/brace-expansion/@hono）

### DIFF
--- a/src_web/kamaho-shokusu/composer.lock
+++ b/src_web/kamaho-shokusu/composer.lock
@@ -2595,16 +2595,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "4120703b9bda8795075047b40361d7ec4d2abe49"
+                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/4120703b9bda8795075047b40361d7ec4d2abe49",
-                "reference": "4120703b9bda8795075047b40361d7ec4d2abe49",
+                "url": "https://api.github.com/repos/composer/composer/zipball/8d4439f572a97670a9edc039eb3b093cc976b4bc",
+                "reference": "8d4439f572a97670a9edc039eb3b093cc976b4bc",
                 "shasum": ""
             },
             "require": {
@@ -2692,7 +2692,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.10.1"
+                "source": "https://github.com/composer/composer/tree/2.10.2"
             },
             "funding": [
                 {
@@ -2704,7 +2704,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-04T08:25:59+00:00"
+            "time": "2026-07-01T09:24:45+00:00"
         },
         {
             "name": "composer/metadata-minifier",

--- a/src_web/kamaho-shokusu/package-lock.json
+++ b/src_web/kamaho-shokusu/package-lock.json
@@ -1315,9 +1315,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src_web/kamaho-shokusu/package.json
+++ b/src_web/kamaho-shokusu/package.json
@@ -9,7 +9,8 @@
     "jest-environment-jsdom": "^29.7.0"
   },
   "overrides": {
-    "js-yaml": "^3.15.0"
+    "js-yaml": "^3.15.0",
+    "brace-expansion": "^1.1.16"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/tools/backlog-design-mcp/package-lock.json
+++ b/tools/backlog-design-mcp/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "backlog-design-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backlog-design-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "^3.25.76"
+        "zod": "3.25.76"
       },
       "bin": {
+        "backlog-design-cli": "src/cli.js",
         "backlog-design-mcp": "src/index.js"
       },
       "engines": {
@@ -19,12 +20,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/tools/backlog-design-mcp/package.json
+++ b/tools/backlog-design-mcp/package.json
@@ -17,7 +17,10 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "3.25.76"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
   }
 }


### PR DESCRIPTION
## 概要

Dependabot のオープンアラート5件（#25/#26/#27/#28/#30）を修正。

## 変更内容

### composer/composer 2.10.1 → 2.10.2（アラート #25/#26/#27）
- **#25** (high): 悪意ある推移的パッケージ名によるベンダー外への任意ファイル書き込み
- **#26** (medium): URLにHTTP-Basic認証情報が混入し verboseログにGitHub PAT漏洩
- **#27** (medium): パッケージのbinフィールド経由でホスト上の任意ファイルをchmod

対応: `composer update composer/composer` で 2.10.2 へアップデート

### brace-expansion 1.1.15 → 1.1.16（アラート #28）
- **#28** (high): 連続する `{}` 展開による指数的展開でメモリ枯渇 DoS

対応: `src_web/kamaho-shokusu/package.json` の `overrides` に `"brace-expansion": "^1.1.16"` を追加

### @hono/node-server 1.19.15 → 2.0.12（アラート #30）
- **#30** (medium): Windowsの `%5C` エンコードバックスラッシュ経由のパストラバーサル（serve-static）

対応: `tools/backlog-design-mcp/package.json` の `overrides` に `"@hono/node-server": "^2.0.5"` を追加
（`@modelcontextprotocol/sdk` が `^1.19.9` に依存するため override で強制更新。hono ピア依存は同じ `^4` のため互換性あり）

あわせて `@modelcontextprotocol/sdk` のバージョン記載を `1.12.1` → `^1.29.0`（lock と整合）に修正。

## 動作確認

- MCP サーバーのモジュールロードを確認済み
- `npm audit` → 0 vulnerabilities（backlog-design-mcp）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * アプリケーションで使用する基盤コンポーネントを更新しました。
  * 関連するパッケージのバージョンを見直し、互換性と安定性の向上を図りました。
  * 一部のパッケージは使用バージョンを固定し、環境による動作差異を抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->