### PR TITLE
hotfix: 過去日の予約操作をUI・コピー処理でガードする

### DIFF
--- a/src_web/kamaho-shokusu/src/Service/ReservationCopyService.php
+++ b/src_web/kamaho-shokusu/src/Service/ReservationCopyService.php
@@ -123,6 +123,7 @@ class ReservationCopyService
         $actor = null
     ): array {
         $childIds = $onlyChildren ? $this->getChildUserIds() : null;
+        $today    = Date::today('Asia/Tokyo');
 
         Log::debug('[copyRangeByOffset] srcStart=' . $srcStart->format('Y-m-d') . ', srcEnd=' . $srcEnd->format('Y-m-d') . ', offsetDays=' . $offsetDays . ', roomId=' . ($roomId ?? 'null') . ', onlyChildren=' . ($onlyChildren ? 'true' : 'false'));
         
@@ -168,6 +169,7 @@ class ReservationCopyService
 
         $affected = 0;
         $skipped = 0;
+        $invalidDate = 0;
         $actorName = ($actor !== null && method_exists($actor, 'get') && $actor->get('c_user_name'))
             ? (string)$actor->get('c_user_name')
             : 'system';
@@ -177,6 +179,11 @@ class ReservationCopyService
             foreach ($rows as $r) {
                 $srcDate = new Date($r['d_reservation_date']);
                 $dstDate = $srcDate->addDays($offsetDays);
+
+                if ($dstDate < $today) {
+                    $invalidDate++;
+                    continue;
+                }
 
                 $existing = $this->TIndividualReservationInfo->find()
                     ->enableAutoFields(false)
@@ -230,14 +237,14 @@ class ReservationCopyService
                 $affected++;
             }
             $conn->commit();
-            Log::debug('[copyRangeByOffset] 完了: total=' . $total . ', copied=' . $affected . ', skipped=' . $skipped);
+            Log::debug('[copyRangeByOffset] 完了: total=' . $total . ', copied=' . $affected . ', skipped=' . $skipped . ', invalidDate=' . $invalidDate);
         } catch (\Throwable $e) {
             $conn->rollback();
             Log::error('ReservationCopyService(copyRangeByOffset) failed: ' . $e->getMessage());
             throw $e;
         }
 
-        return ['total' => $total, 'copied' => $affected, 'skipped' => $skipped];
+        return ['total' => $total, 'copied' => $affected, 'skipped' => $skipped, 'invalid_date' => $invalidDate];
     }
 
     private function copyMonthSameDay(
@@ -248,6 +255,7 @@ class ReservationCopyService
         $actor = null
     ): array {
         $childIds = $onlyChildren ? $this->getChildUserIds() : null;
+        $today    = Date::today('Asia/Tokyo');
 
         // 月の初日と末日を確実に設定
         $srcStart = new Date($srcMonthFirst->format('Y-m-01'));
@@ -316,6 +324,11 @@ class ReservationCopyService
                 } catch (\Throwable $e) {
                     $invalidDate++;
                     continue; // 不正日付はスキップ
+                }
+
+                if ($dstDate < $today) {
+                    $invalidDate++;
+                    continue;
                 }
 
                 $existing = $this->TIndividualReservationInfo->find()
@@ -464,6 +477,7 @@ class ReservationCopyService
         bool $onlyChildren
     ): array {
         $childIds = $onlyChildren ? $this->getChildUserIds() : null;
+        $today    = Date::today('Asia/Tokyo');
 
         $conditions = [
             'd_reservation_date >=' => $srcStart->format('Y-m-d'),
@@ -492,6 +506,11 @@ class ReservationCopyService
         foreach ($rows as $r) {
             $srcDate = new Date($r['d_reservation_date']);
             $dstDate = $srcDate->addDays($offsetDays);
+
+            if ($dstDate < $today) {
+                $willSkip++;
+                continue;
+            }
 
             $exists = $this->TIndividualReservationInfo->exists([
                 'i_id_user'           => (int)$r['i_id_user'],
@@ -524,6 +543,7 @@ class ReservationCopyService
         bool $onlyChildren
     ): array {
         $childIds = $onlyChildren ? $this->getChildUserIds() : null;
+        $today    = Date::today('Asia/Tokyo');
 
         $srcStart = new Date($srcMonthFirst->format('Y-m-01'));
         $srcEnd   = new Date($srcMonthFirst->format('Y-m-t'));
@@ -557,7 +577,7 @@ class ReservationCopyService
         foreach ($rows as $r) {
             $srcDate = new Date($r['d_reservation_date']);
             $day = (int)$srcDate->format('d');
-            
+
             $dstDateStr = $dstStart->format('Y-m-') . str_pad((string)$day, 2, '0', STR_PAD_LEFT);
             try {
                 $dstDate = new Date($dstDateStr);
@@ -566,6 +586,11 @@ class ReservationCopyService
                     continue;
                 }
             } catch (\Throwable $e) {
+                $invalidDate++;
+                continue;
+            }
+
+            if ($dstDate < $today) {
                 $invalidDate++;
                 continue;
             }

--- a/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCopyServiceTest.php
+++ b/src_web/kamaho-shokusu/tests/TestCase/Service/ReservationCopyServiceTest.php
@@ -14,6 +14,11 @@ use Cake\TestSuite\TestCase;
  */
 class ReservationCopyServiceTest extends TestCase
 {
+    protected array $fixtures = [
+        'app.TIndividualReservationInfo',
+        'app.MUserInfo',
+    ];
+
     private ReservationCopyService $service;
 
     protected function setUp(): void
@@ -218,5 +223,41 @@ class ReservationCopyServiceTest extends TestCase
 
         $this->assertTrue($result['ok']);
         $this->assertSame('2026-06-01', $result['src']->format('Y-m-d'));
+    }
+
+    // ----------------------------------------------------------------
+    // 過去日ガード（コピー先が過去日になる場合はスキップされる）
+    // ----------------------------------------------------------------
+
+    public function testCopyWeekSkipsRowsWhenTargetIsPast(): void
+    {
+        // フィクスチャの唯一のレコード（2024-09-07, 土曜）を含む週（2024-09-02 月曜始まり）をコピー元、
+        // その1週間後（実行時点で確実に過去日）をコピー先にする。
+        $result = $this->service->copyWeek(
+            new Date('2024-09-02'),
+            new Date('2024-09-09'),
+            null,
+            false,
+            null,
+            false
+        );
+
+        $this->assertSame(1, $result['total']);
+        $this->assertSame(0, $result['copied']);
+        $this->assertSame(1, $result['invalid_date']);
+    }
+
+    public function testPreviewWeekSkipsRowsWhenTargetIsPast(): void
+    {
+        $result = $this->service->previewWeek(
+            new Date('2024-09-02'),
+            new Date('2024-09-09'),
+            null,
+            false
+        );
+
+        $this->assertSame(1, $result['total']);
+        $this->assertSame(0, $result['will_copy']);
+        $this->assertSame(1, $result['will_skip']);
     }
 }

--- a/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
+++ b/src_web/kamaho-shokusu/webroot/js/pages/treservation_index.js
@@ -1110,6 +1110,11 @@ function openModalById(id){
                     try {
                         var dateStr = info.dateStr;
 
+                        if (window.SERVER_TODAY && dateStr < window.SERVER_TODAY) {
+                            if (window.pageToast) window.pageToast('過去日の予約は登録できません。', 'warning');
+                            return;
+                        }
+
                         // 部屋選択 → 食事選択 → 登録（他の人が予約済みの日も同様に動作）
                         // 新規登録なので「予約可能な部屋」を出す（既存予約の部屋名 roomNames は表示用のため使わない）
                         var roomNames = (window.__TRESP && window.__TRESP.availableRoomNames) || {};
@@ -1137,6 +1142,11 @@ function openModalById(id){
                     var date     = info.event.startStr ? info.event.startStr.slice(0, 10) : '';
                     var mealType = ep.mealType;
                     if (!date || !mealType) return;
+
+                    if (window.SERVER_TODAY && date < window.SERVER_TODAY) {
+                        if (window.pageToast) window.pageToast('過去日の予約は変更できません。', 'warning');
+                        return;
+                    }
 
                     var mealKeyMap  = { 1: 'breakfast', 2: 'lunch', 3: 'dinner', 4: 'bento' };
                     var mealNameMap = { 1: '朝食', 2: '昼食', 3: '夕食', 4: '弁当' };
@@ -2308,6 +2318,7 @@ document.addEventListener('shown.bs.modal', function(ev) {
 
         const sourceInput = document.getElementById('source_start');
         const targetInput = document.getElementById('target_start_input');
+        if (targetInput && window.SERVER_TODAY) targetInput.min = window.SERVER_TODAY;
         const addTargetBtn = document.getElementById('add-target-btn');
         const targetDatesList = document.getElementById('target-dates-list');
         const targetDatesEmpty = document.getElementById('target-dates-empty');
@@ -2366,7 +2377,12 @@ document.addEventListener('shown.bs.modal', function(ev) {
                 toast('有効な日付を選択してください', 'warning');
                 return;
             }
-            
+
+            if (window.SERVER_TODAY && dateStr < window.SERVER_TODAY) {
+                toast('過去日はコピー先に指定できません', 'warning');
+                return;
+            }
+
             // バリデーション
             if (mode === 'week' && !isMonday(date)) {
                 toast('週単位の場合は月曜日を選択してください', 'warning');


### PR DESCRIPTION
## 背景

本番監査ログで、同一ユーザーが同一内容の予約登録に9秒間隔で2回失敗している事象を確認（`t_audit_log` id=62,63, `i_result=0`）。調査の結果、対象日付（2026-08-01）が操作時点で過去日であり、サーバー側の `ReservationDatePolicy::isPastDate()` によって毎回拒否されていたことが判明。ユーザーはエラー理由が分からず同じ操作をリトライしていた。

併せて画面全体を調査したところ、過去日操作を許してしまう箇所が他に2つ見つかった。

## 修正内容

| 画面 / 操作 | 修正前 | 修正後 |
|---|---|---|
| カレンダー空セルクリック→直接登録（`dateClick`） | 過去日でもピッカーが開き登録APIを叩く→サーバーで失敗 | クリック時点で`window.SERVER_TODAY`と比較し、過去日ならトーストで案内して終了 |
| カレンダー食数バッジのON/OFF（`eventClick`） | 同上 | 同上のガードを追加 |
| 週・月コピー機能（管理者専用） | **過去日チェックが皆無**。過去日へ実際に予約データが書き込まれてしまう | クライアント側で日付入力に`min`属性＋バリデーション追加、サーバー側`ReservationCopyService`の実行系・プレビュー系すべてのメソッドで`dstDate < today`のレコードをスキップ（`invalid_date`としてカウント） |

「詳細フォームで登録する」モーダル・Kid UIグリッド・グループ予約フォームは既に過去日ガードが実装済みで対象外。

## Test plan

- [x] `vendor/bin/phpunit tests/TestCase/Service/ReservationCopyServiceTest.php` — 過去日コピーが `copied=0` / `invalid_date` にカウントされる回帰テストを追加、全16件パス
- [x] `vendor/bin/phpunit tests/TestCase/Service` — 282件全てパス
- [x] `php -l` / `node --check` でシンタックスエラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 過去日への予約コピーやプレビューをスキップするようになりました。
  * 週・月単位のコピーで、対象外となった件数を確認できるようになりました。
  * カレンダー上で過去日の予約変更や日付選択を行えないようになりました。
  * コピー先の日付に当日を最小値として設定し、過去日を追加できないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->