### PR TITLE
feat: 成功時もSlack通知するように変更

### DIFF
--- a/.github/workflows/resource-check.yml
+++ b/.github/workflows/resource-check.yml
@@ -61,6 +61,15 @@ jobs:
         env:
           DB_CONTAINER: ${{ secrets.DB_CONTAINER }}
 
+      - name: Slack Notification on Success
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Resource Check / OK
+          SLACK_COLOR: good
+          SLACK_MESSAGE: >-
+            本番VPSのリソース・コンテナ状態は正常です（ディスク85%未満・メモリ90%未満・全コンテナ稼働中）✅
+
       - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -39,6 +39,15 @@ jobs:
             exit 1
           fi
 
+      - name: Slack Notification on Success
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Uptime Check / OK
+          SLACK_COLOR: good
+          SLACK_MESSAGE: >-
+            本番環境は正常です（HTTPステータス: ${{ steps.check.outputs.status }}）✅
+
       - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Summary
- uptime-check / resource-check の両方で、失敗時だけでなく成功時にもSlack通知を送るように変更
- 成功時: SLACK_COLOR: good（緑）、メンションなし
- 失敗時: 既存どおり SLACK_COLOR: danger + メンション

## 注意
- 通知頻度が増加します（uptime-check 10分間隔・resource-check 30分間隔 → 合計 約190件/日）。ユーザー確認済みで許容範囲として進行

## Test plan
- [x] workflow_dispatch で両方実行し、成功時のSlack通知が実際に送信されることを確認済み
  - uptime-check: https://github.com/kamaho-source/shokusuu1/actions/runs/30611013337
  - resource-check: https://github.com/kamaho-source/shokusuu1/actions/runs/30611017106