### PR TITLE
fix: uptime-checkの監視対象をPROD_HOSTから公開ドメインに変更

### DIFF
--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           set -uo pipefail
 
-          HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
-          URL="https://${HOST}/"
+          URL="https://kamaho-shokusu.jp/"
 
           set +e
           STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)


### PR DESCRIPTION
## Summary
- `uptime-check.yml` が `secrets.PROD_HOST`（SSH接続用のVPSホスト名）に対してHTTPSアクセスしていたため、本番の実際のTLS証明書（`kamaho-shokusu.jp` / `www.kamaho-shokusu.jp` 向け）とホスト名が一致せず、`curl: (60) SSL: no alternative certificate subject name matches` で常に失敗していた
- VPS上で `certbot certificates` および実際に443番ポートで提供されている証明書のSANを確認し、公開ドメインが `kamaho-shokusu.jp` であることを確認済み（証明書自体は有効期限まで27日残っており正常）
- 監視対象を `kamaho-shokusu.jp` に修正

## Test plan
- [x] `workflow_dispatch` でこのブランチを直接実行し、`HTTP 302` で成功することを確認済み（run: https://github.com/kamaho-source/shokusuu1/actions/runs/30610456015）