### PR TITLE
fix: certbot 更新を webroot 認証に切り替えダウンタイムを解消する

### DIFF
--- a/.github/workflows/cert-renew.yml
+++ b/.github/workflows/cert-renew.yml
@@ -75,48 +75,8 @@ jobs:
               echo "$SUDO_PASS" | sudo -S -p '' "$@"
             }
 
-            # standalone 認証は :80 が空いている必要がある。
-            # 以前の pre-hook だけではホスト nginx 等が残ると失敗するため、明示停止する。
-            stop_http_listeners() {
-              echo "Stopping reverse proxy / nginx that may hold :80 ..."
-              run_sudo docker stop docker-network-reverse-1 2>/dev/null || true
-
-              # ホスト :80 を publish しているコンテナをすべて止める
-              while read -r cid; do
-                [ -n "$cid" ] || continue
-                echo "Stopping container on :80: $cid"
-                run_sudo docker stop "$cid" 2>/dev/null || true
-              done < <(run_sudo docker ps --format '{{.ID}} {{.Ports}}' | awk '/(^|[^0-9])80->|:80->/ {print $1}')
-
-              run_sudo systemctl stop nginx 2>/dev/null || true
-              run_sudo service nginx stop 2>/dev/null || true
-            }
-
-            start_http_listeners() {
-              echo "Restoring HTTP listeners ..."
-              run_sudo docker start docker-network-reverse-1 2>/dev/null || true
-              run_sudo systemctl start nginx 2>/dev/null || true
-            }
-
-            trap start_http_listeners EXIT
-
-            stop_http_listeners
-
-            echo "Waiting for :80 to be free ..."
-            for _ in $(seq 1 20); do
-              if ! run_sudo ss -ltn | grep -qE '[:.]80[[:space:]]'; then
-                break
-              fi
-              sleep 1
-            done
-
-            if run_sudo ss -ltn | grep -qE '[:.]80[[:space:]]'; then
-              echo "ERROR: port 80 is still in use:" >&2
-              run_sudo ss -ltnp | grep -E '[:.]80[[:space:]]' >&2 || true
-              run_sudo lsof -iTCP:80 -sTCP:LISTEN >&2 || true
-              exit 1
-            fi
-
+            # webroot 認証のため :80 を止める必要はない（nginx は常時稼働のまま）。
+            # 証明書更新後の nginx reload は certbot renewal conf の post_hook で行う。
             echo "Running certbot renew ..."
             run_sudo certbot renew --non-interactive
 

--- a/.github/workflows/cert-renew.yml
+++ b/.github/workflows/cert-renew.yml
@@ -77,10 +77,33 @@ jobs:
 
             # webroot 認証のため :80 を止める必要はない（nginx は常時稼働のまま）。
             # 証明書更新後の nginx reload は certbot renewal conf の post_hook で行う。
+            # 前提: 本番ホストの nginx に /.well-known/acme-challenge/ を webroot に
+            # 渡す location 設定と、certbot renewal conf の webroot 設定・post_hook
+            # (nginx reload) が事前に構成されていること。これらは本リポジトリでは
+            # 管理しておらず、本番ホスト上で直接管理されている。
             echo "Running certbot renew ..."
             run_sudo certbot renew --non-interactive
 
             echo "Certificate renewal finished"
+
+      - name: Verify certificate was actually renewed
+        run: |
+          set -euo pipefail
+          HOST=$(echo "${{ secrets.PROD_HOST }}" | tr -d '[:space:]')
+          EXPIRY=$(echo | timeout 10 openssl s_client -connect "${HOST}:443" -servername "${HOST}" 2>/dev/null \
+            | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2 || true)
+          if [ -z "$EXPIRY" ]; then
+            echo "::error::証明書の取得に失敗しました（HTTPS疎通確認NG）"
+            exit 1
+          fi
+          EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s)
+          NOW_EPOCH=$(date +%s)
+          DAYS_LEFT=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+          echo "Certificate now expires in ${DAYS_LEFT} days"
+          if [ "$DAYS_LEFT" -le 30 ]; then
+            echo "::error::certbot renew は成功と報告されたが、実際の証明書の有効期限が更新されていません（残り ${DAYS_LEFT} 日）。nginx の reload に失敗している可能性があります。"
+            exit 1
+          fi
 
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## 背景

2026-08-03、証明書更新ワークフロー実行後に kamaho-shokusu.jp が HTTPS で到達不能になる障害が発生した。

調査の結果、以下が判明した：

- 本番トラフィックを実際に処理しているのは **host の `nginx.service`**（`/etc/nginx/conf.d/kamaho-shokusu.jp.conf`：80→443リダイレクト、443でTLS終端し `localhost:8091` へproxy）
- `docker-network-reverse-1`（docker-compose の `network-reverse`）は本番トラフィックとは無関係の孤立したコンテナ
- 直前の cert-renew ワークフロー修正（`19a39a6`）の `start_http_listeners` が `docker-network-reverse-1` を先に起動し host の `:80` を横取りしてしまい、後段の `systemctl start nginx` が `bind() to 0.0.0.0:80 failed (Address already in use)` で失敗 → 443（HTTPS本体）が丸ごと停止していた
- さらに certbot の `standalone` 認証方式自体が、更新のたびに稼働中の Web サーバーを止める必要がある構造的な問題だった

## 対応

証明書更新の認証方式を `standalone` → `webroot` に変更し、稼働中の nginx を一切止めずに更新できるようにした（本番サーバー側で先行対応済み・`--dry-run` で動作確認済み）：

- 本番 `/etc/nginx/conf.d/kamaho-shokusu.jp.conf` に `/.well-known/acme-challenge/` 用の location を追加
- 本番 `/etc/letsencrypt/renewal/kamaho-shokusu.jp.conf` の authenticator を `webroot` に変更、`post_hook = systemctl reload nginx` を設定（reload はグレースフルで無停止）
- 上記に伴い、本 PR ではワークフロー側の `:80` 占有プロセス停止・復旧ロジック（`docker-network-reverse-1` / host nginx の stop-start dance）を全て撤去し、`certbot renew` のみのシンプルな内容にした

## 効果

- 証明書更新時のダウンタイムがゼロになる
- 本番トラフィックと無関係な `docker-network-reverse-1` をワークフローが触らなくなり、今回のような競合が再発しない

## Test plan

- [x] 本番で `certbot renew --dry-run --cert-name kamaho-shokusu.jp` 実行し `Congratulations, all simulated renewals succeeded` を確認
- [x] `nginx -t` / reload 後に `https://kamaho-shokusu.jp/` の HTTPS 応答（302）を確認
- [ ] 次回のスケジュール実行（毎週月曜 3:17 JST）または `workflow_dispatch` (force) で実際の renew を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - SSL/TLS証明書の更新中もWebサーバーを稼働し続け、サービス停止を回避します。
  - 更新後の証明書を自動検証し、有効期限が十分でない場合や取得に失敗した場合は異常として通知します。
  - 証明書更新後のWebサーバー再読み込みを自動化し、更新内容をスムーズに反映します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->