### PR TITLE
release: promote develop to release (uptime-check修正)

### DIFF
--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           set -uo pipefail
 
-          HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
-          URL="https://${HOST}/"
+          URL="https://kamaho-shokusu.jp/"
 
           set +e
           STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,20 +24,19 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
+
           set +e
           STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)
-          CURL_EXIT=$?
           set -e
-          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null)
+          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null | tr '\n' ' ')
           [ -z "$STATUS" ] && STATUS="000"
-          echo "curl exit code: ${CURL_EXIT}"
-          echo "curl stderr: ${CURL_ERR}"
 
+          echo "detail=${CURL_ERR}" >> "$GITHUB_OUTPUT"
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
-          echo "Checked ${URL} -> HTTP ${STATUS}"
+          echo "Checked ${URL} -> HTTP ${STATUS} (${CURL_ERR})"
 
           if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 400 ]; then
-            echo "::error::production is unreachable or returned an error status"
+            echo "::error::production is unreachable or returned an error status: ${CURL_ERR}"
             exit 1
           fi
 
@@ -49,5 +48,5 @@ jobs:
           SLACK_COLOR: danger
           SLACK_MESSAGE: >-
             <@${{ secrets.SLACK_MENTION_USER_ID }}> 本番環境に接続できません（HTTPステータス:
-            ${{ steps.check.outputs.status || '取得失敗' }}）😢
+            ${{ steps.check.outputs.status || '取得失敗' }} / ${{ steps.check.outputs.detail }}）😢
             詳細: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,9 +24,11 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
-          CURL_ERR=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>&1 1>/tmp/status)
+          set +e
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/tmp/curl_err)
           CURL_EXIT=$?
-          STATUS=$(cat /tmp/status)
+          set -e
+          CURL_ERR=$(cat /tmp/curl_err 2>/dev/null)
           [ -z "$STATUS" ] && STATUS="000"
           echo "curl exit code: ${CURL_EXIT}"
           echo "curl stderr: ${CURL_ERR}"

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -24,7 +24,12 @@ jobs:
 
           HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+          CURL_ERR=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>&1 1>/tmp/status)
+          CURL_EXIT=$?
+          STATUS=$(cat /tmp/status)
+          [ -z "$STATUS" ] && STATUS="000"
+          echo "curl exit code: ${CURL_EXIT}"
+          echo "curl stderr: ${CURL_ERR}"
 
           echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
           echo "Checked ${URL} -> HTTP ${STATUS}"

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           set -uo pipefail
 
-          HOST="${{ secrets.PROD_HOST }}"
+          HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
           URL="https://${HOST}/"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$URL" || echo "000")
 


### PR DESCRIPTION
## Summary
- develop に対して release/main が7コミット遅れており、`uptime-check.yml` の修正（PR #620, #623, #624）が本番のスケジュール実行・デフォルト手動実行に反映されていなかった
- このため誤った「本番に接続できません」というアラートがSlackに送信され続けていた
- release へ昇格し、続けて main へも昇格させる

## Test plan
- [x] develop 側で workflow_dispatch により正常動作を確認済み