### PR TITLE
feat: Backlog 設計書・仕様書の自動生成・公開ツールを追加 + バグ修正2件

### DIFF
--- a/.github/scripts/backlog_to_github.py
+++ b/.github/scripts/backlog_to_github.py
@@ -167,7 +167,10 @@ def main():
             if existing and existing.get("state") != target_state:
                 gh_request(token, "PATCH", f"/repos/{repo}/issues/{existing['number']}", {"state": target_state})
                 print(f"GitHub Issue状態を更新しました: #{existing['number']} ← {backlog_key} ({target_state})")
-                updated += 1
+                if target_state == "closed":
+                    closed += 1
+                else:
+                    updated += 1
             else:
                 skipped += 1
             continue
@@ -194,7 +197,10 @@ def main():
                      "再オープン" if target_state == "open" and existing.get("state") == "closed" else "更新"
             if changed:
                 print(f"GitHub Issueを{action}しました: #{existing['number']} ← {backlog_key}")
-                updated += 1
+                if action == "クローズ":
+                    closed += 1
+                else:
+                    updated += 1
             else:
                 skipped += 1
 

--- a/src_web/kamaho-shokusu/src/Service/BulkReservationFormService.php
+++ b/src_web/kamaho-shokusu/src/Service/BulkReservationFormService.php
@@ -21,7 +21,7 @@ class BulkReservationFormService
 
     public function buildBulkAddData(string $selectedDate, ?string $baseWeekParam): array
     {
-        $today = new \DateTimeImmutable('now', new \DateTimeZone('Asia/Tokyo'));
+        $today = new \DateTimeImmutable('today', new \DateTimeZone('Asia/Tokyo'));
         $base  = $this->buildWeekBase($selectedDate, $baseWeekParam, $today);
 
         $days = [];


### PR DESCRIPTION
## 概要

Backlog 課題から設計書・仕様書を自動生成して公開するツール（MCP / CLI）を追加し、
調査で発見した既存バグ2件を合わせて修正します。

## 変更内容

### feat: Backlog 設計書・仕様書の自動生成・公開ツール
- `tools/backlog-design-mcp/` — Backlog Documents API を使った MCP サーバー・CLI ツールを新規追加
  - 設計書（概要・基本・詳細）と仕様書を Backlog ドキュメントへ公開
  - 使用プロンプトを自動添付してトレーサビリティを確保
- `.claude/commands/`, `.cursor/commands/`, `.codex/prompts/` — 各エージェント向けスラッシュコマンドを配置
- `docs/design-prompts/` — 設計書・仕様書生成プロンプト原本を追加
- `docs/backlog-design-docs.md` — ツール利用手順書を追加
- `.mcp.json` — MCP サーバー設定を追加

### fix: バグ修正2件

**① `backlog_to_github.py` — `closed` カウンターが常に 0**
- GitHub Issue をクローズする操作（`target_state == "closed"` / `action == "クローズ"`）が
  `updated` に加算されていたため、同期完了ログの `closed=N` が常に 0 だった
- クローズ操作は `closed += 1`、それ以外は `updated += 1` に振り分けるよう修正

**② `BulkReservationFormService.php` — 一括予約フォームにちょうど15日後の日付が表示されないバグ**
- `buildBulkAddData` が `DateTimeImmutable('now')` を使っていたため `$today` に時刻成分（例: 14:30）が混入
- `startOfWeek` から生成される `$d` は日付文字列由来で深夜0時のため、
  `2026-08-11 00:00 >= 2026-08-11 14:30` が `false` になり15日目が除外されていた
- `ReservationDatePolicy::minimumOrderDate()` は `Date::today()（日付のみ）+ 15日` で判定するため
  ポリシーとフォーム表示の不整合が発生していた
- `'now'` → `'today'` に変更し、同ファイルの `buildBulkChangeEditData` と一貫させた

### その他
- CodeRabbit 指摘対応・Dependabot セキュリティアラート対応（#25〜#30）を含む

## テスト

- `vendor/bin/phpunit`: 563 tests, 1195 assertions — all passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 課題の更新・クローズ件数が正しく集計されるようになりました。
  * 一括予約登録の日付判定が時刻ではなく当日を基準に行われ、日付境界付近でも安定して処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->