### PR TITLE
fix: uptime-checkでPROD_HOSTの空白除去とcurlエラー詳細のSlack出力

### DIFF
--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,20 +24,19 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
+
           set +e
           STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)
-          CURL_EXIT=$?
           set -e
-          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null)
+          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null | tr '\n' ' ')
           [ -z "$STATUS" ] && STATUS="000"
-          echo "curl exit code: ${CURL_EXIT}"
-          echo "curl stderr: ${CURL_ERR}"
 
+          echo "detail=${CURL_ERR}" >> "$GITHUB_OUTPUT"
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
-          echo "Checked ${URL} -> HTTP ${STATUS}"
+          echo "Checked ${URL} -> HTTP ${STATUS} (${CURL_ERR})"
 
           if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 400 ]; then
-            echo "::error::production is unreachable or returned an error status"
+            echo "::error::production is unreachable or returned an error status: ${CURL_ERR}"
             exit 1
           fi
 
@@ -49,5 +48,5 @@ jobs:
           SLACK_COLOR: danger
           SLACK_MESSAGE: >-
             <@${{ secrets.SLACK_MENTION_USER_ID }}> 本番環境に接続できません（HTTPステータス:
-            ${{ steps.check.outputs.status || '取得失敗' }}）😢
+            ${{ steps.check.outputs.status || '取得失敗' }} / ${{ steps.check.outputs.detail }}）😢
             詳細: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,9 +24,11 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
-          CURL_ERR=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>&1 1>/tmp/status)
+          set +e
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)
           CURL_EXIT=$?
-          STATUS=$(cat /tmp/status)
+          set -e
+          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null)
           [ -z "$STATUS" ] && STATUS="000"
           echo "curl exit code: ${CURL_EXIT}"
           echo "curl stderr: ${CURL_ERR}"

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,7 +24,12 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+          CURL_ERR=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>&1 1>/tmp/status)
+          CURL_EXIT=$?
+          STATUS=$(cat /tmp/status)
+          [ -z "$STATUS" ] && STATUS="000"
+          echo "curl exit code: ${CURL_EXIT}"
+          echo "curl stderr: ${CURL_ERR}"
 
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
           echo "Checked ${URL} -> HTTP ${STATUS}"

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           set -uo pipefail
 
-          HOST="${{ secrets.PROD_HOST }}"
+          HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
 


### PR DESCRIPTION
## Summary
- PR #620 でマージした `uptime-check.yml` が実際には毎回失敗していた（初回の総実行数が0件だったため手動実行して発覚）
- 原因1: `secrets.PROD_HOST` に末尾の空白/改行が含まれておりURLが壊れていた → `cert-renew.yml` と同様に `tr -d '[:space:]'` で除去
- 原因2（別問題・本番側）: 空白除去後に再テストしたところ `curl: (60) SSL: no alternative certificate subject name matches target host name` で失敗。**本番のTLS証明書にPROD_HOSTのホスト名がSANとして含まれていない**ことが判明。`cert-renew.yml` の `openssl s_client` はホスト名検証をしないため、この問題を検知できていなかった
- ワークフローの修正としては、curlの失敗理由をSlack通知本文にも出力するようにし、今後同種の問題がすぐ分かるようにした

## 本番側の課題（別途対応が必要・本PRのスコープ外）
本番サーバーが返しているTLS証明書がPROD_HOSTのホスト名をカバーしていない可能性があります。実際のブラウザでアクセスした場合も証明書エラーが出ている可能性があるため、別途確認をお願いします。

## Test plan
- [x] `workflow_dispatch` でこのブランチを直接実行し、Slack通知が正常に送信されることを確認済み（run: https://github.com/kamaho-source/shokusuu1/actions/runs/30609135315）
- [ ] マージ後、証明書問題が解消したら成功することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 本番環境の稼働状況チェックでURLの余分な空白を適切に処理するよう改善しました。
  - 通信エラーが発生した場合もHTTPステータスの判定を継続し、監視結果の信頼性を向上しました。

- **改善**
  - エラーの詳細をログや失敗通知に表示し、問題の確認と対応を容易にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->